### PR TITLE
Fix behavior server

### DIFF
--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -237,15 +237,6 @@ protected:
 
     while (rclcpp::ok()) {
       elasped_time_ = clock_->now() - start_time;
-      if (action_server_->is_cancel_requested()) {
-        RCLCPP_INFO(logger_, "Canceling %s", behavior_name_.c_str());
-        stopRobot();
-        result->total_elapsed_time = elasped_time_;
-        onActionCompletion(result);
-        action_server_->terminate_all(result);
-        return;
-      }
-
       // TODO(orduno) #868 Enable preempting a Behavior on-the-fly without stopping
       if (action_server_->is_preempt_requested()) {
         RCLCPP_ERROR(
@@ -256,6 +247,15 @@ protected:
         result->total_elapsed_time = clock_->now() - start_time;
         onActionCompletion(result);
         action_server_->terminate_current(result);
+        return;
+      }
+
+      if (action_server_->is_cancel_requested()) {
+        RCLCPP_INFO(logger_, "Canceling %s", behavior_name_.c_str());
+        stopRobot();
+        result->total_elapsed_time = elasped_time_;
+        onActionCompletion(result);
+        action_server_->terminate_all(result);
         return;
       }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation) |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

**Purpose:**

This PR fix a problem with TimedBehavior. It occurs when we run first DriveOnHeading -> cancel first DriveOnHeading -> immediately run the second  DriveOnHeading. This way we accept new goal -> requested preemption -> terminate_all goals because of cancel first DriveOnHeading -> current goal from second DriveOnHeading is empty -> second  DriveOnHeading fails.

![image](https://github.com/user-attachments/assets/4b27f9bf-2d22-4dcc-9a03-6b9faf0770fb)

**Changes:**

We swapped two checks in TimedBehavior. First we check if we have preemption requested and then check if we request to cancel. In this case our current goal won’t be empty and DriveOnHeading won’t fail.

**Before:**

![image](https://github.com/user-attachments/assets/96c867ae-3600-44c9-9fa7-d3d7852e0ecc)

We don`t see log "Running drive_on_heading"  from the second DriveOnHeading because it fails

**After:**

![image](https://github.com/user-attachments/assets/9134c412-6c52-48a7-8ea1-8af0e1bb7bf1)



#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
