### PR TITLE
Fixes inability to find `yaml-cpp::yaml-cpp` when building nav2_waypoint_follower from source

### DIFF
--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 project(nav2_waypoint_follower)
 
 find_package(ament_cmake REQUIRED)
@@ -21,6 +21,7 @@ find_package(robot_localization REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 nav2_package()
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   #4773  |
| Primary OS tested on | Ubuntu 22.04 (will also work in Ubuntu 24.04) |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---
Please see Issue #4773 for more details.

## Description of documentation updates required from your changes
Not required

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
