### PR TITLE
Make nav2_bt_navigator use modern CMake idioms.

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -2,79 +2,110 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_bt_navigator)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(nav2_msgs REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(nav2_util REQUIRED)
+find_package(nav2_common REQUIRED)
 find_package(nav2_core REQUIRED)
-find_package(tf2_ros REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include
-)
-
 set(executable_name bt_navigator)
 
-add_executable(${executable_name}
-  src/main.cpp
-)
-
 set(library_name ${executable_name}_core)
-
-set(dependencies
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  rclcpp_components
-  std_msgs
-  geometry_msgs
-  nav2_behavior_tree
-  nav_msgs
-  nav2_msgs
-  behaviortree_cpp
-  std_srvs
-  nav2_util
-  nav2_core
-  tf2_ros
-  pluginlib
-)
 
 add_library(${library_name} SHARED
   src/bt_navigator.cpp
 )
-
-ament_target_dependencies(${executable_name}
-  ${dependencies}
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  nav2_core::nav2_core
+  nav2_util::nav2_util_core
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${library_name} PRIVATE
+  nav2_behavior_tree::nav2_behavior_tree
+  rclcpp_components::component
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
-target_link_libraries(${executable_name} ${library_name})
-
-ament_target_dependencies(${library_name}
-  ${dependencies}
+add_executable(${executable_name}
+  src/main.cpp
+)
+target_include_directories(${executable_name}
+  PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${executable_name} PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
 )
 
 add_library(nav2_navigate_to_pose_navigator SHARED src/navigators/navigate_to_pose.cpp)
-ament_target_dependencies(nav2_navigate_to_pose_navigator ${dependencies})
+target_include_directories(nav2_navigate_to_pose_navigator
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(nav2_navigate_to_pose_navigator PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+)
+target_link_libraries(nav2_navigate_to_pose_navigator PRIVATE
+  ament_index_cpp::ament_index_cpp
+  nav2_behavior_tree::nav2_behavior_tree
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
 
 add_library(nav2_navigate_through_poses SHARED src/navigators/navigate_through_poses.cpp)
-ament_target_dependencies(nav2_navigate_through_poses ${dependencies})
+target_include_directories(nav2_navigate_through_poses
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(nav2_navigate_through_poses PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  ${nav2_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+)
+target_link_libraries(nav2_navigate_through_poses PRIVATE
+  ament_index_cpp::ament_index_cpp
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
 
 pluginlib_export_plugin_description_file(nav2_core navigator_plugins.xml)
 rclcpp_components_register_nodes(${library_name} "nav2_bt_navigator::BtNavigator")
 
 install(TARGETS ${library_name} nav2_navigate_to_pose_navigator nav2_navigate_through_poses
+  EXPORT export_${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -85,7 +116,7 @@ install(TARGETS ${executable_name}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
@@ -95,7 +126,8 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name} nav2_navigate_to_pose_navigator nav2_navigate_through_poses)
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(geometry_msgs nav2_core nav2_msgs nav2_util nav_msgs pluginlib rclcpp rclcpp_action tf2_ros)
+ament_export_targets(export_${library_name})
 ament_package()

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -7,36 +7,22 @@
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <license>Apache-2.0</license>
 
-  <depend>tf2_ros</depend>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_action</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>nav2_behavior_tree</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>behaviortree_cpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>nav2_util</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>nav2_core</build_depend>
 
-  <exec_depend>behaviortree_cpp</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_action</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>nav2_behavior_tree</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>nav2_util</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>pluginlib</exec_depend>
-  <exec_depend>nav2_core</exec_depend>
+  <depend>ament_index_cpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav2_behavior_tree</depend>
+  <depend>nav2_core</depend>
+  <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>nav_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This PR cleans up nav2_bt_navigator to use modern CMake idioms.  In particular:
1. Switch from ament_target_dependencies to target_link_libraries.
2. Make sure to export the target so downstream packages can use it.
3. Move the include directory down one directory, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

There will be follow-up PRs coming to switch more of the packages over to modern CMake idioms.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
