### PR TITLE
dynamic parameter handling of observation_sources for obstacle layer

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -85,6 +85,10 @@ public:
    */
   virtual void onInitialize();
   /**
+   * @brief Initialize observation sources
+   */
+  virtual void initializeObservationSources(std::string sources);
+  /**
    * @brief Update the bounds of the master costmap by this layer's update dimensions
    * @param robot_x X pose of robot
    * @param robot_y Y pose of robot
@@ -253,6 +257,9 @@ protected:
   bool rolling_window_;
   bool was_reset_;
   int combination_method_;
+  std::string observation_sources_;
+  double transform_tolerance;
+
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -333,7 +333,7 @@ ObstacleLayer::dynamicParametersCallback(
         std::vector<std::string> matched_sources;
         std::ostringstream new_sources_stream;
 
-        //find sources that already have been defined
+        //find all the sources that have already been set.
         while (ss >> source) {
           while (ss_old >> source_old) {
             if (source == source_old) {
@@ -359,7 +359,7 @@ ObstacleLayer::dynamicParametersCallback(
         std::int16_t index = 0;
         std::stringstream ss_old_final(observation_sources_);
 
-        // find the subscribers that weren't mentioned and remove them
+        // find and remove the sources that were not passed into the parameter update
         while (ss_old_final >> source_old) {
           if (std::find(matched_sources.begin(), matched_sources.end(), source_old) == matched_sources.end()) {
             // The observation source needs to be removed
@@ -378,6 +378,7 @@ ObstacleLayer::dynamicParametersCallback(
           }
         }
 
+        //initializse any new sources
         auto start_index = observation_subscribers_.size() - 1;
         if (!new_sources.empty()) {
           initializeObservationSources(new_sources);
@@ -387,7 +388,6 @@ ObstacleLayer::dynamicParametersCallback(
           }
         }
 
-        //replace with new sources
         observation_sources_ = parameter.as_string();
       }
     }


### PR DESCRIPTION
## Basic Info

| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo |
| Does this PR contain AI generated software? | No |

Dynamic parameter handling for `observation_sources` in the obstacle layer.

This functionality can also be extended to the voxel_layer.

## Description of documentation updates required from your changes

`observation_sources` should probably be identified in the docs as a dynamic parameter.

## Future work that may be required in bullet points

I made this a Draft PR as there is probably some optimisation to be done here, and it might be best to not remove sources from the buffers entirely but keep them there, with their subscribers simply unsubscribed? Would like to get some feedback on my implementation here

#### For Maintainers: 
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
