### PR TITLE
nav2_map_saver: map_io: properly handle special cost values in raw mode

### DIFF
--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -504,16 +504,13 @@ void tryWriteMapToFile(
             Magick::Quantum q;
             if (map_cell < 0 || 100 < map_cell) {
               q = MaxRGB;
-            }
-            else if (map_cell == 100) {
+            } else if (map_cell == 100) {
               // LETHAL obstacle
               q = 254 / 255.0 * MaxRGB;
-            }
-            else if (map_cell == 99) {
+            } else if (map_cell == 99) {
               // INSCRIBED obstacle
               q = 253 / 255.0 * MaxRGB;
-            }
-            else {
+            } else {
               q = map_cell / 255.0 * MaxRGB;
             }
             pixel = Magick::Color(q, q, q);

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -504,7 +504,18 @@ void tryWriteMapToFile(
             Magick::Quantum q;
             if (map_cell < 0 || 100 < map_cell) {
               q = MaxRGB;
-            } else {
+            }
+            else if (map_cell == 100)
+            {
+              // LETHAL obstacle
+              q = 254 / 255.0 * MaxRGB;
+            }
+            else if (map_cell == 99)
+            {
+              // INSCRIBED obstacle
+              q = 253 / 255.0 * MaxRGB;
+            }
+            else {
               q = map_cell / 255.0 * MaxRGB;
             }
             pixel = Magick::Color(q, q, q);

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -505,13 +505,11 @@ void tryWriteMapToFile(
             if (map_cell < 0 || 100 < map_cell) {
               q = MaxRGB;
             }
-            else if (map_cell == 100)
-            {
+            else if (map_cell == 100) {
               // LETHAL obstacle
               q = 254 / 255.0 * MaxRGB;
             }
-            else if (map_cell == 99)
-            {
+            else if (map_cell == 99) {
               // INSCRIBED obstacle
               q = 253 / 255.0 * MaxRGB;
             }


### PR DESCRIPTION
Values -1, 0, 99, and 100 of the OccupancyGrid have special meanings [1]. When converting the grid to an RGB image, those values should be properly mapped.

In our case, the -1 and 0 are already well managed. However, the 99 and 100 values are currently mapped to 252 and 255 while they should map to 253 and 254 [2]. As a consequence, the LETHAL (100 -> 255) and the UNKNOWN (-1 -> 255) areas share the same pixel intensity.

[1] https://github.com/ros-navigation/navigation2/blob/main/nav2_costmap_2d/src/costmap_2d_publisher.cpp#L94
[2] https://github.com/ros-navigation/navigation2/blob/main/nav2_costmap_2d/include/nav2_costmap_2d/cost_values.hpp#L71

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | / |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | / |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
