### PR TITLE
Switch opennav_docking_core to modern CMake idioms.

### DIFF
--- a/nav2_docking/opennav_docking_core/CMakeLists.txt
+++ b/nav2_docking/opennav_docking_core/CMakeLists.txt
@@ -2,23 +2,34 @@ cmake_minimum_required(VERSION 3.5)
 project(opennav_docking_core)
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
-set(dependencies
-  rclcpp
-  rclcpp_lifecycle
-  nav2_msgs
-  nav2_util
+add_library(opennav_docking_core INTERFACE)
+target_include_directories(opennav_docking_core
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(opennav_docking_core INTERFACE
+  ${geometry_msgs_TARGETS}
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+)
+
+install(TARGETS opennav_docking_core
+  EXPORT opennav_docking_core
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -28,7 +39,12 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_include_directories(include)
-ament_export_dependencies(${dependencies})
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_dependencies(
+  geometry_msgs
+  rclcpp_lifecycle
+  tf2_ros
+)
+ament_export_targets(opennav_docking_core)
 
 ament_package()

--- a/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
+++ b/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
@@ -18,9 +18,8 @@
 #include <string>
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "nav2_util/lifecycle_node.hpp"
 #include "tf2_ros/buffer.h"
 
 

--- a/nav2_docking/opennav_docking_core/package.xml
+++ b/nav2_docking/opennav_docking_core/package.xml
@@ -8,16 +8,14 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>nav2_util</depend>
-  <depend>nav2_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update opennav_docking_core to modern CMake idioms:
1.  Add in an INTERFACE target that contains the header files
2.  Export a CMake target so downstream packages can use it.
3.  Reduce the exported dependencies.
4.  Push the include directory down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series to convert Navigation2 to modern CMake idioms.  There are 6 PRs required after this one.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
