### PR TITLE
Fix unexpected behavior of docking when already in charger

### DIFF
--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -236,7 +236,7 @@ void DockingServer::dockRobot()
     }
 
     // Check if the robot is docked or charging before proceeding
-    if (dock->plugin->isDocked() || dock->plugin->isCharging()){
+    if (dock->plugin->isDocked() || dock->plugin->isCharging()) {
       RCLCPP_INFO(get_logger(), "Robot is already charging, no need to dock");
       return;
     }

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -235,6 +235,12 @@ void DockingServer::dockRobot()
       dock = generateGoalDock(goal);
     }
 
+    // Check if the robot is docked or charging before proceeding
+    if (dock->plugin->isDocked() || dock->plugin->isCharging()){
+      RCLCPP_INFO(get_logger(), "Robot is already charging, no need to dock");
+      return;
+    }
+
     // Send robot to its staging pose
     publishDockingFeedback(DockRobot::Feedback::NAV_TO_STAGING_POSE);
     const auto initial_staging_pose = dock->getStagingPose();
@@ -568,6 +574,12 @@ void DockingServer::undockRobot()
     RCLCPP_INFO(
       get_logger(),
       "Attempting to undock robot from charger of type %s.", dock->getName().c_str());
+
+    // Check if the robot is docked before proceeding
+    if (!dock->isDocked()) {
+      RCLCPP_INFO(get_logger(), "Robot is not in the charger, no need to undock");
+      return;
+    }
 
     // Get "dock pose" by finding the robot pose
     geometry_msgs::msg::PoseStamped dock_pose = getRobotPoseInFrame(fixed_frame_);

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -86,9 +86,8 @@ TEST(DockingServerTests, testErrorExceptions)
   node->on_configure(rclcpp_lifecycle::State());
   node->on_activate(rclcpp_lifecycle::State());
 
-  node->declare_parameter(
-    "exception_to_throw",
-    rclcpp::ParameterValue(""));
+  node->declare_parameter("exception_to_throw", rclcpp::ParameterValue(""));
+  node->declare_parameter("dock_action_called", rclcpp::ParameterValue(false));
 
   // Error codes docking
   std::vector<std::string> error_ids{
@@ -141,6 +140,9 @@ TEST(DockingServerTests, testErrorExceptions)
     "TransformException", "DockNotValid", "FailedToControl",
     "DockingException", "exception"};
   std::vector<int> error_codes_undocking{999, 902, 905, 999, 999};
+
+  // Set dock_action_called to true to simulate robot being docked in dock plugin
+  node->set_parameter(rclcpp::Parameter("dock_action_called", true));
 
   // Call action, check error code
   for (unsigned int i = 0; i != error_ids_undocking.size(); i++) {

--- a/nav2_docking/opennav_docking/test/testing_dock.cpp
+++ b/nav2_docking/opennav_docking/test/testing_dock.cpp
@@ -80,7 +80,9 @@ public:
 
   virtual bool isDocked()
   {
-    return false;
+    bool dock_action_called;
+    node_->get_parameter("dock_action_called", dock_action_called);
+    return dock_action_called;
   }
 
   virtual bool isCharging()


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#4447 |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | Morphia robot |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Check if the robot is in the charging station before try to dock / undock to prevent docking when it's already in the charging station and undocking if is not docked.

The fix just return, aborting the handle. It can be improve addind result / error code if necessary.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
