### PR TITLE
Fix incorrect doxygen comment in costmap_2d

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
@@ -150,8 +150,7 @@ public:
 
   /**
    * @brief  Get the cost of a cell in the costmap
-   * @param mx The x coordinate of the cell
-   * @param my The y coordinate of the cell
+   * @param index The cell index
    * @return The cost of the cell
    */
   unsigned char getCost(unsigned int index) const;


### PR DESCRIPTION
## Description of contribution in a few bullet points


* Fix incorrect doxygen comment naming params that don't exist.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
