### PR TITLE
Switch nav2_velocity_smoother to modern CMake idioms.

### DIFF
--- a/nav2_velocity_smoother/CMakeLists.txt
+++ b/nav2_velocity_smoother/CMakeLists.txt
@@ -2,57 +2,42 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_velocity_smoother)
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
-
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+find_package(rclcpp_lifecycle REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include
-)
-
 set(executable_name velocity_smoother)
 set(library_name ${executable_name}_core)
-
-set(dependencies
-  rclcpp
-  rclcpp_components
-  geometry_msgs
-  nav2_util
-)
 
 # Main library
 add_library(${library_name} SHARED
   src/velocity_smoother.cpp
 )
-ament_target_dependencies(${library_name}
-  ${dependencies}
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
+target_link_libraries(${library_name} PRIVATE
+  rclcpp_components::component
 )
 
 # Main executable
 add_executable(${executable_name}
   src/main.cpp
 )
-ament_target_dependencies(${executable_name}
-  ${dependencies}
-)
-target_link_libraries(${executable_name} ${library_name})
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-
-  find_package(ament_cmake_gtest REQUIRED)
-endif()
+target_link_libraries(${executable_name} PRIVATE ${library_name} rclcpp::rclcpp)
 
 rclcpp_components_register_nodes(${library_name} "nav2_velocity_smoother::VelocitySmoother")
 
@@ -68,17 +53,28 @@ install(TARGETS ${executable_name}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(nav_msgs REQUIRED)
+
+  ament_find_gtest()
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  geometry_msgs
+  nav2_util
+  rclcpp
+  rclcpp_lifecycle
+)
 ament_package()

--- a/nav2_velocity_smoother/package.xml
+++ b/nav2_velocity_smoother/package.xml
@@ -9,14 +9,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
+
   <depend>geometry_msgs</depend>
   <depend>nav2_util</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>nav_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_velocity_smoother/test/CMakeLists.txt
+++ b/nav2_velocity_smoother/test/CMakeLists.txt
@@ -2,9 +2,11 @@
 ament_add_gtest(velocity_smoother_tests
   test_velocity_smoother.cpp
 )
-ament_target_dependencies(velocity_smoother_tests
-  ${dependencies}
-)
 target_link_libraries(velocity_smoother_tests
   ${library_name}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update nav2_velocity_smoother to use modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries
2.  Export a CMake target so that downstream packages can use it.
3.  Push the include directory down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 to use modern CMake idioms.  There are approximately 11 more PRs to follow this one.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
