### PR TITLE
[AMCL] reduce the amount of memory used

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -152,7 +152,8 @@ protected:
   std::recursive_mutex mutex_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
 #if NEW_UNIFORM_SAMPLING
-  static std::vector<std::pair<int, int>> free_space_indices;
+  struct Point2D { int32_t x; int32_t y; };
+  static std::vector<Point2D> free_space_indices;
 #endif
 
   // Transforms

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -392,6 +392,7 @@ protected:
   double z_rand_;
   std::string scan_topic_{"scan"};
   std::string map_topic_{"map"};
+  bool freespace_downsampling_ = false;
 };
 
 }  // namespace nav2_amcl

--- a/nav2_amcl/include/nav2_amcl/map/map.hpp
+++ b/nav2_amcl/include/nav2_amcl/map/map.hpp
@@ -41,20 +41,21 @@ struct _rtk_fig_t;
 // Limits
 #define MAP_WIFI_MAX_LEVELS 8
 
-
+// make sure that the sizeof(map_cell_t) == 5
+#pragma pack(push, 1)
 // Description for a single map cell.
 typedef struct
 {
   // Occupancy state (-1 = free, 0 = unknown, +1 = occ)
-  int occ_state;
+  int8_t occ_state;
 
   // Distance to the nearest occupied cell
-  double occ_dist;
+  float occ_dist;
 
   // Wifi levels
   // int wifi_levels[MAP_WIFI_MAX_LEVELS];
 } map_cell_t;
-
+#pragma pack(pop)
 
 // Description for a map
 typedef struct

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -231,7 +231,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
   add_parameter(
     "freespace_downsampling", rclcpp::ParameterValue(
       false),
-    "If true, downsample the free space used by the Pose Generator. This will save memory in VERY large maps");
+    "Downsample the free space used by the Pose Generator. Use it with large maps to save memory");
 }
 
 AmclNode::~AmclNode()


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This is a memory optimization that should not affect realtime perfomance, but will reduce considerably the amount of memory used by AMCL.

In our large map (200 Mb) this is the memory usage **before** the change:

![2024-06-12_19-03_1](https://github.com/ros-navigation/navigation2/assets/2822888/17554305-048d-44e6-a261-d215846d00b1)

And **after** the changes:

![2024-06-12_19-03](https://github.com/ros-navigation/navigation2/assets/2822888/ee6939f4-c43e-468f-8bb0-a8c5cdeb71ff)

The main changes are:

1. Changes in `map_cell_t`: reduction from 12 bytes to 5 bytes
2. Add a new parameter to reduce the memory used by `free_space_indices` using 1/4th of the points (equally spaced)

## Description of documentation updates required from your changes

Describe the new parameter "freespace_downsampling"

---

## Future work that may be required in bullet points

To be discussed

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
