### PR TITLE
mppi parameters_handler: Improve verbose handling (#4704)

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
@@ -252,7 +252,7 @@ void ParametersHandler::setParamCallback(
     const rclcpp::Parameter & param, rcl_interfaces::msg::SetParametersResult & result) {
       std::string reason = "Rejected change to static parameter: " + std::to_string(param);
       result.successful = false;
-      if (result.reason.empty()) {
+      if (!result.reason.empty()) {
         result.reason += "\n";
       }
       result.reason += reason;

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
@@ -211,7 +211,7 @@ void ParametersHandler::getParam(
 
   if (param_type == ParameterType::Dynamic) {
     if (verbose_) {
-      RCLCPP_INFO(node->get_logger(), "setDynamicParamCallback for %s", name.c_str());
+      RCLCPP_DEBUG(node->get_logger(), "setDynamicParamCallback for %s", name.c_str());
     }
     setDynamicParamCallback(setting, name);
   } else {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
@@ -210,7 +210,16 @@ void ParametersHandler::getParam(
   setParam<ParamT>(setting, name, node);
 
   if (param_type == ParameterType::Dynamic) {
+    if (verbose_) {
+      RCLCPP_INFO(node->get_logger(), "setDynamicParamCallback for %s", name.c_str());
+    }
     setDynamicParamCallback(setting, name);
+  } else {
+    if (verbose_) {
+      RCLCPP_DEBUG(
+        node->get_logger(), "ParameterType::Static therefore no setDynamicParamCallback for %s",
+        name.c_str());
+    }
   }
 }
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
@@ -36,12 +36,13 @@ enum class ParameterType { Dynamic, Static };
 
 /**
  * @class mppi::ParametersHandler
- * @brief Handles getting parameters and dynamic parmaeter changes
+ * @brief Handles getting parameters and dynamic parameter changes
  */
 class ParametersHandler
 {
 public:
-  using get_param_func_t = void (const rclcpp::Parameter & param);
+  using get_param_func_t = void (const rclcpp::Parameter & param,
+    rcl_interfaces::msg::SetParametersResult & result);
   using post_callback_t = void ();
   using pre_callback_t = void ();
 
@@ -103,7 +104,7 @@ public:
     * @param param_type Type of parameter (dynamic or static)
     */
   template<typename T>
-  void setDynamicParamCallback(
+  void setParamCallback(
     T & setting, const std::string & name, ParameterType param_type = ParameterType::Dynamic);
 
   /**
@@ -116,12 +117,20 @@ public:
   }
 
   /**
-    * @brief Set a parameter to a dynamic parameter callback
+    * @brief register a function to be called when setting a parameter
+    *
+    * The callback funciton is expected to behave as follows.
+    * Successful parameter changes should not interfere with
+    * the result parameter.
+    * Unsuccessful parameter changes should set the result.successful = false
+    * The result.reason should have "\n" appended if not empty before
+    * appending the reason that setting THIS parameter has failed.
+    *
     * @param name Name of parameter
     * @param callback Parameter callback
     */
   template<typename T>
-  void addDynamicParamCallback(const std::string & name, T && callback);
+  void addParamCallback(const std::string & name, T && callback);
 
 protected:
   /**
@@ -162,8 +171,7 @@ protected:
 
   bool verbose_{false};
 
-  std::unordered_map<std::string, std::function<get_param_func_t>>
-  get_param_callbacks_;
+  std::unordered_map<std::string, std::function<get_param_func_t>> get_param_callbacks_;
 
   std::vector<std::function<pre_callback_t>> pre_callbacks_;
   std::vector<std::function<post_callback_t>> post_callbacks_;
@@ -181,7 +189,7 @@ inline auto ParametersHandler::getParamGetter(const std::string & ns)
 }
 
 template<typename T>
-void ParametersHandler::addDynamicParamCallback(const std::string & name, T && callback)
+void ParametersHandler::addParamCallback(const std::string & name, T && callback)
 {
   get_param_callbacks_[name] = callback;
 }
@@ -210,7 +218,7 @@ void ParametersHandler::getParam(
     node, name, rclcpp::ParameterValue(default_value));
 
   setParam<ParamT>(setting, name, node);
-  setDynamicParamCallback(setting, name, param_type);
+  setParamCallback(setting, name, param_type);
 }
 
 template<typename ParamT, typename SettingT, typename NodeT>
@@ -223,32 +231,37 @@ void ParametersHandler::setParam(
 }
 
 template<typename T>
-void ParametersHandler::setDynamicParamCallback(
+void ParametersHandler::setParamCallback(
   T & setting, const std::string & name, ParameterType param_type)
 {
   if (get_param_callbacks_.find(name) != get_param_callbacks_.end()) {
     return;
   }
 
-  auto dynamic_callback = [this, &setting, name](const rclcpp::Parameter & param) {
+  auto dynamic_callback =
+    [this, &setting, name](
+    const rclcpp::Parameter & param, rcl_interfaces::msg::SetParametersResult & /*result*/) {
       setting = as<T>(param);
-
       if (verbose_) {
         RCLCPP_INFO(logger_, "Dynamic parameter changed: %s", std::to_string(param).c_str());
       }
     };
 
-  auto static_callback = [this, &setting, name](const rclcpp::Parameter & param) {
-      if (verbose_) {
-        RCLCPP_DEBUG(logger_, "Ignoring change to static parameter: %s",
-          std::to_string(param).c_str());
+  auto static_callback =
+    [this, &setting, name](
+    const rclcpp::Parameter & param, rcl_interfaces::msg::SetParametersResult & result) {
+      std::string reason = "Rejected change to static parameter: " + std::to_string(param);
+      result.successful = false;
+      if (result.reason.empty()) {
+        result.reason += "\n";
       }
+      result.reason += reason;
     };
 
   if (param_type == ParameterType::Dynamic) {
-    addDynamicParamCallback(name, dynamic_callback);
+    addParamCallback(name, dynamic_callback);
   } else {
-    addDynamicParamCallback(name, static_callback);
+    addParamCallback(name, static_callback);
   }
 }
 

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -35,10 +35,11 @@ void CostCritic::initialize()
   weight_ /= 254.0f;
 
   // Normalize weight when parameter is changed dynamically as well
-  auto weightDynamicCb = [&](const rclcpp::Parameter & weight) {
+  auto weightDynamicCb = [&](
+    const rclcpp::Parameter & weight, rcl_interfaces::msg::SetParametersResult & /*result*/) {
       weight_ = weight.as_double() / 254.0f;
     };
-  parameters_handler_->addDynamicParamCallback(name_ + ".cost_weight", weightDynamicCb);
+  parameters_handler_->addParamCallback(name_ + ".cost_weight", weightDynamicCb);
 
   collision_checker_.setCostmap(costmap_);
   possible_collision_cost_ = findCircumscribedCost(costmap_ros_);

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -54,7 +54,7 @@ ParametersHandler::dynamicParamsCallback(
 {
   rcl_interfaces::msg::SetParametersResult result;
   std::lock_guard<std::mutex> lock(parameters_change_mutex_);
-  bool success;
+  bool success = true;
 
   for (auto & pre_cb : pre_callbacks_) {
     pre_cb();
@@ -68,9 +68,7 @@ ParametersHandler::dynamicParamsCallback(
     {
       callback->second(param);
     } else {
-      if (verbose_) {
-        RCLCPP_WARN(logger_, "Parameter callback func for '%s' not found", param_name.c_str());
-      }
+      RCLCPP_ERROR(logger_, "Parameter callback func for '%s' not found", param_name.c_str());
       success = false;
     }
   }

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -39,7 +39,6 @@ void ParametersHandler::start()
 {
   auto node = node_.lock();
 
-  // Register the special case "verbose" parameter before registering dynamicParamsCallback
   auto get_param = getParamGetter(node_name_);
   get_param(verbose_, "verbose", false);
 
@@ -70,11 +69,8 @@ ParametersHandler::dynamicParamsCallback(
       callback->second(param);
     } else {
       if (verbose_) {
-        // Expected if static parameter, ie one with no registered callback is attempted
-        // to be changed
         RCLCPP_WARN(logger_, "Parameter callback func for '%s' not found", param_name.c_str());
       }
-      // success = true; // Decision ??? Still return true to avoid exception ???
       success = false;
     }
   }

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -71,6 +71,9 @@ ParametersHandler::dynamicParamsCallback(
       callback->second(param, result);
     } else {
       result.successful = false;
+      if (!result.reason.empty()) {
+        result.reason += "\n";
+      }
       result.reason += "get_param_callback func for '" + param_name + "' not found.\n";
     }
   }

--- a/nav2_mppi_controller/test/parameter_handler_test.cpp
+++ b/nav2_mppi_controller/test/parameter_handler_test.cpp
@@ -168,8 +168,49 @@ TEST(ParameterHandlerTest, DynamicAndStaticParametersTest)
     node->get_node_services_interface());
 
   auto results = rec_param->set_parameters_atomically(
-    {rclcpp::Parameter("dynamic_int", 10),
-      rclcpp::Parameter("static_int", 10)});
+  {
+    rclcpp::Parameter("my_node.verbose", true),
+    rclcpp::Parameter("dynamic_int", 10),
+    rclcpp::Parameter("static_int", 10)
+  });
+
+  rclcpp::spin_until_future_complete(
+    node->get_node_base_interface(),
+    results);
+
+  // Now, only param1 should change, param 2 should be the same
+  EXPECT_EQ(p1, 10);
+  EXPECT_EQ(p2, 7);
+}
+
+TEST(ParameterHandlerTest, DynamicAndStaticParametersNotVerboseTest)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
+  node->declare_parameter("dynamic_int", rclcpp::ParameterValue(7));
+  node->declare_parameter("static_int", rclcpp::ParameterValue(7));
+  ParametersHandlerWrapper handler(node);
+  handler.start();
+
+  // Get parameters and check they have initial values
+  auto getParamer = handler.getParamGetter("");
+  int p1 = 0, p2 = 0;
+  getParamer(p1, "dynamic_int", 0, ParameterType::Dynamic);
+  getParamer(p2, "static_int", 0, ParameterType::Static);
+  EXPECT_EQ(p1, 7);
+  EXPECT_EQ(p2, 7);
+
+  // Now change them both via dynamic parameters
+  auto rec_param = std::make_shared<rclcpp::AsyncParametersClient>(
+    node->get_node_base_interface(), node->get_node_topics_interface(),
+    node->get_node_graph_interface(),
+    node->get_node_services_interface());
+
+  auto results = rec_param->set_parameters_atomically(
+  {
+    // Don't set default param rclcpp::Parameter("my_node.verbose", false),
+    rclcpp::Parameter("dynamic_int", 10),
+    rclcpp::Parameter("static_int", 10)
+  });
 
   rclcpp::spin_until_future_complete(
     node->get_node_base_interface(),


### PR DESCRIPTION
The "verbose" parameter of the parameters_handler is a special case that needs registration before the
dynamic parameter handler callback is registered.

In verbose mode make the parameter handler info/warn/debug messages more expressive.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #4704 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | AOS kelpie |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Improve the verbose handling of the mppi parameter_handler class and make it more verbose to
help distinguish between ParameterType::Dynamic and ParameterType::Static parameters.

## Description of documentation updates required from your changes

Key point is to treat the verbose parameter of the mppi parameter_handler class
as a special case and register it *BEFORE* the dynamic parameter handler callback is
registered.

Other parameters may be "ParameterType::Static" on purpose, so a decision is required 
about whether or not to return false from the dynamicParamsCallback is required.

I left it as false as per initial PR. 

---

## Future work that may be required in bullet points

Make decision about returning false and remove commented out return true.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
