### PR TITLE
Switch nav2_collision_monitor to modern CMake idioms.

### DIFF
--- a/nav2_collision_monitor/CMakeLists.txt
+++ b/nav2_collision_monitor/CMakeLists.txt
@@ -1,47 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 project(nav2_collision_monitor)
 
-### Dependencies ###
-
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_costmap_2d REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(nav2_common REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_costmap_2d REQUIRED)
-find_package(nav2_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
-### Header ###
-
 nav2_package()
-
-### Libraries and executables ###
-
-include_directories(
-  include
-)
-
-set(dependencies
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  geometry_msgs
-  std_msgs
-  tf2
-  tf2_ros
-  tf2_geometry_msgs
-  nav2_util
-  nav2_costmap_2d
-  nav2_msgs
-  visualization_msgs
-)
 
 set(monitor_executable_name collision_monitor)
 set(detector_executable_name collision_detector)
@@ -60,6 +35,27 @@ add_library(${monitor_library_name} SHARED
   src/range.cpp
   src/kinematics.cpp
 )
+target_include_directories(${monitor_library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${monitor_library_name} PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_costmap_2d::nav2_costmap_2d_core
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  tf2::tf2
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
+)
+target_link_libraries(${monitor_library_name} PRIVATE
+  rclcpp_components::component
+)
+
 add_library(${detector_library_name} SHARED
   src/collision_detector_node.cpp
   src/polygon.cpp
@@ -72,43 +68,57 @@ add_library(${detector_library_name} SHARED
   src/range.cpp
   src/kinematics.cpp
 )
+target_include_directories(${detector_library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${detector_library_name} PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_costmap_2d::nav2_costmap_2d_core
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  tf2::tf2
+  ${visualization_msgs_TARGETS}
+)
+target_link_libraries(${detector_library_name} PRIVATE
+  rclcpp_components::component
+)
 
 add_executable(${monitor_executable_name}
   src/collision_monitor_main.cpp
 )
+target_include_directories(${monitor_executable_name}
+  PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${monitor_executable_name} PRIVATE
+  rclcpp::rclcpp
+  ${monitor_library_name}
+)
+
 add_executable(${detector_executable_name}
   src/collision_detector_main.cpp
 )
-
-ament_target_dependencies(${monitor_library_name}
-  ${dependencies}
-)
-ament_target_dependencies(${detector_library_name}
-  ${dependencies}
-)
-
-target_link_libraries(${monitor_executable_name}
-  ${monitor_library_name}
-)
-target_link_libraries(${detector_executable_name}
+target_include_directories(${detector_executable_name}
+  PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${detector_executable_name} PRIVATE
+  rclcpp::rclcpp
   ${detector_library_name}
-)
-
-ament_target_dependencies(${monitor_executable_name}
-  ${dependencies}
-)
-
-ament_target_dependencies(${detector_executable_name}
-  ${dependencies}
 )
 
 rclcpp_components_register_nodes(${monitor_library_name} "nav2_collision_monitor::CollisionMonitor")
 
 rclcpp_components_register_nodes(${detector_library_name} "nav2_collision_monitor::CollisionDetector")
 
-### Install ###
-
 install(TARGETS ${monitor_library_name} ${detector_library_name}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -119,13 +129,11 @@ install(TARGETS ${monitor_executable_name} ${detector_executable_name}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY params DESTINATION share/${PROJECT_NAME})
-
-### Testing ###
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -135,13 +143,26 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+
+  ament_find_gtest()
+
   add_subdirectory(test)
 endif()
 
-### Ament stuff ###
-
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${monitor_library_name} ${detector_library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  geometry_msgs
+  nav2_costmap_2d
+  nav2_msgs
+  nav2_util
+  rclcpp
+  rclcpp_lifecycle
+  sensor_msgs
+  tf2
+  tf2_ros
+  visualization_msgs
+)
+ament_export_targets(export_${PROJECT_NAME})
 
 ament_package()

--- a/nav2_collision_monitor/package.xml
+++ b/nav2_collision_monitor/package.xml
@@ -9,19 +9,19 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
-  <depend>tf2</depend>
-  <depend>tf2_ros</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>nav2_common</depend>
   <depend>nav2_util</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/nav2_collision_monitor/test/CMakeLists.txt
+++ b/nav2_collision_monitor/test/CMakeLists.txt
@@ -1,52 +1,60 @@
 # Kinematics test
 ament_add_gtest(kinematics_test kinematics_test.cpp)
-ament_target_dependencies(kinematics_test
-  ${dependencies}
-)
 target_link_libraries(kinematics_test
   ${monitor_library_name}
+  rclcpp::rclcpp
 )
 
 # Data sources test
 ament_add_gtest(sources_test sources_test.cpp)
-ament_target_dependencies(sources_test
-  ${dependencies}
-)
 target_link_libraries(sources_test
   ${monitor_library_name}
+  rclcpp::rclcpp
+  nav2_util::nav2_util_core
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
 )
 
 # Polygon shapes test
 ament_add_gtest(polygons_test polygons_test.cpp)
-ament_target_dependencies(polygons_test
-  ${dependencies}
-)
 target_link_libraries(polygons_test
   ${monitor_library_name}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
 )
 
 # Velocity Polygon test
 ament_add_gtest(velocity_polygons_test velocity_polygons_test.cpp)
-ament_target_dependencies(velocity_polygons_test
-  ${dependencies}
-)
 target_link_libraries(velocity_polygons_test
   ${monitor_library_name}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
 )
 
 # Collision Monitor node test
 ament_add_gtest(collision_monitor_node_test collision_monitor_node_test.cpp)
-ament_target_dependencies(collision_monitor_node_test
-  ${dependencies}
-)
 target_link_libraries(collision_monitor_node_test
   ${monitor_library_name}
+  ${geometry_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
 )
 # Collision Detector node test
 ament_add_gtest(collision_detector_node_test collision_detector_node_test.cpp)
-ament_target_dependencies(collision_detector_node_test
-  ${dependencies}
-)
 target_link_libraries(collision_detector_node_test
   ${detector_library_name}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
 )

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -14,13 +14,13 @@
 
 #include <gtest/gtest.h>
 
-#include <math.h>
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
-#include <limits>
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Switch nav2_collision_monitor to modern CMake idioms:
1.  Change from ament_target_dependencies to target_link_libraries.
2.  Add in ament_export_target to export the target to downstreams.
3.  Move the include directories down one level, which has been best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series of changes to update to modern CMake practices.  There will be follow-on PRs converting more packages.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
