### PR TITLE
bt_service_node and bt_action_node: Don't block BT loop (backport #4214 + #4234)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -56,13 +56,16 @@ public:
     callback_group_executor_.add_callback_group(callback_group_, node_->get_node_base_interface());
 
     // Get the required items from the blackboard
-    bt_loop_duration_ =
+    auto bt_loop_duration =
       config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
     server_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
     wait_for_service_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("wait_for_service_timeout");
+
+    // timeout should be less than bt_loop_duration to be able to finish the current tick
+    max_timeout_ = std::chrono::duration_cast<std::chrono::milliseconds>(bt_loop_duration * 0.5);
 
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
@@ -404,7 +407,7 @@ protected:
       return false;
     }
 
-    auto timeout = remaining > bt_loop_duration_ ? bt_loop_duration_ : remaining;
+    auto timeout = remaining > max_timeout_ ? max_timeout_ : remaining;
     auto result =
       callback_group_executor_.spin_until_future_complete(*future_goal_handle_, timeout);
     elapsed += timeout;
@@ -460,7 +463,7 @@ protected:
   std::chrono::milliseconds server_timeout_;
 
   // The timeout value for BT loop execution
-  std::chrono::milliseconds bt_loop_duration_;
+  std::chrono::milliseconds max_timeout_;
 
   // The timeout value for waiting for a service to response
   std::chrono::milliseconds wait_for_service_timeout_;

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -316,8 +316,10 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::FAILURE);
 
-  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should be 2
-  EXPECT_EQ(ticks, 2);
+  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should
+  // be at most 2, but it can be 1 too, because the tickOnce may execute two ticks.
+  EXPECT_LE(ticks, 3);
+  EXPECT_GE(ticks, 1);
 }
 
 TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
@@ -362,7 +364,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   EXPECT_EQ(result, BT::NodeStatus::FAILURE);
 
   // since the server timeout is 90ms and bt loop duration is 10ms, number of ticks should be 9
-  EXPECT_EQ(ticks, 9);
+  EXPECT_EQ(ticks, 10);
 
   // start a new execution cycle with the previous BT to ensure previous state doesn't leak into
   // the new cycle


### PR DESCRIPTION
See https://github.com/ros-navigation/navigation2/pull/4408

Test results are the same for humble:

```
$ colcon test-result
build/nav2_behavior_tree/Testing/20240624-1845/Test.xml: 57 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/cpplint.xunit.xml: 165 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_action_navigate_through_poses_action.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_single_trigger_node.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/uncrustify.xunit.xml: 163 tests, 0 errors, 2 failures, 0 skipped

Summary: 811 tests, 0 errors, 12 failures, 163 skipped
```
and this PR

```
$ colcon test-result
build/nav2_behavior_tree/Testing/20240624-1907/Test.xml: 57 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/cpplint.xunit.xml: 165 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_action_navigate_through_poses_action.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/test_single_trigger_node.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/uncrustify.xunit.xml: 163 tests, 0 errors, 2 failures, 0 skipped

Summary: 811 tests, 0 errors, 12 failures, 163 skipped
```