### PR TITLE
Revamp nav2_constrained_smoother to use modern CMake idioms.

### DIFF
--- a/nav2_constrained_smoother/CMakeLists.txt
+++ b/nav2_constrained_smoother/CMakeLists.txt
@@ -4,47 +4,48 @@ project(nav2_constrained_smoother)
 set(CMAKE_BUILD_TYPE Release) # significant Ceres optimization speedup
 
 find_package(ament_cmake REQUIRED)
+find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
+find_package(Eigen3 REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_common REQUIRED)
-find_package(angles REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_msgs REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
-
-set(CMAKE_CXX_STANDARD 17)
-
-if(${CERES_VERSION} VERSION_LESS_EQUAL 2.0.0)
-  add_definitions(-DUSE_OLD_CERES_API)
-endif()
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
 set(library_name nav2_constrained_smoother)
 
-include_directories(
-  include
-)
-
-set(dependencies
-  angles
-  rclcpp
-  rclcpp_action
-  nav2_msgs
-  nav2_costmap_2d
-  nav2_util
-  nav2_core
-  pluginlib
-)
-
 add_library(${library_name} SHARED src/constrained_smoother.cpp)
-target_link_libraries(${library_name} Ceres::ceres)
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-ament_target_dependencies(${library_name} ${dependencies})
+if(${CERES_VERSION} VERSION_LESS_EQUAL 2.0.0)
+  target_compile_definitions(${library_name} PUBLIC -DUSE_OLD_CERES_API)
+endif()
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  Ceres::ceres
+  Eigen3::Eigen
+  nav2_core::nav2_core
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${library_name} PRIVATE
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  pluginlib::pluginlib
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -53,29 +54,29 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(angles REQUIRED)
+
+  ament_find_gtest()
+
   add_subdirectory(test)
 endif()
 
 install(
-  TARGETS
-    ${library_name}
+  TARGETS ${library_name}
+  EXPORT ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(ceres eigen3 nav2_core nav2_costmap_2d nav2_util rclcpp rclcpp_lifecycle tf2_ros)
+ament_export_targets(${library_name})
 
 pluginlib_export_plugin_description_file(nav2_core nav2_constrained_smoother.xml)
 

--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/constrained_smoother.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/constrained_smoother.hpp
@@ -27,7 +27,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/odometry_utils.hpp"
 #include "nav2_util/geometry_utils.hpp"
-#include "geometry_msgs/msg/pose2_d.hpp"
 
 namespace nav2_constrained_smoother
 {

--- a/nav2_constrained_smoother/package.xml
+++ b/nav2_constrained_smoother/package.xml
@@ -9,20 +9,25 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>nav2_common</depend>
-  <depend>angles</depend>
-  <depend>rclcpp</depend>
-  <depend>nav2_util</depend>
-  <depend>nav2_msgs</depend>
-  <depend>nav2_costmap_2d</depend>
-  <depend>nav2_core</depend>
-  <depend>pluginlib</depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>nav2_common</build_depend>
+
+  <depend>geometry_msgs</depend>
   <depend>libceres-dev</depend>
+  <depend>nav2_core</depend>
+  <depend>nav2_costmap_2d</depend>
+  <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>angles</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_constrained_smoother/src/constrained_smoother.cpp
+++ b/nav2_constrained_smoother/src/constrained_smoother.cpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
 #include "nav2_constrained_smoother/constrained_smoother.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/geometry_utils.hpp"

--- a/nav2_constrained_smoother/test/CMakeLists.txt
+++ b/nav2_constrained_smoother/test/CMakeLists.txt
@@ -1,12 +1,15 @@
 ament_add_gtest(test_constrained_smoother
   test_constrained_smoother.cpp
 )
-
 target_link_libraries(test_constrained_smoother
   ${library_name}
-)
-ament_target_dependencies(test_constrained_smoother
-  ${dependencies}
+  angles::angles
+  ${geometry_msgs_TARGETS}
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
 )
 
 ament_add_gtest(test_smoother_cost_function
@@ -14,7 +17,5 @@ ament_add_gtest(test_smoother_cost_function
 )
 target_link_libraries(test_smoother_cost_function
   ${library_name}
-)
-ament_target_dependencies(test_smoother_cost_function
-  ${dependencies}
+  rclcpp::rclcpp
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Revamp nav2_constrained smoother to use modern CMake idioms:
1. Switch all uses of ament_target_dependencies to target_link_libraries.
2. Move the include directories down one level, which is best practice since Humble.
3. Make a few dependencies PRIVATE, so we don't need to export them to downstream consumers.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of the wider work of #4357.  As such, there will be follow-up PRs to transition more of the packages to modern CMake.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
