### PR TITLE
map_server: update to yaml-cpp 0.8.0

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -118,7 +119,8 @@ target_include_directories(${map_io_library_name} SYSTEM PRIVATE
   ${GRAPHICSMAGICKCPP_INCLUDE_DIRS})
 
 target_link_libraries(${map_io_library_name}
-  ${GRAPHICSMAGICKCPP_LIBRARIES})
+  ${GRAPHICSMAGICKCPP_LIBRARIES}
+  yaml-cpp::yaml-cpp)
 
 if(WIN32)
   target_compile_definitions(${map_io_library_name} PRIVATE
@@ -160,5 +162,5 @@ ament_export_libraries(
   ${library_name}
   ${map_io_library_name}
 )
-ament_export_dependencies(${map_io_dependencies} ${map_server_dependencies})
+ament_export_dependencies(${map_io_dependencies} ${map_server_dependencies} yaml-cpp)
 ament_package()


### PR DESCRIPTION
yaml-cpp 0.8.0 requires explicit linking against yaml-cpp::yaml-cpp.
This fixes building breakage on rolling due to https://github.com/ros2/yaml_cpp_vendor/pull/48

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Not yet. It shouldn't affect anything pratically. |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Fix building on rolling due to recent yaml-cpp upgrade

## Description of documentation updates required from your changes

None.

---

## Future work that may be required in bullet points
None.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
