### PR TITLE
Fix CI with BT test from btv4.X API update

### DIFF
--- a/nav2_behavior_tree/test/test_bt_utils.cpp
+++ b/nav2_behavior_tree/test/test_bt_utils.cpp
@@ -59,13 +59,7 @@ TEST(PointPortTest, test_wrong_syntax)
 
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::Point>>("PointPort");
-  auto tree = factory.createTreeFromText(xml_txt);
-
-  geometry_msgs::msg::Point value;
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(value.x, 0.0);
-  EXPECT_EQ(value.y, 0.0);
-  EXPECT_EQ(value.z, 0.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 
   xml_txt =
     R"(
@@ -75,11 +69,7 @@ TEST(PointPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  tree = factory.createTreeFromText(xml_txt);
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(value.x, 0.0);
-  EXPECT_EQ(value.y, 0.0);
-  EXPECT_EQ(value.z, 0.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 }
 
 TEST(PointPortTest, test_correct_syntax)
@@ -115,14 +105,8 @@ TEST(QuaternionPortTest, test_wrong_syntax)
 
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::Quaternion>>("QuaternionPort");
-  auto tree = factory.createTreeFromText(xml_txt);
 
-  geometry_msgs::msg::Quaternion value;
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(value.x, 0.0);
-  EXPECT_EQ(value.y, 0.0);
-  EXPECT_EQ(value.z, 0.0);
-  EXPECT_EQ(value.w, 1.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 
   xml_txt =
     R"(
@@ -132,12 +116,7 @@ TEST(QuaternionPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  tree = factory.createTreeFromText(xml_txt);
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(value.x, 0.0);
-  EXPECT_EQ(value.y, 0.0);
-  EXPECT_EQ(value.z, 0.0);
-  EXPECT_EQ(value.w, 1.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 }
 
 TEST(QuaternionPortTest, test_correct_syntax)
@@ -174,19 +153,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
 
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::PoseStamped>>("PoseStampedPort");
-  auto tree = factory.createTreeFromText(xml_txt);
-
-  geometry_msgs::msg::PoseStamped value;
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(rclcpp::Time(value.header.stamp).nanoseconds(), 0);
-  EXPECT_EQ(value.header.frame_id, "");
-  EXPECT_EQ(value.pose.position.x, 0.0);
-  EXPECT_EQ(value.pose.position.y, 0.0);
-  EXPECT_EQ(value.pose.position.z, 0.0);
-  EXPECT_EQ(value.pose.orientation.x, 0.0);
-  EXPECT_EQ(value.pose.orientation.y, 0.0);
-  EXPECT_EQ(value.pose.orientation.z, 0.0);
-  EXPECT_EQ(value.pose.orientation.w, 1.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 
   xml_txt =
     R"(
@@ -196,17 +163,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  tree = factory.createTreeFromText(xml_txt);
-  tree.rootNode()->getInput("test", value);
-  EXPECT_EQ(rclcpp::Time(value.header.stamp).nanoseconds(), 0);
-  EXPECT_EQ(value.header.frame_id, "");
-  EXPECT_EQ(value.pose.position.x, 0.0);
-  EXPECT_EQ(value.pose.position.y, 0.0);
-  EXPECT_EQ(value.pose.position.z, 0.0);
-  EXPECT_EQ(value.pose.orientation.x, 0.0);
-  EXPECT_EQ(value.pose.orientation.y, 0.0);
-  EXPECT_EQ(value.pose.orientation.z, 0.0);
-  EXPECT_EQ(value.pose.orientation.w, 1.0);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
 }
 
 TEST(PoseStampedPortTest, test_correct_syntax)

--- a/nav2_behavior_tree/test/test_bt_utils.cpp
+++ b/nav2_behavior_tree/test/test_bt_utils.cpp
@@ -59,7 +59,7 @@ TEST(PointPortTest, test_wrong_syntax)
 
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::Point>>("PointPort");
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 
   xml_txt =
     R"(
@@ -69,7 +69,7 @@ TEST(PointPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 }
 
 TEST(PointPortTest, test_correct_syntax)
@@ -106,7 +106,7 @@ TEST(QuaternionPortTest, test_wrong_syntax)
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::Quaternion>>("QuaternionPort");
 
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 
   xml_txt =
     R"(
@@ -116,7 +116,7 @@ TEST(QuaternionPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 }
 
 TEST(QuaternionPortTest, test_correct_syntax)
@@ -153,7 +153,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
 
   BT::BehaviorTreeFactory factory;
   factory.registerNodeType<TestNode<geometry_msgs::msg::PoseStamped>>("PoseStampedPort");
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 
   xml_txt =
     R"(
@@ -163,7 +163,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
         </BehaviorTree>
       </root>)";
 
-  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::runtime_error);
+  EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 }
 
 TEST(PoseStampedPortTest, test_correct_syntax)


### PR DESCRIPTION
We did this originally with source builds but took time for those updates to make it to binaries which has now happened requiring this change in the test fixtures for incorrect syntax tests