### PR TITLE
Prevent invalid accesses on paths in path_longer_on_approach

### DIFF
--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -63,7 +63,7 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   getInput("length_factor", length_factor_);
 
   if (first_time_ == false) {
-    if (old_path_.poses.back() != new_path_.poses.back()) {
+    if (old_path_.poses.empty() || new_path_.poses.empty() || old_path_.poses.back() != new_path_.poses.back()) {
       first_time_ = true;
     }
   }

--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -63,7 +63,9 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   getInput("length_factor", length_factor_);
 
   if (first_time_ == false) {
-    if (old_path_.poses.empty() || new_path_.poses.empty() || old_path_.poses.back() != new_path_.poses.back()) {
+    if (old_path_.poses.empty() || new_path_.poses.empty() ||
+      old_path_.poses.back() != new_path_.poses.back())
+    {
       first_time_ = true;
     }
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Custom Robot) |
| Does this PR contain AI generated software? | (No) |

---

## Description of contribution in a few bullet points
* We encountered a segmentation fault in the behavior tree while operating our robot. Upon investigation, we discovered that the `PathLongerOnApproach` node was causing these segmentation faults.
* When the `ComputePathToPoseAction` sets an empty path in the behavior tree port `path` due to failure or cancellation, the `path` from `PathLongerOnApproach` can be empty. Without checking its size, the node encounters segmentation faults at that time.
* Co-author: @JinyongJeong

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
