### PR TITLE
[LifecycleManagerClient] clean set_initial_pose and navigate_to_pose

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -84,23 +84,6 @@ public:
    */
   SystemStatus is_active(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
 
-  // A couple convenience methods to facilitate scripting tests
-  /**
-   * @brief Set initial pose with covariance
-   * @param x X position
-   * @param y Y position
-   * @param theta orientation
-   */
-  void set_initial_pose(double x, double y, double theta);
-  /**
-   * @brief Send goal pose to NavigationToPose action server
-   * @param x X position
-   * @param y Y position
-   * @param theta orientation
-   * @return true or false
-   */
-  bool navigate_to_pose(double x, double y, double theta);
-
 protected:
   using ManageLifecycleNodes = nav2_msgs::srv::ManageLifecycleNodes;
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory robot |

---

## Description of contribution in a few bullet points

I was looking at `nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp` and noticed 2 methods that do not seem to be used anywhere: `set_initial_pose` and `navigate_to_pose`. I guess they can be removed ?

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
