### PR TITLE
Fix : Log discrepancy when setting MPPI parameters dynamically

### DIFF
--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -53,7 +53,7 @@ ParametersHandler::dynamicParamsCallback(
 {
   rcl_interfaces::msg::SetParametersResult result;
   std::lock_guard<std::mutex> lock(parameters_change_mutex_);
-  bool success =true;
+  bool success = true;
 
   for (auto & pre_cb : pre_callbacks_) {
     pre_cb();

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -53,6 +53,7 @@ ParametersHandler::dynamicParamsCallback(
 {
   rcl_interfaces::msg::SetParametersResult result;
   std::lock_guard<std::mutex> lock(parameters_change_mutex_);
+  bool success =true;
 
   for (auto & pre_cb : pre_callbacks_) {
     pre_cb();
@@ -67,6 +68,7 @@ ParametersHandler::dynamicParamsCallback(
       callback->second(param);
     } else {
       RCLCPP_WARN(logger_, "Parameter %s not found", param_name.c_str());
+      success = false;
     }
   }
 
@@ -74,7 +76,7 @@ ParametersHandler::dynamicParamsCallback(
     post_cb();
   }
 
-  result.successful = true;
+  result.successful = success;
   return result;
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4704 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No|

---

## Description of contribution in a few bullet points

* If `ParametersHandler::dynamicParamsCallback` cannot find the dynamically set parameter name in its parameters list, set the `ParametersResult`  output message's `successful` field to `false` instead of always `true`.

---

## Future work that may be required in bullet points

*  The `rcl_interfaces/msg/SetParametersResult` message returned also has a `reason` field that could be populated with the reason for failure. This could be the name of the parameter not found or the full [already printed warning](https://github.com/PlatHum/navigation2/blob/e34634c97fc140003c83013682fec39fe9f3ec58/nav2_mppi_controller/src/parameters_handler.cpp#L70).

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
