### PR TITLE
Fix map to world coordinate conversion

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -46,9 +46,9 @@ inline geometry_msgs::msg::Pose getWorldCoords(
 {
   geometry_msgs::msg::Pose msg;
   msg.position.x =
-    static_cast<float>(costmap->getOriginX()) + (mx + 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginX()) + (mx - 0.5) * costmap->getResolution();
   msg.position.y =
-    static_cast<float>(costmap->getOriginY()) + (my + 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginY()) + (my - 0.5) * costmap->getResolution();
   return msg;
 }
 

--- a/nav2_smac_planner/test/test_utils.cpp
+++ b/nav2_smac_planner/test/test_utils.cpp
@@ -147,3 +147,17 @@ TEST(create_marker, test_createMarker)
   EXPECT_EQ(marker2.id, 8u);
   EXPECT_EQ(marker2.points.size(), 0u);
 }
+
+TEST(convert_map_to_world_to_map, test_convert_map_to_world_to_map)
+{
+  auto costmap = nav2_costmap_2d::Costmap2D(10.0, 10.0, 0.05, 0.0, 0.0, 0);
+
+  float mx = 200.0;
+  float my = 100.0;
+  geometry_msgs::msg::Pose pose = getWorldCoords(mx, my, &costmap);
+
+  float mx1, my1;
+  costmap.worldToMapContinuous(pose.position.x, pose.position.y, mx1, my1);
+  EXPECT_NEAR(mx, mx1, 1e-3);
+  EXPECT_NEAR(my, my1, 1e-3);
+}


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

For reproducing the issue see the test I added 

We noticed that ComputePathThroughPoses with SmacPlannerHybrid when asked to generate path through poses that are on the same line (in this example: [{x: 2, y: 0}, {x: 4, y: 0}, {x: 6, y: 0}]) generates path like this: 
![Screenshot from 2024-07-01 13-33-38](https://github.com/ros-navigation/navigation2/assets/72872431/1fa4e67a-5b71-4b2d-9c6c-9c196424f454)

It is assumed that end of path1 is the start of path2, but when end of path1 is converted from map to world, and then back to map it ends up in a different costmap cell.

When we convert world to map coordinates we [add 0.5](https://github.com/ros-navigation/navigation2/blob/30f028d1bf5a4cb3ba429061823135ba6b394ca9/nav2_costmap_2d/src/costmap_2d.cpp#L299)

Therefore when we convert map to world I think we should subtract 0.5. Otherwise we end up in the next costmap cell
With this change path looks like more straight: 
![Screenshot from 2024-07-01 13-35-33](https://github.com/ros-navigation/navigation2/assets/72872431/77d850da-bc60-4660-9957-3d1c8c64328d)

## Description of documentation updates required from your changes

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
