### PR TITLE
min_turning_r_ getting param fix

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -140,7 +140,7 @@ public:
   /**
     * @brief Constructor for mppi::AckermannMotionModel
     */
-  explicit AckermannMotionModel(ParametersHandler * param_handler, const std::string &name)
+  explicit AckermannMotionModel(ParametersHandler * param_handler, const std::string & name)
   {
     auto getParam = param_handler->getParamGetter(name + ".AckermannConstraints");
     getParam(min_turning_r_, "min_turning_r", 0.2);

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -140,9 +140,9 @@ public:
   /**
     * @brief Constructor for mppi::AckermannMotionModel
     */
-  explicit AckermannMotionModel(ParametersHandler * param_handler)
+  explicit AckermannMotionModel(ParametersHandler * param_handler, const std::string &name)
   {
-    auto getParam = param_handler->getParamGetter("AckermannConstraints");
+    auto getParam = param_handler->getParamGetter(name + ".AckermannConstraints");
     getParam(min_turning_r_, "min_turning_r", 0.2);
   }
 

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -442,7 +442,7 @@ void Optimizer::setMotionModel(const std::string & model)
   } else if (model == "Omni") {
     motion_model_ = std::make_shared<OmniMotionModel>();
   } else if (model == "Ackermann") {
-    motion_model_ = std::make_shared<AckermannMotionModel>(parameters_handler_);
+    motion_model_ = std::make_shared<AckermannMotionModel>(parameters_handler_, name_);
   } else {
     throw nav2_core::ControllerException(
             std::string(

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -116,7 +116,7 @@ TEST(CriticTests, ConstraintsCritic)
   // Now with ackermann, all in constraint so no costs to score
   state.vx = 0.40 * xt::ones<float>({1000, 30});
   state.wz = 1.5 * xt::ones<float>({1000, 30});
-  data.motion_model = std::make_shared<AckermannMotionModel>(&param_handler);
+  data.motion_model = std::make_shared<AckermannMotionModel>(&param_handler, node->get_name());
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0, 1e-6);
 

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -136,7 +136,7 @@ TEST(MotionModelTests, AckermannTest)
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
   ParametersHandler param_handler(node);
   std::unique_ptr<AckermannMotionModel> model =
-    std::make_unique<AckermannMotionModel>(&param_handler);
+    std::make_unique<AckermannMotionModel>(&param_handler, node->get_name());
 
   // Check that predict properly populates the trajectory velocities with the control velocities
   state.cvx = 10 * xt::ones<float>({batches, timesteps});


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4509 |
| Primary OS tested on | Ubuntu |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

<!--
* The AckermannMotionModel constructor has been changed to get parameters using the correct path
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
