### PR TITLE
Switch opennav_docking to modern CMake idioms.

### DIFF
--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -3,65 +3,45 @@ project(opennav_docking)
 
 find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(visualization_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
 find_package(nav2_graceful_controller REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(builtin_interfaces REQUIRED)
+find_package(opennav_docking_core REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(pluginlib REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
-find_package(opennav_docking_core REQUIRED)
 
-# potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
-
-include_directories(
-  include
-)
+nav2_package()
 
 set(executable_name opennav_docking)
 set(library_name ${executable_name}_core)
 
-set(dependencies
-  angles
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  rclcpp_components
-  std_msgs
-  sensor_msgs
-  visualization_msgs
-  nav2_graceful_controller
-  nav2_util
-  nav2_msgs
-  nav_msgs
-  geometry_msgs
-  builtin_interfaces
-  tf2_ros
-  tf2_geometry_msgs
-  pluginlib
-  yaml_cpp_vendor
-  opennav_docking_core
-)
-
 add_library(controller SHARED
   src/controller.cpp
 )
-
-ament_target_dependencies(controller
-  ${dependencies}
+target_include_directories(controller
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(controller PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_graceful_controller::nav2_graceful_controller
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${rcl_interfaces_TARGETS}
 )
 
 add_library(${library_name} SHARED
@@ -69,47 +49,87 @@ add_library(${library_name} SHARED
   src/dock_database.cpp
   src/navigator.cpp
 )
-
-ament_target_dependencies(${library_name}
-  ${dependencies}
+target_include_directories(${library_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-
-target_link_libraries(${library_name}
-  yaml-cpp::yaml-cpp
+target_link_libraries(${library_name} PUBLIC
+  angles::angles
   controller
+  ${geometry_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  opennav_docking_core::opennav_docking_core
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${rcl_interfaces_TARGETS}
+  tf2_ros::tf2_ros
+  yaml-cpp::yaml-cpp
+)
+target_link_libraries(${library_name} PRIVATE
+  rclcpp_components::component
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 add_library(pose_filter SHARED
   src/pose_filter.cpp
 )
-
-ament_target_dependencies(pose_filter
-  ${dependencies}
+target_include_directories(pose_filter
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(pose_filter PUBLIC
+  ${geometry_msgs_TARGETS}
+)
+target_link_libraries(pose_filter PRIVATE
+  rclcpp::rclcpp
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-target_link_libraries(${executable_name} ${library_name})
-
-ament_target_dependencies(${executable_name}
-  ${dependencies}
+target_include_directories(${executable_name}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
+target_link_libraries(${executable_name} PRIVATE ${library_name} rclcpp::rclcpp)
 
 rclcpp_components_register_nodes(${library_name} "opennav_docking::DockingServer")
 
 add_library(simple_charging_dock SHARED
   src/simple_charging_dock.cpp
 )
-ament_target_dependencies(simple_charging_dock
-  ${dependencies}
+target_include_directories(simple_charging_dock
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-target_link_libraries(simple_charging_dock pose_filter)
+target_link_libraries(simple_charging_dock PUBLIC
+  ${geometry_msgs_TARGETS}
+  opennav_docking_core::opennav_docking_core
+  pose_filter
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
+target_link_libraries(simple_charging_dock PRIVATE
+  nav2_util::nav2_util_core
+  pluginlib::pluginlib
+  tf2::tf2
+)
 
 pluginlib_export_plugin_description_file(opennav_docking_core plugins.xml)
 
 install(TARGETS ${library_name} controller pose_filter simple_charging_dock
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -120,7 +140,7 @@ install(TARGETS ${executable_name}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(FILES test/test_dock_file.yaml
@@ -131,11 +151,28 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+
   ament_lint_auto_find_test_dependencies()
+  ament_find_gtest()
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name} controller pose_filter)
-ament_export_dependencies(${dependencies} yaml-cpp)
+ament_export_dependencies(
+  geometry_msgs
+  nav2_graceful_controller
+  nav2_msgs
+  nav2_util
+  opennav_docking_core
+  pluginlib
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  rcl_interfaces
+  tf2_ros
+  yaml-cpp
+)
+ament_export_targets(${PROJECT_NAME})
 ament_package()

--- a/nav2_docking/opennav_docking/include/opennav_docking/pose_filter.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/pose_filter.hpp
@@ -16,7 +16,6 @@
 #define OPENNAV_DOCKING__POSE_FILTER_HPP_
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace opennav_docking
 {

--- a/nav2_docking/opennav_docking/package.xml
+++ b/nav2_docking/opennav_docking/package.xml
@@ -8,25 +8,30 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
   <depend>angles</depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
-  <depend>rclcpp_lifecycle</depend>
+  <depend>geometry_msgs</depend>
   <depend>nav2_graceful_controller</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
   <depend>nav_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>builtin_interfaces</depend>
-  <depend>sensor_msgs</depend>
-  <depend>pluginlib</depend>
-  <depend>yaml_cpp_vendor</depend>
   <depend>opennav_docking_core</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 

--- a/nav2_docking/opennav_docking/src/pose_filter.cpp
+++ b/nav2_docking/opennav_docking/src/pose_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "opennav_docking/pose_filter.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace opennav_docking
 {

--- a/nav2_docking/opennav_docking/test/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/test/CMakeLists.txt
@@ -2,77 +2,90 @@
 ament_add_gtest(test_utils
   test_utils.cpp
 )
-ament_target_dependencies(test_utils
-  ${dependencies}
-)
 target_link_libraries(test_utils
+  ament_index_cpp::ament_index_cpp
+  ${geometry_msgs_TARGETS}
   ${library_name}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 # Test dock database
 ament_add_gtest(test_dock_database
   test_dock_database.cpp
 )
-ament_target_dependencies(test_dock_database
-  ${dependencies}
-)
 target_link_libraries(test_dock_database
+  ament_index_cpp::ament_index_cpp
   ${library_name}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 # Test navigator
 ament_add_gtest(test_navigator
   test_navigator.cpp
 )
-ament_target_dependencies(test_navigator
-  ${dependencies}
-)
 target_link_libraries(test_navigator
+  ament_index_cpp::ament_index_cpp
+  ${geometry_msgs_TARGETS}
   ${library_name}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 # Test Controller
 ament_add_gtest(test_controller
   test_controller.cpp
 )
-ament_target_dependencies(test_controller
-  ${dependencies}
-)
 target_link_libraries(test_controller
+  ${geometry_msgs_TARGETS}
   ${library_name}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 # Test Simple Dock
 ament_add_gtest(test_simple_charging_dock
   test_simple_charging_dock.cpp
 )
-ament_target_dependencies(test_simple_charging_dock
-  ${dependencies}
-)
 target_link_libraries(test_simple_charging_dock
-  ${library_name} simple_charging_dock
+  ament_index_cpp::ament_index_cpp
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  simple_charging_dock
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 # Test Pose Filter (unit)
 ament_add_gtest(test_pose_filter
   test_pose_filter.cpp
 )
-ament_target_dependencies(test_pose_filter
-  ${dependencies}
-)
 target_link_libraries(test_pose_filter
-  ${library_name}
+  ${geometry_msgs_TARGETS}
   pose_filter
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 # Test dock pluing for server tests
 add_library(test_dock SHARED testing_dock.cpp)
-ament_target_dependencies(test_dock ${dependencies})
-target_compile_definitions(test_dock PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_link_libraries(test_dock PUBLIC
+  ${geometry_msgs_TARGETS}
+  opennav_docking_core::opennav_docking_core
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+)
 install(TARGETS test_dock
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 ament_export_libraries(test_dock)
 
@@ -80,11 +93,12 @@ ament_export_libraries(test_dock)
 ament_add_gtest(test_docking_server_unit
   test_docking_server_unit.cpp
 )
-ament_target_dependencies(test_docking_server_unit
-  ${dependencies}
-)
 target_link_libraries(test_docking_server_unit
+  ${geometry_msgs_TARGETS}
   ${library_name}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 # Test docking server (smoke)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Switch opennav_docking to modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries.
2.  Export a CMake target so downstream users can link against it.
3.  Push the include directories down one level, which is best practice since Humble.
4. Switch this package to be a "nav2_package".

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series converting Navigation2 to modern CMake idioms.  After this PR there are 4 PRs to go.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
