### PR TITLE
Improvements in RemoveInCollisionGoals and adjacent features

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
@@ -52,17 +52,23 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts({
+    return providedBasicPorts(
+      {
         BT::InputPort<Goals>("input_goals", "Original goals to remove from"),
-        BT::InputPort<double>("cost_threshold", 254.0,
+        BT::InputPort<double>(
+          "cost_threshold", 254.0,
           "Cost threshold for considering a goal in collision"),
         BT::InputPort<bool>("use_footprint", true, "Whether to use footprint cost"),
+        BT::InputPort<bool>(
+          "consider_unknown_as_obstacle", false,
+          "Whether to consider unknown cost as obstacle"),
         BT::OutputPort<Goals>("output_goals", "Goals with in-collision goals removed"),
-    });
+      });
   }
 
 private:
   bool use_footprint_;
+  bool consider_unknown_as_obstacle_;
   double cost_threshold_;
   Goals input_goals_;
 };

--- a/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
@@ -37,6 +37,7 @@ void RemoveInCollisionGoals::on_tick()
   getInput("use_footprint", use_footprint_);
   getInput("cost_threshold", cost_threshold_);
   getInput("input_goals", input_goals_);
+  getInput("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
 
   if (input_goals_.empty()) {
     setOutput("output_goals", input_goals_);
@@ -47,22 +48,32 @@ void RemoveInCollisionGoals::on_tick()
   request_->use_footprint = use_footprint_;
 
   for (const auto & goal : input_goals_) {
-    geometry_msgs::msg::Pose2D pose;
-    pose.x = goal.pose.position.x;
-    pose.y = goal.pose.position.y;
-    pose.theta = tf2::getYaw(goal.pose.orientation);
-    request_->poses.push_back(pose);
+    request_->poses.push_back(goal);
   }
 }
 
 BT::NodeStatus RemoveInCollisionGoals::on_completion(
   std::shared_ptr<nav2_msgs::srv::GetCosts::Response> response)
 {
+  for (size_t i = 0; i < input_goals_.size(); ++i) {
+    double yaw = tf2::getYaw(input_goals_[i].pose.orientation);
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Goal %ld: x: %f, y: %f, yaw: %f, costs: %f", i,
+      input_goals_[i].pose.position.x, input_goals_[i].pose.position.y, yaw, response->costs[i]);
+  }
+
   Goals valid_goal_poses;
   for (size_t i = 0; i < response->costs.size(); ++i) {
-    if (response->costs[i] < cost_threshold_) {
+    if ((response->costs[i] == 255 && !consider_unknown_as_obstacle_) || response->costs[i] < cost_threshold_) {
       valid_goal_poses.push_back(input_goals_[i]);
     }
+  }
+  // Warn if all goals have been removed
+  if (valid_goal_poses.empty()) {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "All goals are in collision and have been removed from the list");
   }
   setOutput("output_goals", valid_goal_poses);
   return BT::NodeStatus::SUCCESS;

--- a/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
@@ -65,7 +65,9 @@ BT::NodeStatus RemoveInCollisionGoals::on_completion(
 
   Goals valid_goal_poses;
   for (size_t i = 0; i < response->costs.size(); ++i) {
-    if ((response->costs[i] == 255 && !consider_unknown_as_obstacle_) || response->costs[i] < cost_threshold_) {
+    if ((response->costs[i] == 255 && !consider_unknown_as_obstacle_) ||
+      response->costs[i] < cost_threshold_)
+    {
       valid_goal_poses.push_back(input_goals_[i]);
     }
   }

--- a/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
@@ -55,14 +55,6 @@ void RemoveInCollisionGoals::on_tick()
 BT::NodeStatus RemoveInCollisionGoals::on_completion(
   std::shared_ptr<nav2_msgs::srv::GetCosts::Response> response)
 {
-  for (size_t i = 0; i < input_goals_.size(); ++i) {
-    double yaw = tf2::getYaw(input_goals_[i].pose.orientation);
-    RCLCPP_INFO(
-      node_->get_logger(),
-      "Goal %ld: x: %f, y: %f, yaw: %f, costs: %f", i,
-      input_goals_[i].pose.position.x, input_goals_[i].pose.position.y, yaw, response->costs[i]);
-  }
-
   Goals valid_goal_poses;
   for (size_t i = 0; i < response->costs.size(); ++i) {
     if ((response->costs[i] == 255 && !consider_unknown_as_obstacle_) ||
@@ -71,9 +63,9 @@ BT::NodeStatus RemoveInCollisionGoals::on_completion(
       valid_goal_poses.push_back(input_goals_[i]);
     }
   }
-  // Warn if all goals have been removed
+  // Inform if all goals have been removed
   if (valid_goal_poses.empty()) {
-    RCLCPP_WARN(
+    RCLCPP_INFO(
       node_->get_logger(),
       "All goals are in collision and have been removed from the list");
   }

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -862,7 +862,8 @@ void Costmap2DROS::getCostsCallback(
           pose_transformed.pose.position.y, yaw, footprint));
     } else {
       RCLCPP_DEBUG(
-        get_logger(), "Received request to get cost at point (%f, %f)", pose_transformed.pose.position.x,
+        get_logger(), "Received request to get cost at point (%f, %f)",
+          pose_transformed.pose.position.x,
         pose_transformed.pose.position.y);
 
       // Get the cost at the map coordinates

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -843,7 +843,7 @@ void Costmap2DROS::getCostsCallback(
       pose_transformed.pose.position.y, mx, my);
 
     if (!in_bounds) {
-      response->costs.push_back(costmap->getDefaultValue());
+      response->costs.push_back(NO_INFORMATION);
       continue;
     }
     double yaw = tf2::getYaw(pose_transformed.pose.orientation);

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -254,7 +254,8 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Service to get the cost at a point
   get_cost_service_ = create_service<nav2_msgs::srv::GetCosts>(
     "get_cost_" + getName(),
-    std::bind(&Costmap2DROS::getCostsCallback, this, std::placeholders::_1, std::placeholders::_2,
+    std::bind(
+      &Costmap2DROS::getCostsCallback, this, std::placeholders::_1, std::placeholders::_2,
       std::placeholders::_3));
 
   // Add cleaning service
@@ -835,12 +836,17 @@ void Costmap2DROS::getCostsCallback(
   Costmap2D * costmap = layered_costmap_->getCostmap();
 
   for (const auto & pose : request->poses) {
-    bool in_bounds = costmap->worldToMap(pose.x, pose.y, mx, my);
+    geometry_msgs::msg::PoseStamped pose_transformed;
+    transformPoseToGlobalFrame(pose, pose_transformed);
+    bool in_bounds = costmap->worldToMap(
+      pose_transformed.pose.position.x,
+      pose_transformed.pose.position.y, mx, my);
 
     if (!in_bounds) {
-      response->costs.push_back(-1.0);
+      response->costs.push_back(costmap->getDefaultValue());
       continue;
     }
+    double yaw = tf2::getYaw(pose_transformed.pose.orientation);
 
     if (request->use_footprint) {
       Footprint footprint = layered_costmap_->getFootprint();
@@ -848,13 +854,16 @@ void Costmap2DROS::getCostsCallback(
 
       RCLCPP_DEBUG(
         get_logger(), "Received request to get cost at footprint pose (%.2f, %.2f, %.2f)",
-        pose.x, pose.y, pose.theta);
+        pose_transformed.pose.position.x, pose_transformed.pose.position.y, yaw);
 
       response->costs.push_back(
-        collision_checker.footprintCostAtPose(pose.x, pose.y, pose.theta, footprint));
+        collision_checker.footprintCostAtPose(
+          pose_transformed.pose.position.x,
+          pose_transformed.pose.position.y, yaw, footprint));
     } else {
       RCLCPP_DEBUG(
-        get_logger(), "Received request to get cost at point (%f, %f)", pose.x, pose.y);
+        get_logger(), "Received request to get cost at point (%f, %f)", pose_transformed.pose.position.x,
+        pose_transformed.pose.position.y);
 
       // Get the cost at the map coordinates
       response->costs.push_back(static_cast<float>(costmap->getCost(mx, my)));

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -72,11 +72,11 @@ LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bo
   footprint_(std::make_shared<std::vector<geometry_msgs::msg::Point>>())
 {
   if (track_unknown) {
-    primary_costmap_.setDefaultValue(255);
-    combined_costmap_.setDefaultValue(255);
+    primary_costmap_.setDefaultValue(NO_INFORMATION);
+    combined_costmap_.setDefaultValue(NO_INFORMATION);
   } else {
-    primary_costmap_.setDefaultValue(0);
-    combined_costmap_.setDefaultValue(0);
+    primary_costmap_.setDefaultValue(FREE_SPACE);
+    combined_costmap_.setDefaultValue(FREE_SPACE);
   }
 }
 

--- a/nav2_costmap_2d/test/unit/costmap_cost_service_test.cpp
+++ b/nav2_costmap_2d/test/unit/costmap_cost_service_test.cpp
@@ -50,9 +50,9 @@ protected:
 TEST_F(GetCostServiceTest, TestWithoutFootprint)
 {
   auto request = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
-  geometry_msgs::msg::Pose2D pose;
-  pose.x = 0.5;
-  pose.y = 1.0;
+  geometry_msgs::msg::PoseStamped pose;
+  pose.pose.position.x = 0.5;
+  pose.pose.position.y = 1.0;
   request->poses.push_back(pose);
   request->use_footprint = false;
 
@@ -72,10 +72,12 @@ TEST_F(GetCostServiceTest, TestWithoutFootprint)
 TEST_F(GetCostServiceTest, TestWithFootprint)
 {
   auto request = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
-  geometry_msgs::msg::Pose2D pose;
-  pose.x = 0.5;
-  pose.y = 1.0;
-  pose.theta = 0.5;
+  geometry_msgs::msg::PoseStamped pose;
+  pose.pose.position.x = 0.5;
+  pose.pose.position.y = 1.0;
+  tf2::Quaternion q;
+  q.setRPY(0, 0, 0.5);
+  pose.pose.orientation = tf2::toMsg(q);
   request->poses.push_back(pose);
   request->use_footprint = true;
 

--- a/nav2_msgs/srv/GetCosts.srv
+++ b/nav2_msgs/srv/GetCosts.srv
@@ -1,6 +1,6 @@
 # Get costmap costs at given poses
 
 bool use_footprint
-geometry_msgs/Pose2D[] poses
+geometry_msgs/PoseStamped[] poses
 ---
 float32[] costs

--- a/nav2_rviz_plugins/src/costmap_cost_tool.cpp
+++ b/nav2_rviz_plugins/src/costmap_cost_tool.cpp
@@ -96,21 +96,24 @@ void CostmapCostTool::callCostService(float x, float y)
 {
   // Create request for local costmap
   auto request = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
-  geometry_msgs::msg::Pose2D pose;
-  pose.x = x;
-  pose.y = y;
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = context_->getFixedFrame().toStdString();
+  pose.pose.position.x = x;
+  pose.pose.position.y = y;
   request->poses.push_back(pose);
   request->use_footprint = false;
 
   // Call local costmap service
   if (local_cost_client_->wait_for_service(std::chrono::seconds(1))) {
-    local_cost_client_->async_send_request(request,
+    local_cost_client_->async_send_request(
+      request,
       std::bind(&CostmapCostTool::handleLocalCostResponse, this, std::placeholders::_1));
   }
 
   // Call global costmap service
   if (global_cost_client_->wait_for_service(std::chrono::seconds(1))) {
-    global_cost_client_->async_send_request(request,
+    global_cost_client_->async_send_request(
+      request,
       std::bind(&CostmapCostTool::handleGlobalCostResponse, this, std::placeholders::_1));
   }
 }
@@ -120,11 +123,7 @@ void CostmapCostTool::handleLocalCostResponse(
 {
   rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   auto response = future.get();
-  if (response->costs[0] != -1) {
-    RCLCPP_INFO(node->get_logger(), "Local costmap cost: %.1f", response->costs[0]);
-  } else {
-    RCLCPP_ERROR(node->get_logger(), "Failed to get local costmap cost");
-  }
+  RCLCPP_INFO(node_->get_logger(), "Local costmap cost: %.1f", response->costs[0]);
 }
 
 void CostmapCostTool::handleGlobalCostResponse(
@@ -132,11 +131,7 @@ void CostmapCostTool::handleGlobalCostResponse(
 {
   rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   auto response = future.get();
-  if (response->costs[0] != -1) {
-    RCLCPP_INFO(node->get_logger(), "Global costmap cost: %.1f", response->costs[0]);
-  } else {
-    RCLCPP_ERROR(node->get_logger(), "Failed to get global costmap cost");
-  }
+  RCLCPP_INFO(node_->get_logger(), "Global costmap cost: %.1f", response->costs[0]);
 }
 }  // namespace nav2_rviz_plugins
 

--- a/nav2_rviz_plugins/src/costmap_cost_tool.cpp
+++ b/nav2_rviz_plugins/src/costmap_cost_tool.cpp
@@ -123,7 +123,7 @@ void CostmapCostTool::handleLocalCostResponse(
 {
   rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   auto response = future.get();
-  RCLCPP_INFO(node_->get_logger(), "Local costmap cost: %.1f", response->costs[0]);
+  RCLCPP_INFO(node->get_logger(), "Local costmap cost: %.1f", response->costs[0]);
 }
 
 void CostmapCostTool::handleGlobalCostResponse(
@@ -131,7 +131,7 @@ void CostmapCostTool::handleGlobalCostResponse(
 {
   rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   auto response = future.get();
-  RCLCPP_INFO(node_->get_logger(), "Global costmap cost: %.1f", response->costs[0]);
+  RCLCPP_INFO(node->get_logger(), "Global costmap cost: %.1f", response->costs[0]);
 }
 }  // namespace nav2_rviz_plugins
 

--- a/nav2_rviz_plugins/src/costmap_cost_tool.cpp
+++ b/nav2_rviz_plugins/src/costmap_cost_tool.cpp
@@ -94,10 +94,12 @@ int CostmapCostTool::processMouseEvent(rviz_common::ViewportMouseEvent & event)
 
 void CostmapCostTool::callCostService(float x, float y)
 {
+  rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   // Create request for local costmap
   auto request = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
   geometry_msgs::msg::PoseStamped pose;
   pose.header.frame_id = context_->getFixedFrame().toStdString();
+  pose.header.stamp = node->now();
   pose.pose.position.x = x;
   pose.pose.position.y = y;
   request->poses.push_back(pose);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu, |
| Robotic platform tested on | custom gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Change GetCosts to use PoseStamped instead of Pose2D so that we can use the frame_id to transform the pose in the costmap frame
* Added consider_unknown_as_obstacle to control whether NO_INFORMATION is treated as "in collision" or not
* Make GetCosts service return 255.0 instead of -1.0 if the coords are out of bounds
* fix rviz costmap tool to use the global fixed frame of rviz

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
