### PR TITLE
WIP: Add a BT plugin to check valid forward motion with an ML model (ChatGPT specifically)

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -117,6 +117,9 @@ list(APPEND plugin_libs nav2_goal_updated_condition_bt_node)
 add_library(nav2_is_path_valid_condition_bt_node SHARED plugins/condition/is_path_valid_condition.cpp)
 list(APPEND plugin_libs nav2_is_path_valid_condition_bt_node)
 
+add_library(nav2_ml_model_is_path_valid_condition_bt_node SHARED plugins/condition/ml_model_is_path_valid_condition.cpp)
+list(APPEND plugin_libs nav2_ml_model_is_path_valid_condition_bt_node)
+
 add_library(nav2_time_expired_condition_bt_node SHARED plugins/condition/time_expired_condition.cpp)
 list(APPEND plugin_libs nav2_time_expired_condition_bt_node)
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/ml_model_is_path_valid_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/ml_model_is_path_valid_condition.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Joshua Wallace
+// Copyright (c) 2024 Andy Zelenak
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,36 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__IS_PATH_VALID_CONDITION_HPP_
-#define NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__IS_PATH_VALID_CONDITION_HPP_
+#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__LLM_IS_PATH_VALID_CONDITION_HPP_
+#define NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__LLM_IS_PATH_VALID_CONDITION_HPP_
 
 #include <string>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 #include "behaviortree_cpp_v3/condition_node.h"
-#include "nav2_msgs/srv/is_path_valid.hpp"
+#include "nav_msgs/msg/path.h"
 
 namespace nav2_behavior_tree
 {
 
 /**
- * @brief A BT::ConditionNode that returns SUCCESS when the IsPathValid
- * service returns true and FAILURE otherwise
+ * @brief A BT::ConditionNode that returns SUCCESS when a large language model says that a path is clear
+ *        The input data has type sensor_msgs::msg::Image.
  */
-class IsPathValidCondition : public BT::ConditionNode
+class MLModelIsPathValidCondition : public BT::ConditionNode
 {
 public:
   /**
-   * @brief A constructor for nav2_behavior_tree::IsPathValidCondition
+   * @brief A constructor for nav2_behavior_tree::MLModelIsPathValidCondition
    * @param condition_name Name for the XML tag for this node
    * @param conf BT node configuration
    */
-  IsPathValidCondition(
+  MLModelIsPathValidCondition(
     const std::string & condition_name,
     const BT::NodeConfiguration & conf);
 
-  IsPathValidCondition() = delete;
+  MLModelIsPathValidCondition() = delete;
 
   /**
    * @brief The main override required by a BT action
@@ -56,19 +56,20 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<nav_msgs::msg::Path>("path", "Path to Check"),
+      BT::InputPort<nav_msgs::msg::Path>("path", "Path to check"),
+      BT::InputPort<std::string>("image topic", "Image topic which is subscribed to"),
       BT::InputPort<std::chrono::milliseconds>("server_timeout")
     };
   }
 
 private:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Client<nav2_msgs::srv::IsPathValid>::SharedPtr client_;
   // The timeout value while waiting for a response from the
   // is path valid service
   std::chrono::milliseconds server_timeout_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr iamge_sub_;
 };
 
 }  // namespace nav2_behavior_tree
 
-#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__IS_PATH_VALID_CONDITION_HPP_
+#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__LLM_IS_PATH_VALID_CONDITION_HPP_

--- a/nav2_behavior_tree/plugins/condition/ml_model_is_path_valid_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/ml_model_is_path_valid_condition.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 Andy Zelenak
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_behavior_tree/plugins/condition/ml_model_is_path_valid_condition.hpp"
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace nav2_behavior_tree
+{
+
+MLModelIsPathValidCondition::MLModelIsPathValidCondition(
+  const std::string & condition_name,
+  const BT::NodeConfiguration & conf)
+: BT::ConditionNode(condition_name, conf)
+{
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+
+  server_timeout_ = config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
+  getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
+}
+
+BT::NodeStatus MLModelIsPathValidCondition::tick()
+{
+  nav_msgs::msg::Path path;
+  getInput("path", path);
+
+  // TODO: check if upcoming motion is forward
+
+  // TODO: send image to ChatGPT
+
+  return BT::NodeStatus::FAILURE;
+}
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::MLModelIsPathValidCondition>("MLModelIsPathValid");
+}


### PR DESCRIPTION
## Basic Info

| ------ | ----------- |
| Ticket(s) this addresses   | n/a |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | RealSense D415 |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Add a BT plugin to check whether forward motion is valid
* A JSON request is sent to a machine learning model (in this case, ChatGPT) to check the image
* The GPT is smart enough to recognize this cord as an obstacle that should be avoided
* (the cord wouldn't show up in a typical Lidar scan)
* I think there are tons of other things AI could do for nav, but this is a good start

![IMG_20240624_164854061](https://github.com/ros-navigation/navigation2/assets/11284393/2f7ca47e-eab1-4798-8c18-db63af076ee0)

## Description of documentation updates required from your changes

* Add to [nav2 BT tutorials](https://docs.nav2.org/plugins/index.html#behavior-tree-nodes)

---

## Future work that may be required in bullet points

* I would like to figure out inheritance so this feature isn't specifically tied to ChatGPT
* Be more clear about what "forward motion" actually means. Parameterize it?

#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
