### PR TITLE
Fix the bug that behavior tree plugin PathLongerOnApproach will not work while using smac planner.

### DIFF
--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -36,7 +36,7 @@ bool PathLongerOnApproach::isPathUpdated(
 {
   return new_path != old_path && old_path.poses.size() != 0 &&
          new_path.poses.size() != 0 &&
-         old_path.poses.back() == new_path.poses.back();
+         old_path.poses.back().pose == new_path.poses.back().pose;
 }
 
 bool PathLongerOnApproach::isRobotInGoalProximity(


### PR DESCRIPTION
See https://github.com/ros-navigation/navigation2/issues/4326.
Fix the bug that isPathUpdated function will return false even if the new path is update for the reason that it not only compare the position between new path and old path's last pose.But also compare these two poses 's timestamped which is obviously different.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |

---


