### PR TITLE
[Docking] Feature: support for not needing to set dock instances

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -407,11 +407,12 @@ docking_server:
       filter_coef: 0.1
 
     # Dock instances
-    docks: ['home_dock']  # Input your docks here
-    home_dock:
-      type: 'simple_charging_dock'
-      frame: map
-      pose: [0.0, 0.0, 0.0]
+    # The following example illustrates how you should configure the docks instances.
+    # docks: ['home_dock']  # Input your docks here
+    # home_dock:
+    #   type: 'simple_charging_dock'
+    #   frame: map
+    #   pose: [0.0, 0.0, 0.0]
 
     controller:
       k_phi: 3.0

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -407,7 +407,7 @@ docking_server:
       filter_coef: 0.1
 
     # Dock instances
-    # The following example illustrates how you should configure the docks instances.
+    # The following example illustrates configuring dock instances.
     # docks: ['home_dock']  # Input your docks here
     # home_dock:
     #   type: 'simple_charging_dock'

--- a/nav2_docking/opennav_docking/src/dock_database.cpp
+++ b/nav2_docking/opennav_docking/src/dock_database.cpp
@@ -84,7 +84,7 @@ void DockDatabase::reloadDbCb(
 {
   auto node = node_.lock();
   DockMap dock_instances;
-  if (utils::parseDockFile(request->filepath, node_.lock(), dock_instances)) {
+  if (utils::parseDockFile(request->filepath, node, dock_instances)) {
     dock_instances_ = dock_instances;
     response->success = true;
     RCLCPP_INFO(
@@ -92,10 +92,6 @@ void DockDatabase::reloadDbCb(
       "Dock database reloaded from file %s.", request->filepath.c_str());
     return;
   }
-
-  RCLCPP_ERROR(
-    node->get_logger(),
-    "Dock database reload failed from file %s.", request->filepath.c_str());
   response->success = false;
 }
 
@@ -118,17 +114,6 @@ Dock * DockDatabase::findDock(const std::string & dock_id)
 
 Dock * DockDatabase::findDockInstance(const std::string & dock_id)
 {
-  if (dock_instances_.empty()) {
-    auto node = node_.lock();
-    RCLCPP_WARN(
-      node->get_logger(),
-      "Dock database filepath nor dock parameters set. "
-      "Docking actions can only be executed specifying the dock pose via the action request. "
-      "Or update the dock database via the reload_database service.");
-
-    return nullptr;
-  }
-
   auto it = dock_instances_.find(dock_id);
   if (it != dock_instances_.end()) {
     return &(it->second);

--- a/nav2_docking/opennav_docking/test/test_dock_database.cpp
+++ b/nav2_docking/opennav_docking/test/test_dock_database.cpp
@@ -102,8 +102,11 @@ TEST(DatabaseTests, findTests)
 TEST(DatabaseTests, reloadDbService)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
-  std::vector<std::string> plugins{"dockv1", "dockv2"};
+  std::vector<std::string> plugins{"dockv1"};
   node->declare_parameter("dock_plugins", rclcpp::ParameterValue(plugins));
+  node->declare_parameter(
+    "dockv1.plugin",
+    rclcpp::ParameterValue("opennav_docking::SimpleChargingDock"));
   opennav_docking::DockDatabase db;
   db.initialize(node, nullptr);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4415 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo Simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
The changes made are as follows:
* [Support for not needing to set `dock_instances`](https://github.com/ros-navigation/navigation2/commit/15b085167ae4ee7682c636c7987a66a9b94488e1)
* [Improve some log messages in `dock_database.cpp`](https://github.com/ros-navigation/navigation2/commit/24337173b228c22a963be3ae5b98760adf1e6f18)
* [Comment the dock instances out from `nav2_params`](https://github.com/ros-navigation/navigation2/commit/ec9c012e8b4dd1e62d8a0aeaac3b106f3280a984)

These changes enable the system to work in the following use cases:
* Setting the dock instances in the parameters or database yaml file.
* Not setting the dock instances in these files but using the dock pose in the action request or the reload database service.

Also, the reload database service is available in any case where at least one dock plugin has been defined.

## Description of documentation updates required from your changes
* The documentation may need to be updated to reflect the "Not setting ..." use case.

---

## Future work that may be required in bullet points
* The unit tests may need to be updated to address new changes

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
