### PR TITLE
Add current path to GoalChecker interface

### DIFF
--- a/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
@@ -66,7 +66,7 @@ public:
   void reset() override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+    const geometry_msgs::msg::Twist & velocity, const nav_msgs::msg::Path & current_path) override;
   bool getTolerances(
     geometry_msgs::msg::Pose & pose_tolerance,
     geometry_msgs::msg::Twist & vel_tolerance) override;

--- a/nav2_controller/include/nav2_controller/plugins/stopped_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/stopped_goal_checker.hpp
@@ -61,7 +61,7 @@ public:
     const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros) override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+    const geometry_msgs::msg::Twist & velocity, const nav_msgs::msg::Path & current_path) override;
   bool getTolerances(
     geometry_msgs::msg::Pose & pose_tolerance,
     geometry_msgs::msg::Twist & vel_tolerance) override;

--- a/nav2_controller/plugins/simple_goal_checker.cpp
+++ b/nav2_controller/plugins/simple_goal_checker.cpp
@@ -97,7 +97,7 @@ void SimpleGoalChecker::reset()
 
 bool SimpleGoalChecker::isGoalReached(
   const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-  const geometry_msgs::msg::Twist &)
+  const geometry_msgs::msg::Twist &, const nav_msgs::msg::Path &)
 {
   if (check_xy_) {
     double dx = query_pose.position.x - goal_pose.position.x,

--- a/nav2_controller/plugins/stopped_goal_checker.cpp
+++ b/nav2_controller/plugins/stopped_goal_checker.cpp
@@ -82,9 +82,9 @@ void StoppedGoalChecker::initialize(
 
 bool StoppedGoalChecker::isGoalReached(
   const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-  const geometry_msgs::msg::Twist & velocity)
+  const geometry_msgs::msg::Twist & velocity, const nav_msgs::msg::Path & current_path)
 {
-  bool ret = SimpleGoalChecker::isGoalReached(query_pose, goal_pose, velocity);
+  bool ret = SimpleGoalChecker::isGoalReached(query_pose, goal_pose, velocity, current_path);
   if (!ret) {
     return ret;
   }

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -756,7 +756,7 @@ bool ControllerServer::isGoalReached()
 
   return goal_checkers_[current_goal_checker_]->isGoalReached(
     pose.pose, transformed_end_pose.pose,
-    velocity);
+    velocity, current_path_);
 }
 
 bool ControllerServer::getRobotPose(geometry_msgs::msg::PoseStamped & pose)

--- a/nav2_core/include/nav2_core/goal_checker.hpp
+++ b/nav2_core/include/nav2_core/goal_checker.hpp
@@ -42,6 +42,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "nav_msgs/msg/path.hpp"
 
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
@@ -84,8 +85,10 @@ public:
    * @return True if goal is reached
    */
   virtual bool isGoalReached(
-    const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) = 0;
+    const geometry_msgs::msg::Pose & query_pose,
+    const geometry_msgs::msg::Pose & goal_pose,
+    const geometry_msgs::msg::Twist & velocity,
+    const nav_msgs::msg::Path & current_path) = 0;
 
   /**
    * @brief Get the maximum possible tolerances used for goal checking in the major types.

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -53,7 +53,8 @@ public:
   virtual bool isGoalReached(
     const geometry_msgs::msg::Pose & /*query_pose*/,
     const geometry_msgs::msg::Pose & /*goal_pose*/,
-    const geometry_msgs::msg::Twist & /*velocity*/) {return false;}
+    const geometry_msgs::msg::Twist & /*velocity*/,
+    const nav_msgs::msg::Path & /*current_path*/) {return false;}
 
   virtual bool getTolerances(
     geometry_msgs::msg::Pose & pose_tolerance,


### PR DESCRIPTION
The controller server uses a configurable goal checker to determine if the robot has completed its current path as defined by the global plan. Current goal checkers compare the goal (end of path) pose and twist to the current robot state, but that is not sufficient in all cases.

In some use cases, the path will visit the goal multiple times, and the goal might coincide with the starting position. It is still desired that the robot follows the entire path, instead of immediately ending navigation once the goal pose is reached.

This PR adds a parameter to the GoalChecker interface to inform the goal checker of the current path, which enables building more sophisticated goal checkers that (for example) take progress along the path into account.

We already use such a goal checker internally, which just subscribes to the global plan via the appropriate ROS topic, but i think this here is the cleaner solution (and also avoids race conditions of checking against an old path in the goal checker...)

I don't have a nice testing setup and a goal checker using this interface yet (other than our own robot and the mentioned goal checker), which is why I mark this as draft for now.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4304 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (WIP) |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* [x] Extend `GoalChecker::isGoalReached` interface with argument for current path
* [x] Add this argument to the in-tree goal checker implementations
* [ ] Add a goal checker which checks for path-completion
* [ ] Define a test-scenario with global plan that returns to start pose

## Description of documentation updates required from your changes

* [ ] Migration guide for out-of-tree goal checkers

---

## Future work that may be required in bullet points

* Implementing more sophisticated goal checkers

#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
