### PR TITLE
Fix: export libraries and plugins from opennav_docking

### DIFF
--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -127,6 +127,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${library_name})
+ament_export_libraries(${library_name} pose_filter)
 ament_export_dependencies(${dependencies} yaml-cpp)
 ament_package()

--- a/nav2_docking/opennav_docking/package.xml
+++ b/nav2_docking/opennav_docking/package.xml
@@ -32,5 +32,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <opennav_docking plugin="${prefix}/plugins.xml" />
   </export>
 </package>


### PR DESCRIPTION
The current implementation exports neither the plugins nor the `pose_filter` library for use by projects outside `opennav_docking`.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
* Export `pose_filter` library and `plugins.xml` from `opennav_docking` to be used by external projects.

## Description of documentation updates required from your changes
Nothing
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
Nothing
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
