### PR TITLE
Switch nav2_graceful_controller to modern CMake idioms.

### DIFF
--- a/nav2_graceful_controller/CMakeLists.txt
+++ b/nav2_graceful_controller/CMakeLists.txt
@@ -2,44 +2,38 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_graceful_controller)
 
 find_package(ament_cmake REQUIRED)
+find_package(angles REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
 find_package(nav2_util REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(geometry_msgs REQUIRED)
+find_package(nav_2d_utils REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(nav_2d_utils REQUIRED)
-find_package(angles REQUIRED)
+find_package(tf2_ros REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include
-)
-
-set(dependencies
-  rclcpp
-  geometry_msgs
-  nav2_costmap_2d
-  pluginlib
-  nav_msgs
-  nav2_util
-  nav2_core
-  tf2
-  tf2_geometry_msgs
-  nav_2d_utils
-  angles
-  visualization_msgs
-)
-
 # Add Smooth Control Law as library
 add_library(smooth_control_law SHARED src/smooth_control_law.cpp)
-ament_target_dependencies(smooth_control_law ${dependencies})
+target_include_directories(smooth_control_law
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(smooth_control_law PUBLIC
+  angles::angles
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  tf2::tf2
+)
 
 # Add Graceful Controller
 set(library_name nav2_graceful_controller)
@@ -50,18 +44,40 @@ add_library(${library_name} SHARED
   src/path_handler.cpp
   src/utils.cpp
 )
-
-target_link_libraries(${library_name} smooth_control_law)
-ament_target_dependencies(${library_name} ${dependencies})
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  nav2_util::nav2_util_core
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav_2d_utils::tf_help
+  ${nav_msgs_TARGETS}
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${rcl_interfaces_TARGETS}
+  smooth_control_law
+  tf2::tf2
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
+)
+target_link_libraries(${library_name} PRIVATE
+  tf2_geometry_msgs::tf2_geometry_msgs
+)
 
 install(TARGETS smooth_control_law ${library_name}
+  EXPORT nav2_graceful_controller
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -70,12 +86,31 @@ if(BUILD_TESTING)
   # the following line skips the linter which checks for copyrights
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
+
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(smooth_control_law ${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  geometry_msgs
+  nav2_core
+  nav2_util
+  nav2_costmap_2d
+  nav_2d_utils
+  nav_msgs
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  rcl_interfaces
+  tf2
+  tf2_ros
+  visualization_msgs
+)
+ament_export_targets(nav2_graceful_controller)
 
 pluginlib_export_plugin_description_file(nav2_core graceful_controller_plugin.xml)
 

--- a/nav2_graceful_controller/include/nav2_graceful_controller/ego_polar_coords.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/ego_polar_coords.hpp
@@ -15,13 +15,11 @@
 #ifndef NAV2_GRACEFUL_CONTROLLER__EGO_POLAR_COORDS_HPP_
 #define NAV2_GRACEFUL_CONTROLLER__EGO_POLAR_COORDS_HPP_
 
-#include <math.h>
+#include <cmath>
 
 #include "angles/angles.h"
 #include "geometry_msgs/msg/pose.hpp"
 #include "tf2/utils.h"
-#include "tf2/transform_datatypes.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace nav2_graceful_controller
 {

--- a/nav2_graceful_controller/package.xml
+++ b/nav2_graceful_controller/package.xml
@@ -8,24 +8,27 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>nav2_common</depend>
-  <depend>nav2_core</depend>
-  <depend>nav2_util</depend>
-  <depend>nav2_costmap_2d</depend>
-  <depend>rclcpp</depend>
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav2_msgs</depend>
+  <depend>nav2_core</depend>
+  <depend>nav2_costmap_2d</depend>
+  <depend>nav2_util</depend>
+  <depend>nav_2d_utils</depend>
+  <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>rcl_interfaces</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>nav_2d_utils</depend>
-  <depend>angles</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>nav2_controller</test_depend>
 
   <export>

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <mutex>
+
 #include "nav2_core/controller_exceptions.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_graceful_controller/graceful_controller.hpp"

--- a/nav2_graceful_controller/test/CMakeLists.txt
+++ b/nav2_graceful_controller/test/CMakeLists.txt
@@ -4,18 +4,26 @@ find_package(nav2_controller REQUIRED)
 ament_add_gtest(test_graceful_controller
   test_graceful_controller.cpp
 )
-ament_target_dependencies(test_graceful_controller
-  ${dependencies}
-  nav2_controller
-)
 target_link_libraries(test_graceful_controller
   ${library_name}
+  ${geometry_msgs_TARGETS}
+  nav2_controller::simple_goal_checker
+  nav2_core::nav2_core
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
 )
 
 # Egopolar test
 ament_add_gtest(test_egopolar
   test_egopolar.cpp
 )
-ament_target_dependencies(test_egopolar
-  geometry_msgs tf2_geometry_msgs angles
+target_link_libraries(test_egopolar
+  ${library_name}
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  tf2_geometry_msgs::tf2_geometry_msgs
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update nav2_graceful_controller to use modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries.
2.  Export a CMake target so downstream packages can use it.
3.  Push the include directory down, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 to modern CMake practices.  There are approximately 10 PRs left to go after this one.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
