### PR TITLE
Switch nav2_lifecycle_manager to modern CMake idioms.

### DIFF
--- a/nav2_lifecycle_manager/CMakeLists.txt
+++ b/nav2_lifecycle_manager/CMakeLists.txt
@@ -2,26 +2,19 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_lifecycle_manager)
 
 find_package(ament_cmake REQUIRED)
+find_package(bondcpp REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(bondcpp REQUIRED)
-find_package(diagnostic_updater REQUIRED)
 
 nav2_package()
-
-include_directories(
-  include
-)
 
 set(library_name ${PROJECT_NAME}_core)
 
@@ -29,43 +22,42 @@ add_library(${library_name} SHARED
   src/lifecycle_manager.cpp
   src/lifecycle_manager_client.cpp
 )
-
-set(dependencies
-  geometry_msgs
-  lifecycle_msgs
-  nav2_msgs
-  nav2_util
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  rclcpp_components
-  std_msgs
-  std_srvs
-  tf2_geometry_msgs
-  bondcpp
-  diagnostic_updater
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-ament_target_dependencies(${library_name}
-  ${dependencies}
+target_link_libraries(${library_name} PUBLIC
+  bondcpp::bondcpp
+  diagnostic_updater::diagnostic_updater
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  ${std_srvs_TARGETS}
+)
+target_link_libraries(${library_name} PRIVATE
+  ${diagnostic_msgs_TARGETS}
+  ${lifecycle_msgs_TARGETS}
+  rclcpp_components::component
 )
 
 add_executable(lifecycle_manager
   src/main.cpp
 )
-
-target_link_libraries(lifecycle_manager
-  ${library_name}
+target_include_directories(lifecycle_manager
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-ament_target_dependencies(lifecycle_manager
-  ${dependencies}
+target_link_libraries(lifecycle_manager PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
 )
 
 rclcpp_components_register_nodes(${library_name} "nav2_lifecycle_manager::LifecycleManager")
 
-install(TARGETS
-  ${library_name}
+install(TARGETS ${library_name}
+  EXPORT ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -76,7 +68,7 @@ install(TARGETS
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
-install(DIRECTORY include/ DESTINATION include/)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -84,12 +76,16 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(rclcpp_lifecycle REQUIRED)
+
+  ament_find_gtest()
 
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(bondcpp diagnostic_updater nav2_util rclcpp rclcpp_action std_srvs)
+ament_export_targets(${library_name})
 
 ament_package()

--- a/nav2_lifecycle_manager/package.xml
+++ b/nav2_lifecycle_manager/package.xml
@@ -8,36 +8,24 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>lifecycle_msgs</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>nav2_util</build_depend>
-  <build_depend>rclcpp_action</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>bondcpp</build_depend>
   <build_depend>nav2_common</build_depend>
-  <build_depend>diagnostic_updater</build_depend>
 
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>lifecycle_msgs</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>nav2_util</exec_depend>
-  <exec_depend>rclcpp_action</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
-  <exec_depend>bondcpp</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>diagnostic_updater</exec_depend>
+  <depend>bondcpp</depend>
+  <depend>diagnostic_updater</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <utility>
 
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "nav2_util/geometry_utils.hpp"
 
 namespace nav2_lifecycle_manager

--- a/nav2_lifecycle_manager/test/CMakeLists.txt
+++ b/nav2_lifecycle_manager/test/CMakeLists.txt
@@ -1,13 +1,11 @@
 ament_add_gtest_executable(test_lifecycle_gtest
   test_lifecycle_manager.cpp
 )
-
 target_link_libraries(test_lifecycle_gtest
   ${library_name}
-)
-
-ament_target_dependencies(test_lifecycle_gtest
-  ${dependencies}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 ament_add_test(test_lifecycle
@@ -22,13 +20,10 @@ ament_add_test(test_lifecycle
 ament_add_gtest_executable(test_bond_gtest
   test_bond.cpp
 )
-
 target_link_libraries(test_bond_gtest
   ${library_name}
-)
-
-ament_target_dependencies(test_bond_gtest
-  ${dependencies}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
 )
 
 ament_add_test(test_bond


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Change nav2_lifecycle_manager to modern CMake idioms:
1. Change from ament_target_dependencies() to target_link_libraries().
2. Export the target so that downstream packages can make use of it.
3. Move the include directory down one directory, which has been best practice since Humble.
4. Cleanup the dependencies to more accurately reflect what this package needs.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series of PRs to update Navigation2 to modern CMake idioms.  There will be follow-up PRs to convert more of the packages to this style.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
