### PR TITLE
Switch nav_2d_utils to use modern CMake idioms.

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
@@ -2,67 +2,78 @@ cmake_minimum_required(VERSION 3.5)
 project(nav_2d_utils)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(nav_2d_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(nav2_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
-set(dependencies
-  geometry_msgs
-  nav_2d_msgs
-  nav_msgs
-  std_msgs
-  rclcpp
-  tf2
-  tf2_geometry_msgs
-  nav2_msgs
-  nav2_util
-  nav_2d_msgs
-)
-
-include_directories(
-    include
-)
-
 add_library(conversions SHARED
   src/conversions.cpp)
-
-ament_target_dependencies(conversions
-  ${dependencies}
+target_include_directories(conversions
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(conversions PUBLIC
+  ${geometry_msgs_TARGETS}
+  ${nav_2d_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  tf2::tf2
+)
+target_link_libraries(conversions PRIVATE
+  nav2_util::nav2_util_core
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 add_library(path_ops SHARED
   src/path_ops.cpp)
-
-ament_target_dependencies(path_ops
-  ${dependencies}
+target_include_directories(path_ops
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(path_ops PUBLIC
+  ${nav_2d_msgs_TARGETS}
+)
+target_link_libraries(path_ops PRIVATE
+  ${geometry_msgs_TARGETS}
 )
 
 add_library(tf_help SHARED
   src/tf_help.cpp
 )
-
-ament_target_dependencies(tf_help
-  ${dependencies}
+target_include_directories(tf_help
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-target_link_libraries(tf_help conversions)
+target_link_libraries(tf_help PUBLIC
+  conversions
+  ${geometry_msgs_TARGETS}
+  ${nav_2d_msgs_TARGETS}
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
 
 install(TARGETS conversions path_ops tf_help
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(DIRECTORY include/
-        DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -72,11 +83,15 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+
+  ament_find_gtest()
+
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(conversions path_ops tf_help)
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(geometry_msgs nav_2d_msgs nav_msgs rclcpp tf2 tf2_geometry_msgs tf2_ros)
+ament_export_targets(${PROJECT_NAME})
 
 ament_package()

--- a/nav2_dwb_controller/nav_2d_utils/package.xml
+++ b/nav2_dwb_controller/nav_2d_utils/package.xml
@@ -13,11 +13,12 @@
   <depend>geometry_msgs</depend>
   <depend>nav_2d_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
+  <depend>rclcpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_dwb_controller/nav_2d_utils/src/conversions.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/src/conversions.cpp
@@ -41,6 +41,10 @@
 #include "geometry_msgs/msg/pose2_d.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav_2d_msgs/msg/twist2_d.hpp"
+#include "nav_2d_msgs/msg/pose2_d_stamped.hpp"
+#include "nav_2d_msgs/msg/path2_d.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/nav2_dwb_controller/nav_2d_utils/test/CMakeLists.txt
+++ b/nav2_dwb_controller/nav_2d_utils/test/CMakeLists.txt
@@ -6,4 +6,3 @@ target_link_libraries(path_ops_tests path_ops)
 
 ament_add_gtest(tf_help_tests tf_help_test.cpp)
 target_link_libraries(tf_help_tests tf_help conversions)
-


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Change nav_2d_utils to use modern CMake idioms:
1. Switch from ament_target_dependencies() to target_link_libraries()
2. Export the target so that downstream users can link against the library
3. Move the include directories down one directory, which is best practice since Humble.
4. Cleanup the dependencies.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series switching Navigation2 to use modern CMake idioms; there will be follow-up PRs to change more of the packages over.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
