### PR TITLE
Switch dwb_plugins to modern CMake idioms.

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -2,38 +2,41 @@ cmake_minimum_required(VERSION 3.5)
 project(dwb_plugins)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
-find_package(angles REQUIRED)
 find_package(dwb_core REQUIRED)
+find_package(dwb_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_util REQUIRED)
 find_package(nav_2d_msgs REQUIRED)
 find_package(nav_2d_utils REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(nav2_util REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 
 nav2_package()
 
-set(dependencies
-  angles
-  dwb_core
-  nav_2d_msgs
-  nav_2d_utils
-  pluginlib
-  rclcpp
-  nav2_util
-)
-
-include_directories(
-  include
-)
-
 add_library(standard_traj_generator SHARED
-            src/standard_traj_generator.cpp
-            src/limited_accel_generator.cpp
-            src/kinematic_parameters.cpp
-            src/xy_theta_iterator.cpp)
-ament_target_dependencies(standard_traj_generator ${dependencies})
-
+  src/standard_traj_generator.cpp
+  src/limited_accel_generator.cpp
+  src/kinematic_parameters.cpp
+  src/xy_theta_iterator.cpp)
+target_include_directories(standard_traj_generator PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(standard_traj_generator PUBLIC
+  dwb_core::dwb_core
+  ${dwb_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${nav_2d_msgs_TARGETS}
+  rclcpp::rclcpp
+  ${rcl_interfaces_TARGETS}
+)
+target_link_libraries(standard_traj_generator PRIVATE
+  nav_2d_utils::conversions
+  pluginlib::pluginlib
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -42,23 +45,39 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
+
+  find_package(nav2_costmap_2d REQUIRED)
+  find_package(rclcpp_lifecycle REQUIRED)
   add_subdirectory(test)
 endif()
 
 install(TARGETS standard_traj_generator
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(DIRECTORY include/
-        DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 install(FILES plugins.xml
-        DESTINATION share/${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}
 )
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(standard_traj_generator)
+ament_export_dependencies(
+  dwb_core
+  dwb_msgs
+  geometry_msgs
+  nav2_util
+  nav_2d_msgs
+  rclcpp
+  rcl_interfaces
+)
+ament_export_targets(${PROJECT_NAME})
+
 pluginlib_export_plugin_description_file(dwb_core plugins.xml)
 
 ament_package()

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
@@ -38,7 +38,6 @@
 #include <memory>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
 #include "nav_2d_msgs/msg/twist2_d.hpp"
 #include "dwb_plugins/kinematic_parameters.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_dwb_controller/dwb_plugins/package.xml
+++ b/nav2_dwb_controller/dwb_plugins/package.xml
@@ -12,17 +12,21 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
   <depend>dwb_core</depend>
+  <depend>dwb_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav2_util</depend>
   <depend>nav_2d_msgs</depend>
   <depend>nav_2d_utils</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
-  <depend>nav2_util</depend>
+  <depend>rcl_interfaces</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>nav2_costmap_2d</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
@@ -1,10 +1,29 @@
 ament_add_gtest(vtest velocity_iterator_test.cpp)
+target_link_libraries(vtest standard_traj_generator)
 
 ament_add_gtest(twist_gen_test twist_gen.cpp)
-target_link_libraries(twist_gen_test standard_traj_generator)
+target_link_libraries(twist_gen_test
+  standard_traj_generator
+  dwb_core::dwb_core
+  ${dwb_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${nav_2d_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
 
 ament_add_gtest(kinematic_parameters_test kinematic_parameters_test.cpp)
-target_link_libraries(kinematic_parameters_test standard_traj_generator)
+target_link_libraries(kinematic_parameters_test
+  standard_traj_generator
+  rclcpp::rclcpp
+  ${rcl_interfaces_TARGETS}
+)
 
 ament_add_gtest(speed_limit_test speed_limit_test.cpp)
-target_link_libraries(speed_limit_test standard_traj_generator)
+target_link_libraries(speed_limit_test
+  standard_traj_generator
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Followup to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Change dwb_plugins to modern CMake idioms:
1.  Use target_link_libraries instead of ament_target_dependencies
2.  Export a CMake target for downstream users to use.
3.  Push the include directory down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 to use modern CMake idioms.  After this PR, there are 7 PRs left to finish the conversion.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
