### PR TITLE
Switch nav2_waypoint_follower to modern CMake idioms.

### DIFF
--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -1,87 +1,126 @@
 cmake_minimum_required(VERSION 3.5)
 project(nav2_waypoint_follower)
 
-# Try for OpenCV 4.X, but settle for whatever is installed
-find_package(OpenCV 4 QUIET)
-if(NOT OpenCV_FOUND)
-  find_package(OpenCV REQUIRED)
-endif()
-message(STATUS "Found OpenCV version ${OpenCV_VERSION}")
-
-find_package(image_transport REQUIRED)
-find_package(cv_bridge REQUIRED)
 find_package(ament_cmake REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(image_transport REQUIRED)
 find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(nav_msgs REQUIRED)
+find_package(nav2_core REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(nav2_core REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(robot_localization REQUIRED)
-find_package(geographic_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
-include_directories(
-  include
-)
-
 set(executable_name waypoint_follower)
-
-add_executable(${executable_name}
-  src/main.cpp
-)
 
 set(library_name ${executable_name}_core)
 
 add_library(${library_name} SHARED
   src/waypoint_follower.cpp
 )
-
-set(dependencies
-  rclcpp
-  rclcpp_action
-  rclcpp_lifecycle
-  rclcpp_components
-  nav_msgs
-  nav2_msgs
-  nav2_util
-  tf2_ros
-  nav2_core
-  pluginlib
-  image_transport
-  cv_bridge
-  OpenCV
-  robot_localization
+target_include_directories(${library_name} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  ${geographic_msgs_TARGETS}
+  nav2_core::nav2_core
+  ${nav2_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  ${nav_msgs_TARGETS}
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  rclcpp_lifecycle::rclcpp_lifecycle
+  robot_localization::rl_lib
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${library_name} PRIVATE
+  rclcpp_components::component
 )
 
-ament_target_dependencies(${executable_name}
-  ${dependencies}
+add_executable(${executable_name}
+  src/main.cpp
 )
-
-target_link_libraries(${executable_name} ${library_name})
-
-ament_target_dependencies(${library_name}
-  ${dependencies}
+target_include_directories(${executable_name} PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${executable_name} PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
 )
 
 add_library(wait_at_waypoint SHARED plugins/wait_at_waypoint.cpp)
-ament_target_dependencies(wait_at_waypoint ${dependencies})
+target_include_directories(wait_at_waypoint PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(wait_at_waypoint PUBLIC
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  nav2_core::nav2_core
+)
+target_link_libraries(wait_at_waypoint PRIVATE
+  pluginlib::pluginlib
+  nav2_util::nav2_util_core
+)
 
 add_library(photo_at_waypoint SHARED plugins/photo_at_waypoint.cpp)
-ament_target_dependencies(photo_at_waypoint ${dependencies})
+target_include_directories(photo_at_waypoint PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(photo_at_waypoint PUBLIC
+  cv_bridge::cv_bridge
+  ${geometry_msgs_TARGETS}
+  image_transport::image_transport
+  nav2_core::nav2_core
+  opencv_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+)
+target_link_libraries(photo_at_waypoint PRIVATE
+  nav2_util::nav2_util_core
+  pluginlib::pluginlib
+)
 
 add_library(input_at_waypoint SHARED plugins/input_at_waypoint.cpp)
-ament_target_dependencies(input_at_waypoint ${dependencies})
+target_include_directories(input_at_waypoint PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(input_at_waypoint PUBLIC
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${std_msgs_TARGETS}
+)
+target_link_libraries(input_at_waypoint PRIVATE
+  pluginlib::pluginlib
+  nav2_util::nav2_util_core
+)
 
 rclcpp_components_register_nodes(${library_name} "nav2_waypoint_follower::WaypointFollower")
 
 install(TARGETS ${library_name} wait_at_waypoint photo_at_waypoint input_at_waypoint
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -92,19 +131,40 @@ install(TARGETS ${executable_name}
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_find_gtest()
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(wait_at_waypoint photo_at_waypoint input_at_waypoint ${library_name})
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  cv_bridge
+  geographic_msgs
+  geometry_msgs
+  image_transport
+  nav2_core
+  nav2_msgs
+  nav2_util
+  nav_msgs
+  OpenCV
+  pluginlib
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  robot_localization
+  sensor_msgs
+  std_msgs
+  tf2_ros
+)
+ament_export_targets(${PROJECT_NAME})
 pluginlib_export_plugin_description_file(nav2_waypoint_follower plugins.xml)
 
 ament_package()

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
@@ -15,20 +15,12 @@
 #ifndef NAV2_WAYPOINT_FOLLOWER__PLUGINS__PHOTO_AT_WAYPOINT_HPP_
 #define NAV2_WAYPOINT_FOLLOWER__PLUGINS__PHOTO_AT_WAYPOINT_HPP_
 
-/**
- * While C++17 isn't the project standard. We have to force LLVM/CLang
- * to ignore deprecated declarations
- */
-#define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
-
-
 #include <filesystem>
 #include <mutex>
 #include <string>
 #include <exception>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_components/register_node_macro.hpp"
 
 #include "sensor_msgs/msg/image.hpp"
 #include "nav2_core/waypoint_task_executor.hpp"

--- a/nav2_waypoint_follower/package.xml
+++ b/nav2_waypoint_follower/package.xml
@@ -8,26 +8,29 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
 
-  <depend>nav2_common</depend>
   <depend>cv_bridge</depend>
-  <depend>pluginlib</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
-  <depend>rclcpp_lifecycle</depend>
-  <depend>nav_msgs</depend>
+  <depend>nav2_core</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
-  <depend>nav2_core</depend>
-  <depend>tf2_ros</depend>
+  <depend>nav_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>robot_localization</depend>
-  <depend>geographic_msgs</depend> 
-  
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_ros</depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_waypoint_follower/test/CMakeLists.txt
+++ b/nav2_waypoint_follower/test/CMakeLists.txt
@@ -2,20 +2,25 @@
 ament_add_gtest(test_task_executors
   test_task_executors.cpp
 )
-ament_target_dependencies(test_task_executors
-  ${dependencies}
-)
 target_link_libraries(test_task_executors
-  ${library_name} wait_at_waypoint photo_at_waypoint input_at_waypoint
+  ${library_name}
+  wait_at_waypoint
+  photo_at_waypoint
+  input_at_waypoint
+  ${geometry_msgs_TARGETS}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
 )
 
 # Test dynamic parameters
 ament_add_gtest(test_dynamic_parameters
   test_dynamic_parameters.cpp
 )
-ament_target_dependencies(test_dynamic_parameters
-  ${dependencies}
-)
 target_link_libraries(test_dynamic_parameters
   ${library_name}
+  nav2_util::nav2_util_core
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Follow-up to #4357  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Change nav2_waypoint_follower to modern CMake idioms:
1.  Switch from ament_target_dependencies to target_link_libraries.
2.  Export a CMake target so downstream packages can use it.
3.  Push the include directories down one level, which has been best practice since Humble.

Note well that this will fail to compile until https://github.com/cra-ros-pkg/robot_localization/pull/895 is merged, released, and synced into Rolling.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

This is the last of the series to convert Navigation2 to modern CMake idioms.  One suggestion I might make is to attempt to release the `main` branch of Navigation2 into Rolling to make sure we've gotten all of the dependencies correct.  Short of that, this should be the end of this particular series.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
