### PR TITLE
Switch costmap_queue to use modern CMake idioms.

### DIFF
--- a/nav2_dwb_controller/costmap_queue/CMakeLists.txt
+++ b/nav2_dwb_controller/costmap_queue/CMakeLists.txt
@@ -4,26 +4,20 @@ project(costmap_queue)
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
-find_package(rclcpp REQUIRED)
 
 nav2_package()
-
-include_directories(
-  include
-)
 
 add_library(${PROJECT_NAME} SHARED
   src/costmap_queue.cpp
   src/limited_costmap_queue.cpp
 )
-
-set(dependencies
-  rclcpp
-  nav2_costmap_2d
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies}
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  nav2_costmap_2d::nav2_costmap_2d_core
 )
 
 if(BUILD_TESTING)
@@ -34,24 +28,36 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
 
+  find_package(rclcpp REQUIRED)
+
+  ament_find_gtest()
+
   ament_add_gtest(mbq_test test/mbq_test.cpp)
-  ament_target_dependencies(mbq_test ${dependencies})
+  target_link_libraries(mbq_test
+    ${PROJECT_NAME}
+  )
 
   ament_add_gtest(utest test/utest.cpp)
-  ament_target_dependencies(utest ${dependencies})
-  target_link_libraries(utest ${PROJECT_NAME})
+  target_link_libraries(utest
+    ${PROJECT_NAME}
+    nav2_costmap_2d::nav2_costmap_2d_core
+    rclcpp::rclcpp
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(DIRECTORY include/
-        DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(nav2_costmap_2d)
+ament_export_targets(${PROJECT_NAME})
 
 ament_package()

--- a/nav2_dwb_controller/costmap_queue/package.xml
+++ b/nav2_dwb_controller/costmap_queue/package.xml
@@ -10,11 +10,11 @@
   <build_depend>nav2_common</build_depend>
 
   <depend>nav2_costmap_2d</depend>
-  <depend>rclcpp</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>rclcpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update the costmap_queue package to use modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries
2.  Export a CMake target so downstream users can link against it.
3.  Push the include directory down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series to convert all Navigation2 packages to modern CMake idioms.  There are approximately 9 PRs after this one.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
