### PR TITLE
Enable reloading BT xml file with same name (backport #4209)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -235,6 +235,9 @@ protected:
   // The timeout value for waiting for a service to response
   std::chrono::milliseconds wait_for_service_timeout_;
 
+  // should the BT be reloaded even if the same xml filename is requested?
+  bool always_reload_bt_xml_ = false;
+
   // User-provided callbacks
   OnGoalReceivedCallback on_goal_received_callback_;
   OnLoopCallback on_loop_callback_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -60,6 +60,9 @@ BtActionServer<ActionT>::BtActionServer(
   if (!node->has_parameter("default_server_timeout")) {
     node->declare_parameter("default_server_timeout", 20);
   }
+  if (!node->has_parameter("always_reload_bt_xml")) {
+    node->declare_parameter("always_reload_bt_xml", false);
+  }
   if (!node->has_parameter("wait_for_service_timeout")) {
     node->declare_parameter("wait_for_service_timeout", 1000);
   }
@@ -118,6 +121,7 @@ bool BtActionServer<ActionT>::on_configure()
   int wait_for_service_timeout;
   node->get_parameter("wait_for_service_timeout", wait_for_service_timeout);
   wait_for_service_timeout_ = std::chrono::milliseconds(wait_for_service_timeout);
+  node->get_parameter("always_reload_bt_xml", always_reload_bt_xml_);
 
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>(plugin_lib_names_);
@@ -174,8 +178,8 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Empty filename is default for backward compatibility
   auto filename = bt_xml_filename.empty() ? default_bt_xml_filename_ : bt_xml_filename;
 
-  // Use previous BT if it is the existing one
-  if (current_bt_xml_filename_ == filename) {
+  // Use previous BT if it is the existing one and always reload flag is not set to true
+  if (!always_reload_bt_xml_ && current_bt_xml_filename_ == filename) {
     RCLCPP_DEBUG(logger_, "BT will not be reloaded as the given xml is already loaded");
     return true;
   }


### PR DESCRIPTION
Manual backport of https://github.com/ros-navigation/navigation2/pull/4209#issuecomment-2155106680 to humble.

The current test results for humble and this branch are the same:
```
$ colcon test-result
build/nav2_behavior_tree/Testing/20240612-0708/Test.xml: 57 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/cpplint.xunit.xml: 165 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_action_navigate_through_poses_action.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_single_trigger_node.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/uncrustify.xunit.xml: 163 tests, 0 errors, 2 failures, 0 skipped
```