### PR TITLE
Switch nav2_voxel_grid to use modern CMake idioms.

### DIFF
--- a/nav2_voxel_grid/CMakeLists.txt
+++ b/nav2_voxel_grid/CMakeLists.txt
@@ -7,29 +7,26 @@ find_package(rclcpp REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include)
-
 add_library(voxel_grid SHARED
   src/voxel_grid.cpp
 )
-
-set(dependencies
-  rclcpp
-)
-
-ament_target_dependencies(voxel_grid
-  ${dependencies}
+target_include_directories(voxel_grid
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(voxel_grid PUBLIC
+  rclcpp::rclcpp
 )
 
 install(TARGETS voxel_grid
+  EXPORT voxel_grid
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -39,11 +36,15 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+
+  ament_find_gtest()
+
   add_subdirectory(test)
 endif()
 
 ament_export_dependencies(rclcpp)
 ament_export_include_directories(include)
 ament_export_libraries(voxel_grid)
+ament_export_targets(voxel_grid)
 
 ament_package()

--- a/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
+++ b/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
@@ -44,7 +44,9 @@
 #include <math.h>
 #include <limits.h>
 #include <algorithm>
-#include "rclcpp/rclcpp.hpp"
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
 
 /**
  * @class VoxelGrid

--- a/nav2_voxel_grid/src/voxel_grid.cpp
+++ b/nav2_voxel_grid/src/voxel_grid.cpp
@@ -36,6 +36,9 @@
 *********************************************************************/
 #include <nav2_voxel_grid/voxel_grid.hpp>
 
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
 namespace nav2_voxel_grid
 {
 VoxelGrid::VoxelGrid(unsigned int size_x, unsigned int size_y, unsigned int size_z)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This commit does a number of things:

1. Switches to using target_link_libraries in nav2_voxel_grid, which gives us finer-grained control over what dependencies are exported to downstream as public or private.  In the particular case of nav2_voxel_grid, this doesn't matter too much, but it will help for other packages.
2. Moves the include directory down one level to include/${PROJECT_NAME}, which is best practice in ROS 2 since Humble.
3. Makes sure to export nav2_voxel_grid as a CMake target, so downstream users of it can use that target.

In my local testing, this change doesn't change the compilation time in any significant way; that is likely because nav2_voxel_grid is such a small package.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

The rest of the packages in this repository need a similar treatment (PRs will be upcoming).

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
