### PR TITLE
Remove nav2_loopback_sim dependency on transforms3d.

### DIFF
--- a/nav2_loopback_sim/package.xml
+++ b/nav2_loopback_sim/package.xml
@@ -12,7 +12,6 @@
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>tf_transformations</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>python3-transforms3d</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

The package never uses it, so don't declare it.

I noticed this because I noticed that recent builds of Navigation2 on Jazzy don't work on RHEL anymore, i.e. https://build.ros2.org/job/Jsrc_el9__navigation2__rhel_9__source/ is disabled.  The reason for that is that `python3-transforms3d` is not packaged on RHEL-9.  However, it turns out that this package doesn't actually use `transforms3d`, so the easiest thing to do here is to remove the dependency.

Note that if accepted, this should also be backported to the `jazzy` branch, and a new bloom-release should be done on the buildfarm for Jazzy.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

Backport to the `jazzy` branch.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists