### PR TITLE
Switch nav2_system_tests to modern CMake idioms.

### DIFF
--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -1,114 +1,110 @@
 cmake_minimum_required(VERSION 3.5)
 project(nav2_system_tests)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 23)
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_map_server REQUIRED)
-find_package(nav2_behavior_tree REQUIRED)
-find_package(nav2_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(visualization_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(nav2_amcl REQUIRED)
-find_package(nav2_lifecycle_manager REQUIRED)
-find_package(rclpy REQUIRED)
-find_package(nav2_navfn_planner REQUIRED)
-find_package(nav2_planner REQUIRED)
-find_package(navigation2)
-find_package(angles REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(nav2_minimal_tb3_sim REQUIRED)
 
 nav2_package()
 
-set(dependencies
-  rclcpp
-  nav2_util
-  nav2_map_server
-  nav2_msgs
-  nav_msgs
-  visualization_msgs
-  nav2_amcl
-  nav2_lifecycle_manager
-  nav2_behavior_tree
-  geometry_msgs
-  std_msgs
-  tf2_geometry_msgs
-  rclpy
-  nav2_planner
-  nav2_navfn_planner
-  angles
-  behaviortree_cpp
-  pluginlib
-)
-
-set(local_controller_plugin_lib local_controller)
-
-add_library(${local_controller_plugin_lib} SHARED src/error_codes/controller/controller_error_plugins.cpp)
-ament_target_dependencies(${local_controller_plugin_lib} ${dependencies})
-target_compile_definitions(${local_controller_plugin_lib} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-pluginlib_export_plugin_description_file(nav2_core src/error_codes/controller_plugins.xml)
-
-install(TARGETS ${local_controller_plugin_lib}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-install(FILES src/error_codes/controller_plugins.xml
-    DESTINATION share/${PROJECT_NAME}
-)
-
-set(global_planner_plugin_lib global_planner)
-
-add_library(${global_planner_plugin_lib} SHARED src/error_codes/planner/planner_error_plugin.cpp)
-ament_target_dependencies(${global_planner_plugin_lib} ${dependencies})
-target_compile_definitions(${global_planner_plugin_lib} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-pluginlib_export_plugin_description_file(nav2_core src/error_codes/planner_plugins.xml)
-
-install(TARGETS ${global_planner_plugin_lib}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-install(FILES src/error_codes/planner_plugins.xml
-    DESTINATION share/${PROJECT_NAME}
-)
-
-set(smoother_plugin_lib smoother)
-
-add_library(${smoother_plugin_lib} SHARED src/error_codes/smoother/smoother_error_plugin.cpp)
-ament_target_dependencies(${smoother_plugin_lib} ${dependencies})
-target_compile_definitions(${smoother_plugin_lib} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-pluginlib_export_plugin_description_file(nav2_core src/error_codes/smoother_plugins.xml)
-
-install(TARGETS ${smoother_plugin_lib}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-install(FILES src/error_codes/smoother_plugins.xml
-    DESTINATION share/${PROJECT_NAME}
-)
-
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(angles REQUIRED)
+  find_package(behaviortree_cpp REQUIRED)
+  find_package(geometry_msgs REQUIRED)
+  find_package(nav2_amcl REQUIRED)
+  find_package(nav2_behavior_tree REQUIRED)
+  find_package(nav2_lifecycle_manager REQUIRED)
+  find_package(nav2_map_server REQUIRED)
+  find_package(nav2_minimal_tb3_sim REQUIRED)
+  find_package(nav2_msgs REQUIRED)
+  find_package(nav2_navfn_planner REQUIRED)
+  find_package(nav2_planner REQUIRED)
+  find_package(nav2_util REQUIRED)
+  find_package(nav_msgs REQUIRED)
+  find_package(navigation2 REQUIRED)
+  find_package(pluginlib REQUIRED)
+  find_package(rclcpp REQUIRED)
+  find_package(rclcpp_lifecycle REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(tf2 REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
+  find_package(tf2_ros REQUIRED)
+  find_package(visualization_msgs REQUIRED)
+
+  ament_lint_auto_find_test_dependencies()
+
+  ament_find_gtest()
+
+  set(local_controller_plugin_lib local_controller)
+
+  add_library(${local_controller_plugin_lib} SHARED src/error_codes/controller/controller_error_plugins.cpp)
+  target_link_libraries(${local_controller_plugin_lib} PRIVATE
+    ${geometry_msgs_TARGETS}
+    nav2_core::nav2_core
+    nav2_costmap_2d::nav2_costmap_2d_core
+    ${nav_msgs_TARGETS}
+    pluginlib::pluginlib
+  )
+  pluginlib_export_plugin_description_file(nav2_core src/error_codes/controller_plugins.xml)
+
+  install(TARGETS ${local_controller_plugin_lib}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+
+  install(FILES src/error_codes/controller_plugins.xml
+    DESTINATION share/${PROJECT_NAME}
+  )
+
+  set(global_planner_plugin_lib global_planner)
+
+  add_library(${global_planner_plugin_lib} SHARED src/error_codes/planner/planner_error_plugin.cpp)
+  target_link_libraries(${global_planner_plugin_lib} PRIVATE
+    ${geometry_msgs_TARGETS}
+    nav2_core::nav2_core ${nav_msgs_TARGETS}
+    nav2_costmap_2d::nav2_costmap_2d_core
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    tf2_ros::tf2_ros
+  )
+  pluginlib_export_plugin_description_file(nav2_core src/error_codes/planner_plugins.xml)
+
+  install(TARGETS ${global_planner_plugin_lib}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+
+  install(FILES src/error_codes/planner_plugins.xml
+    DESTINATION share/${PROJECT_NAME}
+  )
+
+  set(smoother_plugin_lib smoother)
+
+  add_library(${smoother_plugin_lib} SHARED src/error_codes/smoother/smoother_error_plugin.cpp)
+  target_link_libraries(${smoother_plugin_lib} PRIVATE
+    nav2_core::nav2_core
+    nav2_costmap_2d::nav2_costmap_2d_core
+    ${nav_msgs_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    tf2_ros::tf2_ros
+  )
+  pluginlib_export_plugin_description_file(nav2_core src/error_codes/smoother_plugins.xml)
+
+  install(TARGETS ${smoother_plugin_lib}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+
+  install(FILES src/error_codes/smoother_plugins.xml
+    DESTINATION share/${PROJECT_NAME}
+  )
 
   add_subdirectory(src/behavior_tree)
   add_subdirectory(src/planning)
@@ -126,10 +122,6 @@ if(BUILD_TESTING)
   add_subdirectory(src/costmap_filters)
   add_subdirectory(src/error_codes)
   install(DIRECTORY maps models DESTINATION share/${PROJECT_NAME})
-
 endif()
 
-ament_export_libraries(${local_controller_plugin_lib})
-ament_export_libraries(${global_planner_plugin_lib})
-ament_export_libraries(${smoother_plugin_lib})
 ament_package()

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -10,58 +10,37 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclpy</build_depend>
-  <build_depend>nav2_util</build_depend>
-  <build_depend>nav2_map_server</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>nav2_lifecycle_manager</build_depend>
-  <build_depend>nav2_navfn_planner</build_depend>
-  <build_depend>nav2_behavior_tree</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>nav2_amcl</build_depend>
-  <build_depend>launch_ros</build_depend>
-  <build_depend>launch_testing</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>launch_ros</build_depend>
-  <build_depend>launch_testing</build_depend>
-  <build_depend>nav2_planner</build_depend>
-  <build_depend>nav2_minimal_tb3_sim</build_depend>
-
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>launch_testing</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>nav2_bringup</exec_depend>
-  <exec_depend>nav2_util</exec_depend>
-  <exec_depend>nav2_map_server</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>nav2_lifecycle_manager</exec_depend>
-  <exec_depend>nav2_navfn_planner</exec_depend>
-  <exec_depend>nav2_behavior_tree</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>nav2_amcl</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>nav2_minimal_tb3_sim</exec_depend>
-  <exec_depend>navigation2</exec_depend>
-  <exec_depend>lcov</exec_depend>
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>nav2_planner</exec_depend>
-
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
-  <test_depend>python3-zmq</test_depend>
+  <test_depend>lcov</test_depend>
+  <test_depend>nav2_amcl</test_depend>
+  <test_depend>nav2_behavior_tree</test_depend>
+  <test_depend>nav2_bringup</test_depend>
+  <test_depend>nav2_lifecycle_manager</test_depend>
+  <test_depend>nav2_map_server</test_depend>
+  <test_depend>nav2_minimal_tb3_sim</test_depend>
+  <test_depend>nav2_msgs</test_depend>
+  <test_depend>nav2_navfn_planner</test_depend>
+  <test_depend>nav2_planner</test_depend>
+  <test_depend>nav2_util</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>navigation2</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>tf2</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>visualization_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_system_tests/src/behavior_tree/CMakeLists.txt
+++ b/nav2_system_tests/src/behavior_tree/CMakeLists.txt
@@ -1,16 +1,14 @@
-find_package(Boost COMPONENTS system filesystem REQUIRED)
-
 ament_add_gtest(test_behavior_tree_node
   test_behavior_tree_node.cpp
   server_handler.cpp
 )
-
-ament_target_dependencies(test_behavior_tree_node
-  ${dependencies}
-)
-
-target_include_directories(test_behavior_tree_node PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(test_behavior_tree_node
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
+  ament_index_cpp::ament_index_cpp
+  behaviortree_cpp::behaviortree_cpp
+  ${geometry_msgs_TARGETS}
+  nav2_behavior_tree::nav2_behavior_tree
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
 )

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
-#include <vector>
-#include <string>
+#include <chrono>
 #include <fstream>
+#include <filesystem>
 #include <memory>
+#include <string>
 #include <utility>
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -31,16 +31,18 @@
 #include "tf2_ros/create_timer_ros.h"
 
 #include "nav2_util/odometry_utils.hpp"
+#include "nav2_util/string_utils.hpp"
 
 #include "nav2_behavior_tree/plugins_list.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
 #include "server_handler.hpp"
 
 using namespace std::chrono_literals;
-namespace fs = boost::filesystem;
 
 namespace nav2_system_tests
 {
@@ -61,8 +63,7 @@ public:
 
     odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(node_);
 
-    std::vector<std::string> plugin_libs;
-    boost::split(plugin_libs, nav2::details::BT_BUILTIN_PLUGINS, boost::is_any_of(";"));
+    nav2_util::Tokens plugin_libs = nav2_util::split(nav2::details::BT_BUILTIN_PLUGINS, ';');
 
     for (const auto & p : plugin_libs) {
       factory_.registerFromPlugin(BT::SharedLibrary::getOSName(p));
@@ -194,12 +195,12 @@ std::shared_ptr<BehaviorTreeHandler> BehaviorTreeTestFixture::bt_handler = nullp
 
 TEST_F(BehaviorTreeTestFixture, TestBTXMLFiles)
 {
-  fs::path root = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path root = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   root /= "behavior_trees/";
 
-  if (boost::filesystem::exists(root) && boost::filesystem::is_directory(root)) {
-    for (auto const & entry : boost::filesystem::recursive_directory_iterator(root)) {
-      if (boost::filesystem::is_regular_file(entry) && entry.path().extension() == ".xml") {
+  if (std::filesystem::exists(root) && std::filesystem::is_directory(root)) {
+    for (auto const & entry : std::filesystem::recursive_directory_iterator(root)) {
+      if (std::filesystem::is_regular_file(entry) && entry.path().extension() == ".xml") {
         std::cout << entry.path().string() << std::endl;
         EXPECT_EQ(bt_handler->loadBehaviorTree(entry.path().string()), true);
       }
@@ -216,7 +217,7 @@ TEST_F(BehaviorTreeTestFixture, TestBTXMLFiles)
 TEST_F(BehaviorTreeTestFixture, TestAllSuccess)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
@@ -258,7 +259,7 @@ TEST_F(BehaviorTreeTestFixture, TestAllSuccess)
 TEST_F(BehaviorTreeTestFixture, TestAllFailure)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
@@ -310,7 +311,7 @@ TEST_F(BehaviorTreeTestFixture, TestAllFailure)
 TEST_F(BehaviorTreeTestFixture, TestNavigateSubtreeRecoveries)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
@@ -364,7 +365,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateSubtreeRecoveries)
 TEST_F(BehaviorTreeTestFixture, TestNavigateRecoverySimple)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
@@ -458,7 +459,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoverySimple)
 TEST_F(BehaviorTreeTestFixture, TestNavigateRecoveryComplex)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
@@ -522,7 +523,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoveryComplex)
 TEST_F(BehaviorTreeTestFixture, TestRecoverySubtreeGoalUpdated)
 {
   // Load behavior tree from file
-  fs::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
   bt_file /= "behavior_trees/";
   bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
   EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);

--- a/nav2_system_tests/src/behaviors/assisted_teleop/CMakeLists.txt
+++ b/nav2_system_tests/src/behaviors/assisted_teleop/CMakeLists.txt
@@ -4,9 +4,17 @@ ament_add_gtest_executable(${test_assisted_teleop_behavior}
   test_assisted_teleop_behavior_node.cpp
   assisted_teleop_behavior_tester.cpp
 )
-
-ament_target_dependencies(${test_assisted_teleop_behavior}
-  ${dependencies}
+target_link_libraries(${test_assisted_teleop_behavior}
+  ${geometry_msgs_TARGETS}
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_util::nav2_util_core
+  ${nav2_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  ${std_msgs_TARGETS}
+  tf2::tf2
+  tf2_ros::tf2_ros
 )
 
 ament_add_test(test_assisted_teleop_behavior

--- a/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.hpp
+++ b/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.hpp
@@ -22,7 +22,6 @@
 #include <thread>
 #include <algorithm>
 
-#include "angles/angles.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"

--- a/nav2_system_tests/src/behaviors/wait/CMakeLists.txt
+++ b/nav2_system_tests/src/behaviors/wait/CMakeLists.txt
@@ -4,9 +4,15 @@ ament_add_gtest_executable(${test_wait_behavior_exec}
   test_wait_behavior_node.cpp
   wait_behavior_tester.cpp
 )
-
-ament_target_dependencies(${test_wait_behavior_exec}
-  ${dependencies}
+target_link_libraries(${test_wait_behavior_exec}
+  angles::angles
+  ${geometry_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  tf2::tf2
+  tf2_ros::tf2_ros
 )
 
 ament_add_test(test_wait_behavior

--- a/nav2_system_tests/src/behaviors/wait/wait_behavior_tester.hpp
+++ b/nav2_system_tests/src/behaviors/wait/wait_behavior_tester.hpp
@@ -25,7 +25,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
-#include "angles/angles.h"
 #include "nav2_msgs/action/wait.hpp"
 #include "nav2_util/robot_utils.hpp"
 #include "nav2_util/node_thread.hpp"

--- a/nav2_system_tests/src/dummy_controller/CMakeLists.txt
+++ b/nav2_system_tests/src/dummy_controller/CMakeLists.txt
@@ -2,12 +2,9 @@ add_executable(dummy_controller_node
   src/dummy_controller/main.cpp
   src/dummy_controller/dummy_controller.cpp
 )
-
-ament_target_dependencies(dummy_controller_node
-  rclcpp
-  std_msgs
-  nav2_util
-  nav2_behavior_tree
-  nav2_msgs
-  nav_msgs
+target_link_libraries(dummy_controller_node PRIVATE
+  ${geometry_msgs_TARGETS}
+  nav2_behavior_tree::nav2_behavior_tree
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
 )

--- a/nav2_system_tests/src/dummy_planner/CMakeLists.txt
+++ b/nav2_system_tests/src/dummy_planner/CMakeLists.txt
@@ -2,12 +2,7 @@ add_executable(dummy_planner_node
   src/dummy_planner/main.cpp
   src/dummy_planner/dummy_planner.cpp
 )
-
-ament_target_dependencies(dummy_planner_node
-  rclcpp
-  std_msgs
-  nav2_util
-  nav2_behavior_tree
-  nav2_msgs
-  nav_msgs
+target_link_libraries(dummy_planner_node PRIVATE
+  nav2_behavior_tree::nav2_behavior_tree
+  rclcpp::rclcpp
 )

--- a/nav2_system_tests/src/localization/CMakeLists.txt
+++ b/nav2_system_tests/src/localization/CMakeLists.txt
@@ -1,10 +1,10 @@
 ament_add_gtest_executable(test_localization_node
   test_localization_node.cpp
 )
-ament_target_dependencies(test_localization_node
-  ${dependencies}
+target_link_libraries(test_localization_node
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
 )
-
 
 ament_add_test(test_localization
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -15,12 +15,10 @@
 #include <memory>
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include "nav2_amcl/amcl_node.hpp"
-#include "std_msgs/msg/string.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-using std::placeholders::_1;
 using namespace std::chrono_literals;
 
 // rclcpp::init can only be called once per process, so this needs to be a global variable
@@ -52,7 +50,7 @@ public:
       "initialpose", rclcpp::SystemDefaultsQoS());
     subscription_ = node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
       "amcl_pose", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
-      std::bind(&TestAmclPose::amcl_pose_callback, this, _1));
+      std::bind(&TestAmclPose::amcl_pose_callback, this, std::placeholders::_1));
     initial_pose_pub_->publish(testPose_);
   }
 

--- a/nav2_system_tests/src/planning/CMakeLists.txt
+++ b/nav2_system_tests/src/planning/CMakeLists.txt
@@ -4,12 +4,18 @@ ament_add_gtest_executable(${test_planner_costmaps_exec}
   test_planner_costmaps_node.cpp
   planner_tester.cpp
 )
-
 target_link_libraries(${test_planner_costmaps_exec}
-  ${nav2_map_server_LIBRARIES})
-
-ament_target_dependencies(${test_planner_costmaps_exec}
-  ${dependencies}
+  ${geometry_msgs_TARGETS}
+  nav2_map_server::map_io
+  nav2_map_server::map_server_core
+  ${nav2_msgs_TARGETS}
+  nav2_planner::planner_server_core
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
 )
 
 set(test_planner_random_exec test_planner_random_node)
@@ -18,13 +24,19 @@ ament_add_gtest_executable(${test_planner_random_exec}
   test_planner_random_node.cpp
   planner_tester.cpp
 )
-
-ament_target_dependencies(${test_planner_random_exec}
-  ${dependencies}
-)
-
 target_link_libraries(${test_planner_random_exec}
-  ${nav2_map_server_LIBRARIES})
+  ${geometry_msgs_TARGETS}
+  nav2_map_server::map_io
+  nav2_map_server::map_server_core
+  ${nav2_msgs_TARGETS}
+  nav2_planner::planner_server_core
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
+)
 
 ament_add_test(test_planner_costmaps
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
@@ -47,14 +59,36 @@ ament_add_test(test_planner_random
 )
 
 ament_add_gtest(test_planner_plugins
+  planner_tester.cpp
   test_planner_plugins.cpp
   TIMEOUT 10
 )
-
-ament_target_dependencies(test_planner_plugins rclcpp geometry_msgs nav2_msgs ${dependencies})
+target_link_libraries(test_planner_plugins
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  nav2_map_server::map_io
+  nav2_map_server::map_server_core
+  ${nav2_msgs_TARGETS}
+  nav2_planner::planner_server_core
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+)
 
 ament_add_gtest(test_planner_is_path_valid
-              test_planner_is_path_valid.cpp
-              planner_tester.cpp)
-
-ament_target_dependencies(test_planner_is_path_valid rclcpp geometry_msgs nav2_msgs ${dependencies})
+  planner_tester.cpp
+  test_planner_is_path_valid.cpp
+)
+target_link_libraries(test_planner_is_path_valid
+  ${geometry_msgs_TARGETS}
+  nav2_map_server::map_io
+  nav2_map_server::map_server_core
+  ${nav2_msgs_TARGETS}
+  nav2_planner::planner_server_core
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  tf2_ros::tf2_ros
+)

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -22,18 +22,15 @@
 #include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
 #include "nav2_msgs/action/compute_path_to_pose.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
 #include "nav2_msgs/srv/is_path_valid.hpp"
-#include "visualization_msgs/msg/marker.hpp"
 #include "nav2_util/costmap.hpp"
 #include "nav2_util/node_thread.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "tf2_msgs/msg/tf_message.hpp"
 #include "nav2_planner/planner_server.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 

--- a/nav2_system_tests/src/planning/test_planner_is_path_valid.cpp
+++ b/nav2_system_tests/src/planning/test_planner_is_path_valid.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <vector>
 
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_msgs/srv/is_path_valid.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "planner_tester.hpp"

--- a/nav2_system_tests/src/planning/test_planner_plugins.cpp
+++ b/nav2_system_tests/src/planning/test_planner_plugins.cpp
@@ -17,6 +17,8 @@
 #include <vector>
 #include <string>
 
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav_msgs/msg/path.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "planner_tester.hpp"
 #include "nav2_util/lifecycle_utils.hpp"

--- a/nav2_system_tests/src/updown/CMakeLists.txt
+++ b/nav2_system_tests/src/updown/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(test_updown
   test_updown.cpp
 )
-
-ament_target_dependencies(test_updown
-  ${dependencies}
+target_link_libraries(test_updown PRIVATE
+  ${geometry_msgs_TARGETS}
+  nav2_lifecycle_manager::nav2_lifecycle_manager_core
+  rclcpp::rclcpp
 )
 
 install(TARGETS test_updown RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(FILES test_updown_launch.py DESTINATION share/${PROJECT_NAME})
-

--- a/nav2_system_tests/src/updown/test_updown.cpp
+++ b/nav2_system_tests/src/updown/test_updown.cpp
@@ -19,7 +19,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_lifecycle_manager/lifecycle_manager_client.hpp"
-#include "rcutils/cmdline_parser.h"
+#include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Update nav2_system_tests to use modern CMake idioms:
1.  Make everything in this package a `test_depend`, since this is all tests.
2.  Along with the previous point, move everything in this package under the BUILD_TESTING conditional in CMake.
3.  Switch from ament_target_dependencies to target_link_libraries everywhere.
4.  Remove all references to Boost.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is part of a larger series updating Navigation2 to use modern CMake idioms.  After this PR, there are 2 PRs left to open.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
