### PR TITLE
fix(nav2_theta_star_planner): Planner Server Crashing When Planning Outside Map Bounds with Theta* on Humble

### DIFF
--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -95,8 +95,20 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
 
   // Corner case of start and goal beeing on the same cell
   unsigned int mx_start, my_start, mx_goal, my_goal;
-  planner_->costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start);
-  planner_->costmap_->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal);
+  if (!planner_->costmap_->worldToMap(
+      start.pose.position.x, start.pose.position.y, mx_start, my_start))
+  {
+    RCLCPP_WARN(logger_, "Start Coordinates were outside map bounds");
+    return global_path;
+  }
+
+  if (!planner_->costmap_->worldToMap(
+      goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal))
+  {
+    RCLCPP_WARN(logger_, "Goal Coordinates were outside map bounds");
+    return global_path;
+  }
+
   if (mx_start == mx_goal && my_start == my_goal) {
     if (planner_->costmap_->getCost(mx_start, my_start) == nav2_costmap_2d::LETHAL_OBSTACLE) {
       RCLCPP_WARN(logger_, "Failed to create a unique pose path because of obstacles");


### PR DESCRIPTION
This PR resolves the issue discussed in: https://github.com/ros-navigation/navigation2/issues/4694
The planner server was crashing when attempting to plan paths outside the map bounds using the Theta* planner on Humble.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/4694 |
| Primary OS tested on | Ubuntu 20.04.6 LTS |
| Robotic platform tested on | planner playground, Gary Robot hardware |
| Does this PR contain AI generated software? | No |

---

## Description

* This change returns an empty path when either the goal or start coordinates are outside the map bounds, preventing the planner server from crashing.

