### PR TITLE
Switch nav2_theta_star_planner to modern CMake idioms.

### DIFF
--- a/nav2_theta_star_planner/CMakeLists.txt
+++ b/nav2_theta_star_planner/CMakeLists.txt
@@ -2,80 +2,94 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_theta_star_planner)
 
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
-find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-nav2_package() #Calls the nav2_package.cmake file
-add_compile_options(-O3)
-
-include_directories(
-  include
-)
+nav2_package()
 
 set(library_name ${PROJECT_NAME})
-
-set(dependencies ament_cmake
-  builtin_interfaces
-  nav2_common
-  nav2_core
-  nav2_costmap_2d
-  nav2_msgs
-  nav2_util
-  pluginlib
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  tf2_ros
-)
-
 
 add_library(${library_name} SHARED
   src/theta_star.cpp
   src/theta_star_planner.cpp
 )
-
-ament_target_dependencies(${library_name} ${dependencies})
-
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB_DISABLE_BOOST_FUNCTIONS")
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${library_name} PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${rcl_interfaces_TARGETS}
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${library_name} PRIVATE
+  pluginlib::pluginlib
+)
+target_compile_options(${library_name} PRIVATE -O3)
 
 pluginlib_export_plugin_description_file(nav2_core theta_star_planner.xml)
 
 install(TARGETS ${library_name}
+  EXPORT ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(FILES theta_star_planner.xml
   DESTINATION share/${PROJECT_NAME}
 )
 
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(gtest_disable_pthreads OFF)
   ament_lint_auto_find_test_dependencies()
+
   find_package(ament_cmake_gtest REQUIRED)
+
+  ament_find_gtest()
+
   ament_add_gtest(test_theta_star test/test_theta_star.cpp)
-  ament_target_dependencies(test_theta_star ${dependencies})
-  target_link_libraries(test_theta_star ${library_name})
+  target_link_libraries(test_theta_star
+    ${library_name}
+    ${geometry_msgs_TARGETS}
+    nav2_costmap_2d::nav2_costmap_2d_core
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+  )
 endif()
 
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  geometry_msgs
+  nav2_core
+  nav2_costmap_2dnav2_util
+  nav_msgs
+  rclcpp
+  rclcpp_lifecycle
+  rcl_interfaces
+  tf2_ros
+)
+ament_export_targets(${library_name})
 ament_package()

--- a/nav2_theta_star_planner/package.xml
+++ b/nav2_theta_star_planner/package.xml
@@ -9,26 +9,25 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>builtin_interfaces</depend>
-  <depend>nav2_common</depend>
+  <depend>geometry_msgs</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
-  <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
+  <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>rcl_interfaces</depend>
   <depend>tf2_ros</depend>
-  
+
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
     <nav2_core plugin="${prefix}/global_planner_plugin.xml"/>
   </export>
 </package>
-

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -12,7 +12,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#include <functional>
 #include <vector>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
 #include "nav2_core/planner_exceptions.hpp"
 #include "nav2_theta_star_planner/theta_star.hpp"
 

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -15,6 +15,10 @@
 #include <vector>
 #include <memory>
 #include <string>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+
 #include "nav2_theta_star_planner/theta_star_planner.hpp"
 #include "nav2_theta_star_planner/theta_star.hpp"
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Change nav2_theta_star_planner to modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries
2.  Export a target so downstream packages can use it.
3.  Push the include directory down a level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 packages to modern CMake idioms.  There will be follow-up PRs to convert more of the packages.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
