### PR TITLE
Remove start clear

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -250,12 +250,6 @@ protected:
   inline void populateExpansionsLog(
     const NodePtr & node, std::vector<std::tuple<float, float, float>> * expansions_log);
 
-  /**
-   * @brief Clear Start
-   */
-  void clearStart();
-
-
   bool _traverse_unknown;
   int _max_iterations;
   int _max_on_approach_iterations;

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -250,8 +250,6 @@ bool AStarAlgorithm<NodeT>::areInputsValid()
   }
 
   // Note: We do not check the if the start is valid because it is cleared
-  clearStart();
-
   return true;
 }
 
@@ -482,20 +480,6 @@ template<typename NodeT>
 unsigned int & AStarAlgorithm<NodeT>::getSizeDim3()
 {
   return _dim3_size;
-}
-
-template<>
-void AStarAlgorithm<Node2D>::clearStart()
-{
-  auto coords = Node2D::getCoords(_start->getIndex());
-  _costmap->setCost(coords.x, coords.y, nav2_costmap_2d::FREE_SPACE);
-}
-
-template<typename NodeT>
-void AStarAlgorithm<NodeT>::clearStart()
-{
-  auto coords = NodeT::getCoords(_start->getIndex(), _costmap->getSizeInCellsX(), getSizeDim3());
-  _costmap->setCost(coords.x, coords.y, nav2_costmap_2d::FREE_SPACE);
 }
 
 // Instantiate algorithm for the supported template types


### PR DESCRIPTION
We found that clearing the start made other orientations in the same pose also be "free" even though those might be in critical collision at other orientations. We know the start is "free" because it has to be definitionally since the robot is there. 

This removes the clearing to fix that issue. Conveniently, we have defensive programming elsewhere that this makes it the only required change. Within the planner plugins themselves we already interpret 1 iteration as being start occupied and thus no valid potential path solution could be found, so we keep that contextual failure mode if there's no way out from the start. 

Addresses https://github.com/ros-navigation/navigation2/issues/4271
