### PR TITLE
Switch dwb_critics to modern CMake idioms.

### DIFF
--- a/nav2_dwb_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/CMakeLists.txt
@@ -2,68 +2,66 @@ cmake_minimum_required(VERSION 3.5)
 project(dwb_critics)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
 find_package(angles REQUIRED)
-find_package(nav2_costmap_2d REQUIRED)
 find_package(costmap_queue REQUIRED)
 find_package(dwb_core REQUIRED)
+find_package(dwb_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_costmap_2d REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(nav_2d_msgs REQUIRED)
 find_package(nav_2d_utils REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include
-)
-
 add_library(${PROJECT_NAME} SHARED
-    src/alignment_util.cpp
-    src/map_grid.cpp
-    src/goal_dist.cpp
-    src/path_dist.cpp
-    src/goal_align.cpp
-    src/path_align.cpp
-    src/base_obstacle.cpp
-    src/obstacle_footprint.cpp
-    src/oscillation.cpp
-    src/prefer_forward.cpp
-    src/rotate_to_goal.cpp
-    src/twirling.cpp
+  src/alignment_util.cpp
+  src/map_grid.cpp
+  src/goal_dist.cpp
+  src/path_dist.cpp
+  src/goal_align.cpp
+  src/path_align.cpp
+  src/base_obstacle.cpp
+  src/obstacle_footprint.cpp
+  src/oscillation.cpp
+  src/prefer_forward.cpp
+  src/rotate_to_goal.cpp
+  src/twirling.cpp
 )
-
-set(dependencies
-  angles
-  nav2_costmap_2d
-  costmap_queue
-  dwb_core
-  geometry_msgs
-  nav_2d_msgs
-  nav_2d_utils
-  pluginlib
-  rclcpp
-  sensor_msgs
-  nav2_util
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies}
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  costmap_queue::costmap_queue
+  dwb_core::dwb_core
+  ${dwb_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  nav2_costmap_2d::nav2_costmap_2d_core
+  ${nav_2d_msgs_TARGETS}
+  rclcpp::rclcpp
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  angles::angles
+  nav2_util::nav2_util_core
+  nav_2d_utils::path_ops
+  pluginlib::pluginlib
 )
 
 install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(DIRECTORY include/
-        DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 install(FILES default_critics.xml
-        DESTINATION share/${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -72,15 +70,23 @@ if(BUILD_TESTING)
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
 
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(
-  ${dependencies}
+  costmap_queue
+  dwb_core
+  dwb_msgs
+  geometry_msgs
+  nav2_costmap_2d
+  nav_2d_msgs
+  rclcpp
 )
+ament_export_targets(${PROJECT_NAME})
 
 pluginlib_export_plugin_description_file(dwb_core default_critics.xml)
 

--- a/nav2_dwb_controller/dwb_critics/package.xml
+++ b/nav2_dwb_controller/dwb_critics/package.xml
@@ -10,20 +10,20 @@
   <build_depend>nav2_common</build_depend>
 
   <depend>angles</depend>
-  <depend>nav2_costmap_2d</depend>
-  <depend>nav2_util</depend>
   <depend>costmap_queue</depend>
   <depend>dwb_core</depend>
+  <depend>dwb_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav2_costmap_2d</depend>
+  <depend>nav2_util</depend>
   <depend>nav_2d_msgs</depend>
   <depend>nav_2d_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
       <build_type>ament_cmake</build_type>

--- a/nav2_dwb_controller/dwb_critics/test/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/test/CMakeLists.txt
@@ -1,14 +1,35 @@
 ament_add_gtest(prefer_forward_tests prefer_forward_test.cpp)
-target_link_libraries(prefer_forward_tests dwb_critics)
+target_link_libraries(prefer_forward_tests
+  dwb_critics
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+)
 
 ament_add_gtest(base_obstacle_tests base_obstacle_test.cpp)
-target_link_libraries(base_obstacle_tests dwb_critics)
+target_link_libraries(base_obstacle_tests
+  dwb_critics
+  dwb_core::dwb_core
+  rclcpp::rclcpp
+)
 
 ament_add_gtest(obstacle_footprint_tests obstacle_footprint_test.cpp)
-target_link_libraries(obstacle_footprint_tests dwb_critics)
+target_link_libraries(obstacle_footprint_tests
+  dwb_critics
+  dwb_core::dwb_core
+  rclcpp::rclcpp
+)
 
 ament_add_gtest(alignment_util_tests alignment_util_test.cpp)
-target_link_libraries(alignment_util_tests dwb_critics)
+target_link_libraries(alignment_util_tests
+  dwb_critics
+  dwb_core::dwb_core
+  rclcpp::rclcpp
+)
 
 ament_add_gtest(twirling_tests twirling_test.cpp)
-target_link_libraries(twirling_tests dwb_critics)
+target_link_libraries(twirling_tests
+  dwb_critics
+  dwb_core::dwb_core
+  rclcpp::rclcpp
+)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update dwb_critics to use modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries.
2.  Export a CMake target so downstream packages can use the libraries here.
3.  Push the include directories down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 to modern CMake idioms.  There are approximately 6 packages left after this one.  However, note that I will be taking a break from this work for one or two weeks, as I am on vacation, and still need to do the conversion for 4 more of the packages.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
