### PR TITLE
fix(simple-action-server): info log instead of warn on cancel

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -582,7 +582,7 @@ protected:
 
     if (is_active(handle)) {
       if (handle->is_canceling()) {
-        warn_msg("Client requested to cancel the goal. Cancelling.");
+        info_msg("Client requested to cancel the goal. Cancelling.");
         handle->canceled(result);
       } else {
         warn_msg("Aborting handle.");


### PR DESCRIPTION
Cancelling a goal is nominal behavior and therefore it should not log warning.