### PR TITLE
[DWB] Option to limit velocity commands in trajectory generator

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -147,7 +147,7 @@ protected:
   /// @brief the name of the overlying plugin ID
   std::string plugin_name_;
 
-  /// @brief Option to limit velocity in the trajectory generator by using current velocity for trajectory
+  /// @brief Option to limit velocity in the trajectory generator by using current velocity
   bool limit_vel_cmd_in_traj_;
 
   /* Backwards Compatibility Parameter: include_last_point

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -147,6 +147,9 @@ protected:
   /// @brief the name of the overlying plugin ID
   std::string plugin_name_;
 
+  /// @brief Option to limit velocity in the trajectory generator by using current velocity over current velocity in trajectory
+  bool limit_vel_cmd_in_traj_;
+
   /* Backwards Compatibility Parameter: include_last_point
    *
    * dwa had an off-by-one error built into it.

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -147,7 +147,7 @@ protected:
   /// @brief the name of the overlying plugin ID
   std::string plugin_name_;
 
-  /// @brief Option to limit velocity in the trajectory generator by using current velocity over current velocity in trajectory
+  /// @brief Option to limit velocity in the trajectory generator by using current velocity for trajectory
   bool limit_vel_cmd_in_traj_;
 
   /* Backwards Compatibility Parameter: include_last_point

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -166,8 +166,8 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);
     if (!first_vel && limit_vel_cmd_in_traj_) {
-        traj.velocity = vel;
-        first_vel = true;
+      traj.velocity = vel;
+      first_vel = true;
     }
 
     //  update the position of the robot using the velocities passed in

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -158,8 +158,6 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   //  simulate the trajectory
   geometry_msgs::msg::Pose2D pose = start_pose;
   nav_2d_msgs::msg::Twist2D vel = start_vel;
-
-  
   double running_time = 0.0;
   std::vector<double> steps = getTimeSteps(cmd_vel);
   traj.poses.push_back(start_pose);

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -165,7 +165,7 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   for (double dt : steps) {
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);
-    if(!first_vel && limit_vel_cmd_in_traj_){
+    if (!first_vel && limit_vel_cmd_in_traj_) {
         traj.velocity = vel;
         first_vel = true;
     }

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -75,6 +75,10 @@ void StandardTrajectoryGenerator::initialize(
     nh,
     plugin_name + ".include_last_point", rclcpp::ParameterValue(true));
 
+  nav2_util::declare_parameter_if_not_declared(
+    nh,
+    plugin_name + ".limit_vel_cmd_in_traj_", rclcpp::ParameterValue(false));
+
   /*
    * If discretize_by_time, then sim_granularity represents the amount of time that should be between
    *  two successive points on the trajectory.
@@ -89,6 +93,7 @@ void StandardTrajectoryGenerator::initialize(
   nh->get_parameter(plugin_name + ".linear_granularity", linear_granularity_);
   nh->get_parameter(plugin_name + ".angular_granularity", angular_granularity_);
   nh->get_parameter(plugin_name + ".include_last_point", include_last_point_);
+  nh->get_parameter(plugin_name + ".limit_vel_cmd_in_traj_", limit_vel_cmd_in_traj_);
 }
 
 void StandardTrajectoryGenerator::initializeIterator(
@@ -153,12 +158,19 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   //  simulate the trajectory
   geometry_msgs::msg::Pose2D pose = start_pose;
   nav_2d_msgs::msg::Twist2D vel = start_vel;
+
+  
   double running_time = 0.0;
   std::vector<double> steps = getTimeSteps(cmd_vel);
   traj.poses.push_back(start_pose);
+  bool firstVel = false;
   for (double dt : steps) {
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);
+    if(!firstVel && limit_vel_cmd_in_traj_){
+        traj.velocity = vel;
+        firstVel = true;
+    }
 
     //  update the position of the robot using the velocities passed in
     pose = computeNewPosition(pose, vel, dt);

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -77,7 +77,7 @@ void StandardTrajectoryGenerator::initialize(
 
   nav2_util::declare_parameter_if_not_declared(
     nh,
-    plugin_name + ".limit_vel_cmd_in_traj_", rclcpp::ParameterValue(false));
+    plugin_name + ".limit_vel_cmd_in_traj", rclcpp::ParameterValue(false));
 
   /*
    * If discretize_by_time, then sim_granularity represents the amount of time that should be between
@@ -93,7 +93,7 @@ void StandardTrajectoryGenerator::initialize(
   nh->get_parameter(plugin_name + ".linear_granularity", linear_granularity_);
   nh->get_parameter(plugin_name + ".angular_granularity", angular_granularity_);
   nh->get_parameter(plugin_name + ".include_last_point", include_last_point_);
-  nh->get_parameter(plugin_name + ".limit_vel_cmd_in_traj_", limit_vel_cmd_in_traj_);
+  nh->get_parameter(plugin_name + ".limit_vel_cmd_in_traj", limit_vel_cmd_in_traj_);
 }
 
 void StandardTrajectoryGenerator::initializeIterator(
@@ -161,13 +161,13 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   double running_time = 0.0;
   std::vector<double> steps = getTimeSteps(cmd_vel);
   traj.poses.push_back(start_pose);
-  bool firstVel = false;
+  bool first_vel = false;
   for (double dt : steps) {
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);
-    if(!firstVel && limit_vel_cmd_in_traj_){
+    if(!first_vel && limit_vel_cmd_in_traj_){
         traj.velocity = vel;
-        firstVel = true;
+        first_vel = true;
     }
 
     //  update the position of the robot using the velocities passed in


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Issue #3277 |
| Primary OS tested on | Ubuntu 22.04|
| Robotic platform tested on | Turtlebot3 Gazebo simulation - waffle |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
- Added an option in the standard trajectory generator in DWB to allow the user to limit the velocity command in the trajectory 
-based on current trajectory through a new parameter (`limit_vel_cmd_in_traj_`)
- This option ensures that the acceleration constraints are respected in the event there is a large difference between the current and commanded velocity - which may be more useful when there is no velocity smoother in use
- `limit_vel_cmd_in_traj_` is set to false by default, but when set to true, would use the first velocity computed in the trajectory rollout as the trajectory velocity

Default behavior: 
![dev_default](https://github.com/user-attachments/assets/0259c2b5-06b2-42ee-86d6-eb73da14de23)

When `limit_vel_cmd_in_traj_` is set to `true`:
![proposed_default](https://github.com/user-attachments/assets/4313e983-416c-48eb-94e0-c4470fc513a4)

We observed slightly improved velocity tracking, and similar time to reach the same goal setting this parameter to true.

## Description of documentation updates required from your changes
- Added parameter `limit_vel_cmd_in_traj_` to DWB local planner (in standard trajectory generator)
---

## Future work that may be required in bullet points
- This parameter could also be extensible to other trajectory generation methods within DWB

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
