### PR TITLE
Switch to new-style static_transform_publisher arguments.

### DIFF
--- a/nav2_costmap_2d/test/integration/costmap_tests_launch.py
+++ b/nav2_costmap_2d/test/integration/costmap_tests_launch.py
@@ -36,14 +36,32 @@ def main(argv=sys.argv[1:]):
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'map',
+            '--child-frame-id', 'odom'
+        ],
     )
 
     odom_to_base_link = launch_ros.actions.Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'odom', 'base_link'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'odom',
+            '--child-frame-id', 'base_link'
+        ],
     )
 
     lifecycle_manager = launch_ros.actions.Node(

--- a/nav2_system_tests/src/behaviors/backup/test_backup_behavior.launch.py
+++ b/nav2_system_tests/src/behaviors/backup/test_backup_behavior.launch.py
@@ -94,7 +94,16 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'map',
+                    '--child-frame-id', 'odom'
+                ],
                 parameters=[{'use_sim_time': True}],
             ),
             # Need transforms

--- a/nav2_system_tests/src/behaviors/drive_on_heading/test_drive_on_heading_behavior.launch.py
+++ b/nav2_system_tests/src/behaviors/drive_on_heading/test_drive_on_heading_behavior.launch.py
@@ -94,7 +94,16 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'map',
+                    '--child-frame-id', 'odom'
+                ],
                 parameters=[{'use_sim_time': True}],
             ),
             # Need transforms

--- a/nav2_system_tests/src/behaviors/spin/test_spin_behavior.launch.py
+++ b/nav2_system_tests/src/behaviors/spin/test_spin_behavior.launch.py
@@ -94,7 +94,16 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'map',
+                    '--child-frame-id', 'odom'
+                ],
                 parameters=[{'use_sim_time': True}],
             ),
             # Need transforms

--- a/nav2_system_tests/src/error_codes/test_error_codes_launch.py
+++ b/nav2_system_tests/src/error_codes/test_error_codes_launch.py
@@ -37,13 +37,31 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'map',
+                    '--child-frame-id', 'odom'
+                ],
             ),
             Node(
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'odom', 'base_link'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'odom',
+                    '--child-frame-id', 'base_link'
+                ],
             ),
             Node(
                 package='nav2_controller',

--- a/nav2_system_tests/src/gps_navigation/test_case_py.launch.py
+++ b/nav2_system_tests/src/gps_navigation/test_case_py.launch.py
@@ -64,34 +64,61 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_link'],
-            ),
-            Node(
-                package='tf2_ros',
-                executable='static_transform_publisher',
-                output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan'],
-            ),
-            Node(
-                package='tf2_ros',
-                executable='static_transform_publisher',
-                output='screen',
                 arguments=[
-                    '-0.32',
-                    '0',
-                    '0.068',
-                    '0',
-                    '0',
-                    '0',
-                    'base_link',
-                    'imu_link',
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_footprint',
+                    '--child-frame-id', 'base_link'
                 ],
             ),
             Node(
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'gps_link'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_link',
+                    '--child-frame-id', 'base_scan'
+                ],
+            ),
+            Node(
+                package='tf2_ros',
+                executable='static_transform_publisher',
+                output='screen',
+                arguments=[
+                    '--x', '-0.32',
+                    '--y', '0',
+                    '--z', '0.068',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_link',
+                    '--child-frame-id', 'imu_link'
+                ],
+            ),
+            Node(
+                package='tf2_ros',
+                executable='static_transform_publisher',
+                output='screen',
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_link',
+                    '--child-frame-id', 'gps_link'
+                ],
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(

--- a/nav2_system_tests/src/updown/test_updown_launch.py
+++ b/nav2_system_tests/src/updown/test_updown_launch.py
@@ -34,28 +34,64 @@ def generate_launch_description():
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'map', 'odom'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'map',
+            '--child-frame-id', 'odom'
+        ],
     )
 
     start_tf_cmd_2 = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'odom', 'base_footprint'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'odom',
+            '--child-frame-id', 'base_footprint'
+        ],
     )
 
     start_tf_cmd_3 = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_link'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'base_footprint',
+            '--child-frame-id', 'base_link'
+        ],
     )
 
     start_tf_cmd_4 = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'base_link',
+            '--child-frame-id', 'base_scan'
+        ],
     )
 
     nav2_bringup = launch.actions.IncludeLaunchDescription(

--- a/tools/planner_benchmarking/planning_benchmark_bringup.py
+++ b/tools/planner_benchmarking/planning_benchmark_bringup.py
@@ -53,13 +53,31 @@ def generate_launch_description():
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'map'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_link',
+                    '--child-frame-id', 'map'
+                ],
             ),
             Node(
                 package='tf2_ros',
                 executable='static_transform_publisher',
                 output='screen',
-                arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'odom'],
+                arguments=[
+                    '--x', '0',
+                    '--y', '0',
+                    '--z', '0',
+                    '--roll', '0',
+                    '--pitch', '0',
+                    '--yaw', '0',
+                    '--frame-id', 'base_link',
+                    '--child-frame-id', 'odom'
+                ],
             ),
             Node(
                 package='nav2_lifecycle_manager',

--- a/tools/smoother_benchmarking/smoother_benchmark_bringup.py
+++ b/tools/smoother_benchmarking/smoother_benchmark_bringup.py
@@ -35,14 +35,32 @@ def generate_launch_description():
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'map'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'base_link',
+            '--child-frame-id', 'map'
+        ],
     )
 
     static_transform_two = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'odom'],
+        arguments=[
+            '--x', '0',
+            '--y', '0',
+            '--z', '0',
+            '--roll', '0',
+            '--pitch', '0',
+            '--yaw', '0',
+            '--frame-id', 'base_link',
+            '--child-frame-id', 'odom'
+        ],
     )
 
     start_map_server_cmd = Node(


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4557 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

These arguments have been the preferred way to use things since at least Humble.  This avoids warnings when running it for the tests.

One note is that I did not know how to test the changes to the `tools` subdirectory; hopefully automation will do that, or we can verify it manually.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

None needed.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
