### PR TITLE
Fix: Ensure `server_timeout` Respects Default Values Using `getInputPortOrBlackboard()`

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -58,9 +58,7 @@ public:
     // Get the required items from the blackboard
     auto bt_loop_duration =
       config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
-    server_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
-    getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
+    getInputOrBlackboard("server_timeout", server_timeout_);
     wait_for_service_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("wait_for_service_timeout");
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
@@ -56,9 +56,7 @@ public:
     callback_group_executor_.add_callback_group(callback_group_, node_->get_node_base_interface());
 
     // Get the required items from the blackboard
-    server_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
-    getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
+    getInputOrBlackboard("server_timeout", server_timeout_);
     wait_for_service_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("wait_for_service_timeout");
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -59,9 +59,7 @@ public:
     // Get the required items from the blackboard
     auto bt_loop_duration =
       config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
-    server_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
-    getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
+    getInputOrBlackboard("server_timeout", server_timeout_);
     wait_for_service_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("wait_for_service_timeout");
 


### PR DESCRIPTION
## Basic Info

| Info | Details |
| ------ | ----------- |
| **Ticket(s) this addresses** | #4618 |
| **Primary OS tested on** | Ubuntu 22.04 |
| **Robotic platform tested on** | Gazebo simulation, Turtlebot3 hardware |
| **Does this PR contain AI generated software?** | No |

---

## Description of contribution in a few bullet points

- Updated `bt_action_node`, `bt_cancel_action_node`, and `bt_service_node` to use `getInputPortOrBlackboard()` for initializing `server_timeout`.
- Ensured that the `server_timeout` parameter now respects the default value from the blackboard if not explicitly set in the BT action node.
- This change addresses the issue where the `default_server_timeout` was always overridden, leading to more consistent behavior and reducing configuration overhead.

## Description of documentation updates required from your changes

- No new parameters were added, so no updates to default configs are necessary.

---

## Future work that may be required in bullet points

- Further testing on different robotic platforms to ensure compatibility.
- Potential optimizations in the BT nodes to enhance performance.
- Documentation updates in case of additional related changes in the future.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins are added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for Groot, BT package's readme table, and BT library lists
