### PR TITLE
[LifecycleNode] add bond_heartbeat_period

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -205,6 +205,7 @@ protected:
 
   // Connection to tell that server is still up
   std::unique_ptr<bond::Bond> bond_{nullptr};
+  double bond_heartbeat_period;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "lifecycle_msgs/msg/state.hpp"
+#include "nav2_util/node_utils.hpp"
 
 namespace nav2_util
 {
@@ -34,6 +35,10 @@ LifecycleNode::LifecycleNode(
   this->set_parameter(
     rclcpp::Parameter(
       bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM, true));
+  
+  nav2_util::declare_parameter_if_not_declared(
+    this, "bond_heartbeat_period", rclcpp::ParameterValue(0.1));
+  this->get_parameter("bond_heartbeat_period", bond_heartbeat_period);
 
   printLifecycleNodeNotification();
 
@@ -55,16 +60,18 @@ LifecycleNode::~LifecycleNode()
 
 void LifecycleNode::createBond()
 {
-  RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
+  if (bond_heartbeat_period > 0.0) {
+    RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
 
-  bond_ = std::make_unique<bond::Bond>(
-    std::string("bond"),
-    this->get_name(),
-    shared_from_this());
+    bond_ = std::make_unique<bond::Bond>(
+      std::string("bond"),
+      this->get_name(),
+      shared_from_this());
 
-  bond_->setHeartbeatPeriod(0.10);
-  bond_->setHeartbeatTimeout(4.0);
-  bond_->start();
+    bond_->setHeartbeatPeriod(bond_heartbeat_period);
+    bond_->setHeartbeatTimeout(4.0);
+    bond_->start();
+  }
 }
 
 void LifecycleNode::runCleanups()
@@ -110,10 +117,12 @@ void LifecycleNode::register_rcl_preshutdown_callback()
 
 void LifecycleNode::destroyBond()
 {
-  RCLCPP_INFO(get_logger(), "Destroying bond (%s) to lifecycle manager.", this->get_name());
+  if (bond_heartbeat_period > 0.0) {
+    RCLCPP_INFO(get_logger(), "Destroying bond (%s) to lifecycle manager.", this->get_name());
 
-  if (bond_) {
-    bond_.reset();
+    if (bond_) {
+      bond_.reset();
+    }
   }
 }
 

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -35,7 +35,7 @@ LifecycleNode::LifecycleNode(
   this->set_parameter(
     rclcpp::Parameter(
       bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM, true));
-  
+
   nav2_util::declare_parameter_if_not_declared(
     this, "bond_heartbeat_period", rclcpp::ParameterValue(0.1));
   this->get_parameter("bond_heartbeat_period", bond_heartbeat_period);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Robot |
| Does this PR contain AI generated software? | No|

---

## Description of contribution in a few bullet points

This PR adds the parameter `bond_heartbeat_period` to the lifecycle nodes.

The bond heart beat period of the lifecycle node was fixed to 0.1 (s). This PR doesn't change the default value but allows to customize it, and to disable the bond mechanism if <= 0.0 (so no pub/sub on `/bond`)


## Description of documentation updates required from your changes


---

## Future work that may be required in bullet points

- Should we change the default to a longer period (i.e. less CPU usage on `/bond` subscribers) ?
- Should we also expose `bond_heartbeat_timeout` for `setHeartbeatTimeout` ? (I personally don't have an use case for this)

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
