### PR TITLE
Switch opennav_docking_bt to modern CMake idioms.

### DIFF
--- a/nav2_docking/opennav_docking_bt/CMakeLists.txt
+++ b/nav2_docking/opennav_docking_bt/CMakeLists.txt
@@ -2,56 +2,56 @@ cmake_minimum_required(VERSION 3.5)
 project(opennav_docking_bt)
 
 find_package(ament_cmake REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_behavior_tree REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_core REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_msgs REQUIRED)
-find_package(nav2_core REQUIRED)
-find_package(nav2_behavior_tree REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
 
-# potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
-
-include_directories(
-  include
-)
-
-set(dependencies
-  rclcpp
-  rclcpp_action
-  std_msgs
-  nav2_util
-  nav2_msgs
-  nav2_core
-  nav2_behavior_tree
-  nav_msgs
-  geometry_msgs
-  behaviortree_cpp
-)
+nav2_package()
 
 add_library(opennav_dock_action_bt_node SHARED src/dock_robot.cpp)
-list(APPEND plugin_libs opennav_dock_action_bt_node)
+target_include_directories(opennav_dock_action_bt_node
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_compile_definitions(opennav_dock_action_bt_node PRIVATE BT_PLUGIN_EXPORT)
+target_link_libraries(opennav_dock_action_bt_node PUBLIC
+  behaviortree_cpp::behaviortree_cpp
+  ${geometry_msgs_TARGETS}
+  nav2_behavior_tree::nav2_behavior_tree
+  ${nav2_msgs_TARGETS}
+)
+
 add_library(opennav_undock_action_bt_node SHARED src/undock_robot.cpp)
-list(APPEND plugin_libs opennav_undock_action_bt_node)
+target_include_directories(opennav_undock_action_bt_node
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_compile_definitions(opennav_undock_action_bt_node PRIVATE BT_PLUGIN_EXPORT)
+target_link_libraries(opennav_undock_action_bt_node PUBLIC
+  behaviortree_cpp::behaviortree_cpp
+  ${geometry_msgs_TARGETS}
+  nav2_behavior_tree::nav2_behavior_tree
+  ${nav2_msgs_TARGETS}
+)
 
-foreach(bt_plugin ${plugin_libs})
-  ament_target_dependencies(${bt_plugin} ${dependencies})
-  target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)
-endforeach()
-
-install(TARGETS ${plugin_libs}
+install(TARGETS opennav_dock_action_bt_node opennav_undock_action_bt_node
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
@@ -63,7 +63,13 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
-ament_export_libraries(${plugin_libs})
-ament_export_dependencies(${dependencies})
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_libraries(opennav_dock_action_bt_node opennav_undock_action_bt_node)
+ament_export_dependencies(
+  behaviortree_cpp
+  geometry_msgs
+  nav2_behavior_tree
+  nav2_msgs
+)
+ament_export_targets(${PROJECT_NAME})
 ament_package()

--- a/nav2_docking/opennav_docking_bt/package.xml
+++ b/nav2_docking/opennav_docking_bt/package.xml
@@ -8,16 +8,17 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
+  <depend>behaviortree_cpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>nav2_behavior_tree</depend>
-  <depend>nav2_util</depend>
   <depend>nav2_core</depend>
   <depend>nav2_msgs</depend>
+  <depend>nav2_util</depend>
   <depend>nav_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>behaviortree_cpp</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_docking/opennav_docking_bt/test/CMakeLists.txt
+++ b/nav2_docking/opennav_docking_bt/test/CMakeLists.txt
@@ -1,9 +1,21 @@
 # Cancel test
 ament_add_gtest(test_dock_robot test_dock_robot.cpp)
-target_link_libraries(test_dock_robot opennav_dock_action_bt_node)
-ament_target_dependencies(test_dock_robot ${dependencies})
+target_link_libraries(test_dock_robot
+  behaviortree_cpp::behaviortree_cpp
+  ${geometry_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  opennav_dock_action_bt_node
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+)
 
 # Make command test
 ament_add_gtest(test_undock_robot test_undock_robot.cpp)
-target_link_libraries(test_undock_robot opennav_undock_action_bt_node)
-ament_target_dependencies(test_undock_robot ${dependencies})
+target_link_libraries(test_undock_robot
+  behaviortree_cpp::behaviortree_cpp
+  ${geometry_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  opennav_undock_action_bt_node
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update opennav_docking_bt to use modern CMake idioms:
1.  Use target_link_libraries instead of ament_target_dependencies
2.  Export a CMake target so that downstream packages can link against it.
3.  Push the include directories down one level, which is best practice since Humble.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series converting Navigation2 to modern CMake idioms.  There are 5 PRs after this one.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
