### PR TITLE
Switch nav2_map_server to use modern CMake idioms.

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -4,24 +4,27 @@ project(nav2_map_server)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake_modules)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
+find_package(GRAPHICSMAGICKCPP REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(yaml_cpp_vendor REQUIRED)
+find_package(nav2_util REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(GRAPHICSMAGICKCPP REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 nav2_package()
 
-include_directories(include)
-
 set(map_server_executable map_server)
+
+set(library_name ${map_server_executable}_core)
+
+set(map_io_library_name map_io)
 
 set(map_saver_cli_executable map_saver_cli)
 
@@ -29,103 +32,106 @@ set(map_saver_server_executable map_saver_server)
 
 set(costmap_filter_info_server_executable costmap_filter_info_server)
 
-add_executable(${map_server_executable}
-  src/map_server/main.cpp)
-
-add_executable(${map_saver_cli_executable}
-  src/map_saver/main_cli.cpp)
-
-add_executable(${map_saver_server_executable}
-  src/map_saver/main_server.cpp)
-
-add_executable(${costmap_filter_info_server_executable}
-  src/costmap_filter_info/main.cpp)
-
-set(map_io_library_name map_io)
-
-set(library_name ${map_server_executable}_core)
-
-add_library(${map_io_library_name} SHARED
-  src/map_mode.cpp
-  src/map_io.cpp)
-
 add_library(${library_name} SHARED
   src/map_server/map_server.cpp
   src/map_saver/map_saver.cpp
   src/costmap_filter_info/costmap_filter_info_server.cpp)
+target_include_directories(${library_name}
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${library_name} PUBLIC
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${nav2_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+)
+target_link_libraries(${library_name} PRIVATE
+  ${lifecycle_msgs_TARGETS}
+  rclcpp_components::component
+  yaml-cpp::yaml-cpp
+)
 
-set(map_io_dependencies
-  yaml_cpp_vendor
-  nav_msgs
-  nav2_util
-  tf2)
-
-set(map_server_dependencies
-  rclcpp
-  rclcpp_lifecycle
-  rclcpp_components
-  nav_msgs
-  nav2_msgs
-  yaml_cpp_vendor
-  std_msgs
-  nav2_util)
-
-set(map_saver_dependencies
-  rclcpp
-  rclcpp_lifecycle
-  nav_msgs
-  nav2_msgs
-  nav2_util)
-
-ament_target_dependencies(${map_server_executable}
-  ${map_server_dependencies})
-
-ament_target_dependencies(${map_saver_cli_executable}
-  ${map_saver_dependencies})
-
-ament_target_dependencies(${map_saver_server_executable}
-  ${map_saver_dependencies})
-
-ament_target_dependencies(${costmap_filter_info_server_executable}
-  ${map_saver_dependencies})
-
-ament_target_dependencies(${library_name}
-  ${map_server_dependencies})
-
-ament_target_dependencies(${map_io_library_name}
-  ${map_io_dependencies})
-
-target_link_libraries(${library_name}
-  ${map_io_library_name})
-
-target_link_libraries(${map_server_executable}
-  ${library_name})
-
-if(WIN32)
-  target_compile_definitions(${map_server_executable} PRIVATE
-    YAML_CPP_DLL)
-endif()
-
-target_link_libraries(${map_saver_cli_executable}
-  ${library_name})
-
-target_link_libraries(${map_saver_server_executable}
-  ${library_name})
-
-target_link_libraries(${costmap_filter_info_server_executable}
-  ${library_name})
-
-target_include_directories(${map_io_library_name} SYSTEM PRIVATE
+add_library(${map_io_library_name} SHARED
+  src/map_mode.cpp
+  src/map_io.cpp)
+target_include_directories(${map_io_library_name}
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_include_directories(${map_io_library_name}
+  PRIVATE
   ${GRAPHICSMAGICKCPP_INCLUDE_DIRS})
-
-target_link_libraries(${map_io_library_name}
+target_link_libraries(${map_io_library_name} PUBLIC
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+)
+target_link_libraries(${map_io_library_name} PRIVATE
   ${GRAPHICSMAGICKCPP_LIBRARIES}
-  yaml-cpp::yaml-cpp)
+  tf2::tf2
+  yaml-cpp::yaml-cpp
+)
 
-if(WIN32)
-  target_compile_definitions(${map_io_library_name} PRIVATE
-    YAML_CPP_DLL)
-endif()
+add_executable(${map_server_executable}
+  src/map_server/main.cpp)
+target_include_directories(${map_server_executable}
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${map_server_executable} PRIVATE
+  rclcpp::rclcpp
+  ${library_name}
+  ${map_io_library_name}
+)
+
+add_executable(${map_saver_cli_executable}
+  src/map_saver/main_cli.cpp)
+target_include_directories(${map_saver_cli_executable}
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${map_saver_cli_executable} PRIVATE
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${nav_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${library_name}
+  ${map_io_library_name}
+)
+
+add_executable(${map_saver_server_executable}
+  src/map_saver/main_server.cpp)
+target_include_directories(${map_saver_server_executable}
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${map_saver_server_executable} PRIVATE
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${nav_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${library_name}
+  ${map_io_library_name}
+)
+
+add_executable(${costmap_filter_info_server_executable}
+  src/costmap_filter_info/main.cpp)
+target_include_directories(${costmap_filter_info_server_executable}
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${costmap_filter_info_server_executable} PRIVATE
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${nav_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${library_name}
+  ${map_io_library_name}
+)
 
 rclcpp_components_register_nodes(${library_name} "nav2_map_server::CostmapFilterInfoServer")
 rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapSaver")
@@ -133,6 +139,7 @@ rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapServer")
 
 install(TARGETS
     ${library_name} ${map_io_library_name}
+  EXPORT ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
@@ -143,7 +150,7 @@ install(TARGETS
   RUNTIME DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY include/
-  DESTINATION include/)
+  DESTINATION include/${PROJECT_NAME})
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
@@ -154,6 +161,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
   add_subdirectory(test)
 endif()
 
@@ -162,5 +170,7 @@ ament_export_libraries(
   ${library_name}
   ${map_io_library_name}
 )
-ament_export_dependencies(${map_io_dependencies} ${map_server_dependencies} yaml-cpp)
+ament_export_dependencies(nav_msgs nav2_msgs nav2_util rclcpp rclcpp_lifecycle)
+ament_export_targets(${library_name})
+
 ament_package()

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -32,27 +32,6 @@ set(map_saver_server_executable map_saver_server)
 
 set(costmap_filter_info_server_executable costmap_filter_info_server)
 
-add_library(${library_name} SHARED
-  src/map_server/map_server.cpp
-  src/map_saver/map_saver.cpp
-  src/costmap_filter_info/costmap_filter_info_server.cpp)
-target_include_directories(${library_name}
-  PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(${library_name} PUBLIC
-  nav2_util::nav2_util_core
-  rclcpp::rclcpp
-  rclcpp_lifecycle::rclcpp_lifecycle
-  ${nav2_msgs_TARGETS}
-  ${nav_msgs_TARGETS}
-)
-target_link_libraries(${library_name} PRIVATE
-  ${lifecycle_msgs_TARGETS}
-  rclcpp_components::component
-  yaml-cpp::yaml-cpp
-)
-
 add_library(${map_io_library_name} SHARED
   src/map_mode.cpp
   src/map_io.cpp)
@@ -73,6 +52,28 @@ target_link_libraries(${map_io_library_name} PRIVATE
   yaml-cpp::yaml-cpp
 )
 
+add_library(${library_name} SHARED
+  src/map_server/map_server.cpp
+  src/map_saver/map_saver.cpp
+  src/costmap_filter_info/costmap_filter_info_server.cpp)
+target_include_directories(${library_name}
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${library_name} PUBLIC
+  ${map_io_library_name}
+  ${nav_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
+target_link_libraries(${library_name} PRIVATE
+  ${lifecycle_msgs_TARGETS}
+  rclcpp_components::component
+  yaml-cpp::yaml-cpp
+)
+
 add_executable(${map_server_executable}
   src/map_server/main.cpp)
 target_include_directories(${map_server_executable}
@@ -80,9 +81,9 @@ target_include_directories(${map_server_executable}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${map_server_executable} PRIVATE
-  rclcpp::rclcpp
   ${library_name}
   ${map_io_library_name}
+  rclcpp::rclcpp
 )
 
 add_executable(${map_saver_cli_executable}
@@ -92,13 +93,13 @@ target_include_directories(${map_saver_cli_executable}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${map_saver_cli_executable} PRIVATE
-  rclcpp::rclcpp
-  rclcpp_lifecycle::rclcpp_lifecycle
+  ${library_name}
+  ${map_io_library_name}
   ${nav_msgs_TARGETS}
   ${nav2_msgs_TARGETS}
   nav2_util::nav2_util_core
-  ${library_name}
-  ${map_io_library_name}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 add_executable(${map_saver_server_executable}
@@ -108,13 +109,13 @@ target_include_directories(${map_saver_server_executable}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${map_saver_server_executable} PRIVATE
-  rclcpp::rclcpp
-  rclcpp_lifecycle::rclcpp_lifecycle
+  ${library_name}
+  ${map_io_library_name}
   ${nav_msgs_TARGETS}
   ${nav2_msgs_TARGETS}
   nav2_util::nav2_util_core
-  ${library_name}
-  ${map_io_library_name}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 add_executable(${costmap_filter_info_server_executable}
@@ -124,13 +125,13 @@ target_include_directories(${costmap_filter_info_server_executable}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${costmap_filter_info_server_executable} PRIVATE
-  rclcpp::rclcpp
-  rclcpp_lifecycle::rclcpp_lifecycle
+  ${library_name}
+  ${map_io_library_name}
   ${nav_msgs_TARGETS}
   ${nav2_msgs_TARGETS}
   nav2_util::nav2_util_core
-  ${library_name}
-  ${map_io_library_name}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 rclcpp_components_register_nodes(${library_name} "nav2_map_server::CostmapFilterInfoServer")

--- a/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/msg/costmap_filter_info.hpp"
 

--- a/nav2_map_server/include/nav2_map_server/map_saver.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_saver.hpp
@@ -16,10 +16,11 @@
 #ifndef NAV2_MAP_SERVER__MAP_SAVER_HPP_
 #define NAV2_MAP_SERVER__MAP_SAVER_HPP_
 
-#include <string>
 #include <memory>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/srv/save_map.hpp"
 

--- a/nav2_map_server/include/nav2_map_server/map_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_server.hpp
@@ -15,15 +15,15 @@
 #ifndef NAV2_MAP_SERVER__MAP_SERVER_HPP_
 #define NAV2_MAP_SERVER__MAP_SERVER_HPP_
 
-#include <string>
 #include <memory>
-#include <functional>
+#include <string>
 
-#include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/srv/get_map.hpp"
 #include "nav2_msgs/srv/load_map.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
 
 namespace nav2_map_server
 {

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -25,6 +25,7 @@
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
   <depend>graphicsmagick</depend>
+  <depend>lifecycle_msgs</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -45,6 +45,7 @@
 #include "nav2_util/geometry_utils.hpp"
 
 #include "yaml-cpp/yaml.h"
+
 #include "tf2/LinearMath/Matrix3x3.h"
 #include "tf2/LinearMath/Quaternion.h"
 #include "nav2_util/occ_grid_values.hpp"

--- a/nav2_map_server/test/component/CMakeLists.txt
+++ b/nav2_map_server/test/component/CMakeLists.txt
@@ -1,12 +1,14 @@
-include_directories(${PROJECT_SOURCE_DIR}/test)
-
 # map_server component test
 ament_add_gtest_executable(test_map_server_node
   test_map_server_node.cpp
   ${PROJECT_SOURCE_DIR}/test/test_constants.cpp
 )
-ament_target_dependencies(test_map_server_node rclcpp nav_msgs)
+target_include_directories(test_map_server_node
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/test>")
 target_link_libraries(test_map_server_node
+  rclcpp::rclcpp
+  ${nav_msgs_TARGETS}
   ${library_name}
 )
 
@@ -25,17 +27,23 @@ ament_add_gtest_executable(test_map_saver_node
   test_map_saver_node.cpp
   ${PROJECT_SOURCE_DIR}/test/test_constants.cpp
 )
-
-ament_target_dependencies(test_map_saver_node rclcpp nav_msgs)
+target_include_directories(test_map_saver_node
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/test>")
 target_link_libraries(test_map_saver_node
+  rclcpp::rclcpp
+  ${nav_msgs_TARGETS}
   ${library_name}
+  ${map_io_library_name}
 )
 
 add_executable(test_map_saver_publisher
   test_map_saver_publisher.cpp
   ${PROJECT_SOURCE_DIR}/test/test_constants.cpp
 )
-
+target_include_directories(test_map_saver_publisher
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/test>")
 target_link_libraries(test_map_saver_publisher
   ${map_io_library_name}
 )

--- a/nav2_map_server/test/map_saver_cli/CMakeLists.txt
+++ b/nav2_map_server/test/map_saver_cli/CMakeLists.txt
@@ -1,12 +1,9 @@
-include_directories(${PROJECT_SOURCE_DIR}/test)
-
 # map_saver CLI
 ament_add_gtest(test_map_saver_cli
   test_map_saver_cli.cpp
   ${PROJECT_SOURCE_DIR}/test/test_constants.cpp
 )
-
-ament_target_dependencies(test_map_saver_cli rclcpp nav_msgs)
 target_link_libraries(test_map_saver_cli
-  ${dependencies}
+  rclcpp::rclcpp
+  ${nav_msgs_TARGETS}
 )

--- a/nav2_map_server/test/map_saver_cli/test_map_saver_cli.cpp
+++ b/nav2_map_server/test/map_saver_cli/test_map_saver_cli.cpp
@@ -92,9 +92,9 @@ TEST(MapSaverCLI, CLITest)
     std::string(
     "ros2 run nav2_map_server map_saver_cli "
     "-t map_failure --occ 100 --free 2 --mode trinary --fmt png -f ") + file_path +
-    std::string("--ros-args __node:=map_saver_test_node");
+    std::string(" --ros-args --remap __node:=map_saver_test_node");
   return_code = system(command.c_str());
-  EXPECT_EQ(return_code, 65280);
+  EXPECT_EQ(return_code, 256);
 
   rclcpp::Rate(0.25).sleep();
 
@@ -140,7 +140,7 @@ TEST(MapSaverCLI, CLITest)
 
   command =
     std::string(
-    "ros2 run nav2_map_server map_saver_cli --ros-args -r __node:=map_saver_test_node");
+    "ros2 run nav2_map_server map_saver_cli --ros-args --remap __node:=map_saver_test_node");
   return_code = system(command.c_str());
   EXPECT_EQ(return_code, 0);
 }

--- a/nav2_map_server/test/unit/CMakeLists.txt
+++ b/nav2_map_server/test/unit/CMakeLists.txt
@@ -1,11 +1,11 @@
-include_directories(${PROJECT_SOURCE_DIR}/test)
-
 # map_io unit test
 ament_add_gtest(test_map_io test_map_io.cpp ${PROJECT_SOURCE_DIR}/test/test_constants.cpp)
-
-ament_target_dependencies(test_map_io rclcpp nav_msgs)
-
+target_include_directories(test_map_io
+  PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/test>")
 target_link_libraries(test_map_io
+  rclcpp::rclcpp
+  ${nav_msgs_TARGETS}
   ${map_io_library_name}
 )
 
@@ -13,9 +13,8 @@ target_link_libraries(test_map_io
 ament_add_gtest(test_costmap_filter_info_server
   test_costmap_filter_info_server.cpp
 )
-
-ament_target_dependencies(test_costmap_filter_info_server rclcpp)
-
 target_link_libraries(test_costmap_filter_info_server
+  rclcpp::rclcpp
   ${library_name}
+  ${map_io_library_name}
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This commit does a number of things:

1. Switches to using target_link_libraries in nav2_map_server, which gives us finer-grained control over what dependencies are exported to downstream as public or private.
2. Moves the include directory down one level to include/${PROJECT_NAME}, which is best practice in ROS 2 since Humble.
3. Makes sure to export nav2_map_server as a CMake target, so downstream users of it can use that target.
4. Adds in `lifecycle_msgs` as a dependency.
5. Possibly most controversially, changes one test.  While running the tests I noted some odd output from `test_map_saver_cli.cpp`.  In particular, it was complaining that `__node:=map_saver_test_node` was deprecated.  That is true, but adding in `--ros-args --remap` didn't work, and that is because a space was missing from the front of that.  With that change now in place, I also had to update the return value from the command, since it now returns 256 instead of 65280.

## Description of documentation updates required from your changes

None needed

---

## Future work that may be required in bullet points

The rest of the packages in this repository need a similar treatment (PRs will be upcoming).

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
