### PR TITLE
graceful_controller: implement iterative selection of control points

### DIFF
--- a/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
@@ -151,6 +151,14 @@ protected:
     const std::vector<geometry_msgs::msg::PoseStamped> & poses,
     std::vector<double> & distances);
 
+  /**
+   * @brief Control law requires proper orientations, not all planners provide them
+   * @param path Path to add orientations into
+   * @returns Path with orientations.
+   */
+  std::vector<geometry_msgs::msg::PoseStamped> addOrientations(
+    const std::vector<geometry_msgs::msg::PoseStamped> & path);
+
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::string plugin_name_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;

--- a/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
@@ -108,32 +108,22 @@ public:
 
 protected:
   /**
-   * @brief Get motion target point.
-   * @param motion_target_dist Optimal motion target distance
-   * @param path Current global path
-   * @return Motion target point
-   */
-  geometry_msgs::msg::PoseStamped getMotionTarget(
-    const double & motion_target_dist,
-    const nav_msgs::msg::Path & path);
-
-  /**
    * @brief Simulate trajectory calculating in every step the new velocity command based on
    * a new curvature value and checking for collisions.
    *
-   * @param robot_pose Robot pose
-   * @param motion_target Motion target point
+   * @param motion_target Motion target point (in costmap local frame?)
    * @param costmap_transform Transform between global and local costmap
    * @param trajectory Simulated trajectory
+   * @param cmd_vel Initial command velocity during simulation
    * @param backward Flag to indicate if the robot is moving backward
    * @return true if the trajectory is collision free, false otherwise
    */
   bool simulateTrajectory(
-    const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::PoseStamped & motion_target,
     const geometry_msgs::msg::TransformStamped & costmap_transform,
     nav_msgs::msg::Path & trajectory,
-    const bool & backward);
+    geometry_msgs::msg::TwistStamped & cmd_vel,
+    bool backward);
 
   /**
    * @brief Rotate the robot to face the motion target with maximum angular velocity.
@@ -141,8 +131,7 @@ protected:
    * @param angle_to_target Angle to the motion target
    * @return geometry_msgs::msg::Twist Velocity command
    */
-  geometry_msgs::msg::Twist rotateToTarget(
-    const double & angle_to_target);
+  geometry_msgs::msg::Twist rotateToTarget(double angle_to_target);
 
   /**
    * @brief Checks if the robot is in collision
@@ -152,6 +141,15 @@ protected:
    * @return Whether in collision
    */
   bool inCollision(const double & x, const double & y, const double & theta);
+
+  /**
+   * @brief Compute the distance to each pose in a path
+   * @param poses Poses to compute distances with
+   * @param distances Computed distances
+   */
+  void computeDistanceAlongPath(
+    const std::vector<geometry_msgs::msg::PoseStamped> & poses,
+    std::vector<double> & distances);
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::string plugin_name_;
@@ -163,6 +161,7 @@ protected:
   Parameters * params_;
   double goal_dist_tolerance_;
   bool goal_reached_;
+  bool has_new_path_;
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> transformed_plan_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> local_plan_pub_;

--- a/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/graceful_controller.hpp
@@ -153,11 +153,9 @@ protected:
 
   /**
    * @brief Control law requires proper orientations, not all planners provide them
-   * @param path Path to add orientations into
-   * @returns Path with orientations.
+   * @param path Path to add orientations into, if required
    */
-  std::vector<geometry_msgs::msg::PoseStamped> addOrientations(
-    const std::vector<geometry_msgs::msg::PoseStamped> & path);
+  void validateOrientations(std::vector<geometry_msgs::msg::PoseStamped> & path);
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::string plugin_name_;
@@ -169,7 +167,9 @@ protected:
   Parameters * params_;
   double goal_dist_tolerance_;
   bool goal_reached_;
-  bool has_new_path_;
+
+  // True from the time a new path arrives until we have completed an initial rotation
+  bool do_initial_rotation_;
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> transformed_plan_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> local_plan_pub_;

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -45,6 +45,7 @@ struct Parameters
   double v_linear_max_initial;
   double v_angular_max;
   double v_angular_max_initial;
+  double v_angular_min_in_place;
   double slowdown_radius;
   double initial_rotation_tolerance;
   bool prefer_final_rotation;

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -52,7 +52,7 @@ struct Parameters
   bool prefer_final_rotation;
   double rotation_scaling_factor;
   bool allow_backward;
-  double in_place_collision_tolerance;
+  double in_place_collision_resolution;
 };
 
 /**

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -51,6 +51,7 @@ struct Parameters
   bool prefer_final_rotation;
   double rotation_scaling_factor;
   bool allow_backward;
+  bool add_orientations;
 };
 
 /**

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -33,7 +33,8 @@ namespace nav2_graceful_controller
 struct Parameters
 {
   double transform_tolerance;
-  double motion_target_dist;
+  double min_lookahead;
+  double max_lookahead;
   double max_robot_pose_search_dist;
   double k_phi;
   double k_delta;
@@ -45,9 +46,8 @@ struct Parameters
   double v_angular_max;
   double v_angular_max_initial;
   double slowdown_radius;
-  bool initial_rotation;
-  double initial_rotation_min_angle;
-  bool final_rotation;
+  double initial_rotation_tolerance;
+  bool prefer_final_rotation;
   double rotation_scaling_factor;
   bool allow_backward;
 };

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -47,11 +47,12 @@ struct Parameters
   double v_angular_max_initial;
   double v_angular_min_in_place;
   double slowdown_radius;
+  bool initial_rotation;
   double initial_rotation_tolerance;
   bool prefer_final_rotation;
   double rotation_scaling_factor;
   bool allow_backward;
-  bool add_orientations;
+  double in_place_collision_tolerance;
 };
 
 /**

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -164,7 +164,7 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
     goal_reached_ = true;
     double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
     // Check for collisions between our current pose and goal pose
-    size_t num_steps = fabs(angle_to_goal) / params_->in_place_collision_tolerance;
+    size_t num_steps = fabs(angle_to_goal) / params_->in_place_collision_resolution;
     // Need to check at least the end pose
     num_steps = std::max(static_cast<size_t>(1), num_steps);
     bool collision_free = true;
@@ -430,7 +430,7 @@ void GracefulController::validateOrientations(
   if (path.empty()) {return;}
 
   // Check if we actually need to add orientations
-  for (size_t i = 0; i < path.size() - 1; ++i) {
+  for (size_t i = 1; i < path.size() - 1; ++i) {
     if (tf2::getYaw(path[i].pose.orientation) != 0.0) {return;}
   }
 

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -363,6 +363,11 @@ geometry_msgs::msg::Twist GracefulController::rotateToTarget(double angle_to_tar
   geometry_msgs::msg::Twist vel;
   vel.linear.x = 0.0;
   vel.angular.z = params_->rotation_scaling_factor * angle_to_target * params_->v_angular_max;
+  if (vel.angular.z < 0.0) {
+    vel.angular.z = std::min(vel.angular.z, -params_->v_angular_min_in_place);
+  } else {
+    vel.angular.z = std::max(vel.angular.z, params_->v_angular_min_in_place);
+  }
   return vel;
 }
 

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -114,6 +114,9 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
 {
   std::lock_guard<std::mutex> param_lock(param_handler_->getMutex());
 
+  geometry_msgs::msg::TwistStamped cmd_vel;
+  cmd_vel.header = pose.header;
+
   // Update for the current goal checker's state
   geometry_msgs::msg::Pose pose_tolerance;
   geometry_msgs::msg::Twist velocity_tolerance;
@@ -134,60 +137,6 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
     pose, params_->max_robot_pose_search_dist);
   transformed_plan_pub_->publish(transformed_plan);
 
-  // Get the particular point on the path at the motion target distance and publish it
-  auto motion_target = getMotionTarget(params_->motion_target_dist, transformed_plan);
-  auto motion_target_point = nav2_graceful_controller::createMotionTargetMsg(motion_target);
-  motion_target_pub_->publish(motion_target_point);
-
-  // Publish marker for slowdown radius around motion target for debugging / visualization
-  auto slowdown_marker = nav2_graceful_controller::createSlowdownMarker(
-    motion_target,
-    params_->slowdown_radius);
-  slowdown_pub_->publish(slowdown_marker);
-
-  // Compute distance to goal as the path's integrated distance to account for path curvatures
-  double dist_to_goal = nav2_util::geometry_utils::calculate_path_length(transformed_plan);
-
-  // If the distance to the goal is less than the motion target distance, i.e.
-  // the 'motion target' is the goal, then we skip the motion target orientation by pointing
-  // it in the same orientation that the last segment of the path
-  double angle_to_target = atan2(motion_target.pose.position.y, motion_target.pose.position.x);
-  if (params_->final_rotation && dist_to_goal < params_->motion_target_dist) {
-    geometry_msgs::msg::PoseStamped stl_pose =
-      transformed_plan.poses[transformed_plan.poses.size() - 2];
-    geometry_msgs::msg::PoseStamped goal_pose = transformed_plan.poses.back();
-    double dx = goal_pose.pose.position.x - stl_pose.pose.position.x;
-    double dy = goal_pose.pose.position.y - stl_pose.pose.position.y;
-    double yaw = std::atan2(dy, dx);
-    motion_target.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw);
-  }
-
-  // Flip the orientation of the motion target if the robot is moving backwards
-  bool reversing = false;
-  if (params_->allow_backward && motion_target.pose.position.x < 0.0) {
-    reversing = true;
-    motion_target.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
-      tf2::getYaw(motion_target.pose.orientation) + M_PI);
-  }
-
-  // Compute velocity command:
-  // 1. Check if we are close enough to the goal to do a final rotation in place
-  // 2. Check if we must do a rotation in place before moving
-  // 3. Calculate the new velocity command using the smooth control law
-  geometry_msgs::msg::TwistStamped cmd_vel;
-  cmd_vel.header = pose.header;
-  if (params_->final_rotation && (dist_to_goal < goal_dist_tolerance_ || goal_reached_)) {
-    goal_reached_ = true;
-    double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
-    cmd_vel.twist = rotateToTarget(angle_to_goal);
-  } else if (params_->initial_rotation && // NOLINT
-    fabs(angle_to_target) > params_->initial_rotation_min_angle)
-  {
-    cmd_vel.twist = rotateToTarget(angle_to_target);
-  } else {
-    cmd_vel.twist = control_law_->calculateRegularVelocity(motion_target.pose, reversing);
-  }
-
   // Transform local frame to global frame to use in collision checking
   geometry_msgs::msg::TransformStamped costmap_transform;
   try {
@@ -199,24 +148,109 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
       logger_, "Could not transform %s to %s: %s",
       costmap_ros_->getBaseFrameID().c_str(), costmap_ros_->getGlobalFrameID().c_str(),
       ex.what());
-    return cmd_vel;
+    return cmd_vel;  // TODO(fergs): this seems bad?
   }
 
-  // Generate and publish local plan for debugging / visualization
-  nav_msgs::msg::Path local_plan;
-  if (!simulateTrajectory(pose, motion_target, costmap_transform, local_plan, reversing)) {
-    throw nav2_core::NoValidControl("Collision detected in the trajectory");
-  }
-  local_plan.header = transformed_plan.header;
-  local_plan_pub_->publish(local_plan);
+  // Compute distance to goal as the path's integrated distance to account for path curvatures
+  double dist_to_goal = nav2_util::geometry_utils::calculate_path_length(transformed_plan);
 
-  return cmd_vel;
+  // If we've reached the XY goal tolerance, just rotate
+  if (dist_to_goal < goal_dist_tolerance_ || goal_reached_) {
+    goal_reached_ = true;
+    double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
+    // Check for collisions between our current pose and goal pose
+    size_t num_steps = fabs(angle_to_goal) / 0.1;
+    // Need to check at least the end pose
+    num_steps = std::max(static_cast<size_t>(1), num_steps);
+    // If we fail to generate an in-place rotation, maybe we need to move along path a bit more
+    bool collision_free = true;
+    for (size_t i = 1; i <= num_steps; ++i) {
+      double step = static_cast<double>(i) / static_cast<double>(num_steps);
+      double yaw = step * angle_to_goal;
+      geometry_msgs::msg::PoseStamped next_pose;
+      next_pose.header.frame_id = costmap_ros_->getBaseFrameID();
+      next_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw);
+      geometry_msgs::msg::PoseStamped costmap_pose;
+      tf2::doTransform(next_pose, costmap_pose, costmap_transform);
+      if (inCollision(
+          costmap_pose.pose.position.x, costmap_pose.pose.position.y,
+          tf2::getYaw(costmap_pose.pose.orientation)))
+      {
+        collision_free = false;
+        break;
+      }
+    }
+    // Compute velocity if rotation is possible
+    if (collision_free) {
+      cmd_vel.twist = rotateToTarget(angle_to_goal);
+      return cmd_vel;
+    }
+    // Else, fall through and see if we should follow control law longer
+  }
+
+  // Precompute distance to candidate poses
+  std::vector<double> target_distances;
+  computeDistanceAlongPath(transformed_plan.poses, target_distances);
+
+  // Work back from the end of plan to find valid target pose
+  for (int i = transformed_plan.poses.size() - 1; i >= 0; --i) {
+    // Underlying control law needs a single target pose, which should:
+    //  * Be as far away as possible from the robot (for smoothness)
+    //  * But no further than the max_lookahed_ distance
+    //  * Be feasible to reach in a collision free manner
+    geometry_msgs::msg::PoseStamped target_pose = transformed_plan.poses[i];
+    double dist_to_target = target_distances[i];
+
+    // Continue if target_pose is too far away from robot
+    if (dist_to_target > params_->max_lookahead) {continue;}
+
+    if (dist_to_goal < params_->max_lookahead) {
+      if (params_->prefer_final_rotation) {
+        // Avoid unstability and big sweeping turns at the end of paths by
+        // ignoring final heading
+        double yaw = std::atan2(target_pose.pose.position.y, target_pose.pose.position.x);
+        target_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw);
+      }
+    } else if (dist_to_target < params_->min_lookahead) {
+      // Make sure target is far enough away to avoid instability
+      break;
+    }
+
+    // Flip the orientation of the motion target if the robot is moving backwards
+    bool reversing = false;
+    if (params_->allow_backward && target_pose.pose.position.x < 0.0) {
+      reversing = true;
+      target_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
+        tf2::getYaw(target_pose.pose.orientation) + M_PI);
+    }
+
+    // Actually simulate our path
+    nav_msgs::msg::Path local_plan;
+    if (simulateTrajectory(target_pose, costmap_transform, local_plan, cmd_vel, reversing)) {
+      // Successfully simulated to target_pose - compute velocity at this moment
+      // Publish the selected target_pose
+      auto motion_target_point = nav2_graceful_controller::createMotionTargetMsg(target_pose);
+      motion_target_pub_->publish(motion_target_point);
+      // Publish marker for slowdown radius around motion target for debugging / visualization
+      auto slowdown_marker = nav2_graceful_controller::createSlowdownMarker(
+        target_pose, params_->slowdown_radius);
+      slowdown_pub_->publish(slowdown_marker);
+      // Publish the local plan
+      local_plan.header = transformed_plan.header;
+      local_plan_pub_->publish(local_plan);
+      // Successfully found velocity command
+      return cmd_vel;
+    }
+  }
+
+  throw nav2_core::NoValidControl("Collision detected in trajectory");
 }
 
 void GracefulController::setPlan(const nav_msgs::msg::Path & path)
 {
   path_handler_->setPlan(path);
   goal_reached_ = false;
+  has_new_path_ = true;
 }
 
 void GracefulController::setSpeedLimit(
@@ -243,58 +277,66 @@ void GracefulController::setSpeedLimit(
   }
 }
 
-geometry_msgs::msg::PoseStamped GracefulController::getMotionTarget(
-  const double & motion_target_dist,
-  const nav_msgs::msg::Path & transformed_plan)
-{
-  // Find the first pose which is at a distance greater than the motion target distance
-  auto goal_pose_it = std::find_if(
-    transformed_plan.poses.begin(), transformed_plan.poses.end(), [&](const auto & ps) {
-      return std::hypot(ps.pose.position.x, ps.pose.position.y) >= motion_target_dist;
-    });
-
-  // If the pose is not far enough, take the last pose
-  if (goal_pose_it == transformed_plan.poses.end()) {
-    goal_pose_it = std::prev(transformed_plan.poses.end());
-  }
-
-  return *goal_pose_it;
-}
-
 bool GracefulController::simulateTrajectory(
-  const geometry_msgs::msg::PoseStamped & robot_pose,
   const geometry_msgs::msg::PoseStamped & motion_target,
   const geometry_msgs::msg::TransformStamped & costmap_transform,
-  nav_msgs::msg::Path & trajectory, const bool & backward)
+  nav_msgs::msg::Path & trajectory,
+  geometry_msgs::msg::TwistStamped & cmd_vel,
+  bool backward)
 {
-  // Check for collision before moving
-  if (inCollision(
-      robot_pose.pose.position.x, robot_pose.pose.position.y,
-      tf2::getYaw(robot_pose.pose.orientation)))
-  {
-    return false;
-  }
+  trajectory.poses.clear();
 
-  // First pose
+  // First pose is robot current pose
   geometry_msgs::msg::PoseStamped next_pose;
   next_pose.header.frame_id = costmap_ros_->getBaseFrameID();
   next_pose.pose.orientation.w = 1.0;
-  trajectory.poses.push_back(next_pose);
+
+  // Should we simulate rotation initially?
+  bool sim_initial_rotation = has_new_path_ && (params_->initial_rotation_tolerance > 0.0);
+  double angle_to_target =
+    std::atan2(motion_target.pose.position.y, motion_target.pose.position.x);
+  if (fabs(angle_to_target) < params_->initial_rotation_tolerance) {
+    sim_initial_rotation = false;
+    has_new_path_ = false;
+  }
 
   double distance = std::numeric_limits<double>::max();
   double resolution_ = costmap_ros_->getCostmap()->getResolution();
   double dt = (params_->v_linear_max > 0.0) ? resolution_ / params_->v_linear_max : 0.0;
 
   // Set max iter to avoid infinite loop
-  unsigned int max_iter = 2 * sqrt(
-    motion_target.pose.position.x * motion_target.pose.position.x +
-    motion_target.pose.position.y * motion_target.pose.position.y) / resolution_;
+  unsigned int max_iter = 3 *
+    std::hypot(motion_target.pose.position.x, motion_target.pose.position.y) / resolution_;
 
   // Generate path
   do{
-    // Apply velocities to calculate next pose
-    next_pose.pose = control_law_->calculateNextPose(
-      dt, motion_target.pose, next_pose.pose, backward);
+    if (sim_initial_rotation) {
+      // Compute rotation velocity
+      double next_pose_yaw = tf2::getYaw(next_pose.pose.orientation);
+      auto cmd = rotateToTarget(angle_to_target - next_pose_yaw);
+
+      // If this is first iteration, this is our current target velocity
+      if (trajectory.poses.empty()) {cmd_vel.twist = cmd;}
+
+      // Are we done simulating initial rotation?
+      if (fabs(angle_to_target - next_pose_yaw) < params_->initial_rotation_tolerance) {
+        sim_initial_rotation = false;
+      }
+
+      // Forward simulate rotation command
+      next_pose_yaw += cmd_vel.twist.angular.z * dt;
+      next_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(next_pose_yaw);
+    } else {
+      // If this is first iteration, this is our current target velocity
+      if (trajectory.poses.empty()) {
+        cmd_vel.twist = control_law_->calculateRegularVelocity(
+          motion_target.pose, next_pose.pose, backward);
+      }
+
+      // Apply velocities to calculate next pose
+      next_pose.pose = control_law_->calculateNextPose(
+        dt, motion_target.pose, next_pose.pose, backward);
+    }
 
     // Add the pose to the trajectory for visualization
     trajectory.poses.push_back(next_pose);
@@ -316,7 +358,7 @@ bool GracefulController::simulateTrajectory(
   return true;
 }
 
-geometry_msgs::msg::Twist GracefulController::rotateToTarget(const double & angle_to_target)
+geometry_msgs::msg::Twist GracefulController::rotateToTarget(double angle_to_target)
 {
   geometry_msgs::msg::Twist vel;
   vel.linear.x = 0.0;
@@ -358,6 +400,21 @@ bool GracefulController::inCollision(const double & x, const double & y, const d
   }
 
   return false;
+}
+
+void GracefulController::computeDistanceAlongPath(
+  const std::vector<geometry_msgs::msg::PoseStamped> & poses,
+  std::vector<double> & distances)
+{
+  distances.resize(poses.size());
+  // Do the first pose from robot
+  double d = std::hypot(poses[0].pose.position.x, poses[0].pose.position.y);
+  distances[0] = d;
+  // Compute remaining poses
+  for (size_t i = 1; i < poses.size(); ++i) {
+    d += nav2_util::geometry_utils::euclidean_distance(poses[i - 1].pose, poses[i].pose);
+    distances[i] = d;
+  }
 }
 
 }  // namespace nav2_graceful_controller

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -44,9 +44,9 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_robot_pose_search_dist",
     rclcpp::ParameterValue(costmap_size_x / 2.0));
-  declare_parameter_if_not_declared(node, plugin_name_ + ".k_phi", rclcpp::ParameterValue(3.0));
-  declare_parameter_if_not_declared(node, plugin_name_ + ".k_delta", rclcpp::ParameterValue(2.0));
-  declare_parameter_if_not_declared(node, plugin_name_ + ".beta", rclcpp::ParameterValue(0.2));
+  declare_parameter_if_not_declared(node, plugin_name_ + ".k_phi", rclcpp::ParameterValue(2.0));
+  declare_parameter_if_not_declared(node, plugin_name_ + ".k_delta", rclcpp::ParameterValue(1.0));
+  declare_parameter_if_not_declared(node, plugin_name_ + ".beta", rclcpp::ParameterValue(0.4));
   declare_parameter_if_not_declared(node, plugin_name_ + ".lambda", rclcpp::ParameterValue(2.0));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".v_linear_min", rclcpp::ParameterValue(0.1));
@@ -69,7 +69,7 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".allow_backward", rclcpp::ParameterValue(false));
   declare_parameter_if_not_declared(
-    node, plugin_name_ + ".in_place_collision_tolerance", rclcpp::ParameterValue(0.1));
+    node, plugin_name_ + ".in_place_collision_resolution", rclcpp::ParameterValue(0.1));
 
   node->get_parameter(plugin_name_ + ".transform_tolerance", params_.transform_tolerance);
   node->get_parameter(plugin_name_ + ".min_lookahead", params_.min_lookahead);
@@ -102,7 +102,7 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(plugin_name_ + ".rotation_scaling_factor", params_.rotation_scaling_factor);
   node->get_parameter(plugin_name_ + ".allow_backward", params_.allow_backward);
   node->get_parameter(
-    plugin_name_ + ".in_place_collision_tolerance", params_.in_place_collision_tolerance);
+    plugin_name_ + ".in_place_collision_resolution", params_.in_place_collision_resolution);
 
   if (params_.initial_rotation && params_.allow_backward) {
     RCLCPP_WARN(
@@ -165,8 +165,8 @@ ParameterHandler::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
         params_.initial_rotation_tolerance = parameter.as_double();
       } else if (name == plugin_name_ + ".rotation_scaling_factor") {
         params_.rotation_scaling_factor = parameter.as_double();
-      } else if (name == plugin_name_ + ".in_place_collision_tolerance") {
-        params_.in_place_collision_tolerance = parameter.as_double();
+      } else if (name == plugin_name_ + ".in_place_collision_resolution") {
+        params_.in_place_collision_resolution = parameter.as_double();
       }
     } else if (type == ParameterType::PARAMETER_BOOL) {
       if (name == plugin_name_ + ".initial_rotation") {

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -61,7 +61,7 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".initial_rotation", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(
-    node, plugin_name_ + ".initial_rotation_tolerance", rclcpp::ParameterValue(0.25));
+    node, plugin_name_ + ".initial_rotation_tolerance", rclcpp::ParameterValue(0.75));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".prefer_final_rotation", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -55,6 +55,8 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".v_angular_max", rclcpp::ParameterValue(1.0));
   declare_parameter_if_not_declared(
+    node, plugin_name_ + ".v_angular_min_in_place", rclcpp::ParameterValue(0.25));
+  declare_parameter_if_not_declared(
     node, plugin_name_ + ".slowdown_radius", rclcpp::ParameterValue(1.5));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".initial_rotation_tolerance", rclcpp::ParameterValue(0.25));
@@ -86,6 +88,8 @@ ParameterHandler::ParameterHandler(
   params_.v_linear_max_initial = params_.v_linear_max;
   node->get_parameter(plugin_name_ + ".v_angular_max", params_.v_angular_max);
   params_.v_angular_max_initial = params_.v_angular_max;
+  node->get_parameter(
+    plugin_name_ + ".v_angular_min_in_place", params_.v_angular_min_in_place);
   node->get_parameter(plugin_name_ + ".slowdown_radius", params_.slowdown_radius);
   node->get_parameter(
     plugin_name_ + ".initial_rotation_tolerance", params_.initial_rotation_tolerance);
@@ -146,6 +150,8 @@ ParameterHandler::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
       } else if (name == plugin_name_ + ".v_angular_max") {
         params_.v_angular_max = parameter.as_double();
         params_.v_angular_max_initial = params_.v_angular_max;
+      } else if (name == plugin_name_ + ".v_angular_min_in_place") {
+        params_.v_angular_min_in_place = parameter.as_double();
       } else if (name == plugin_name_ + ".slowdown_radius") {
         params_.slowdown_radius = parameter.as_double();
       } else if (name == plugin_name_ + ".initial_rotation_tolerance") {

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -43,7 +43,7 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".max_lookahead", rclcpp::ParameterValue(1.0));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_robot_pose_search_dist",
-    rclcpp::ParameterValue(costmap_size_x / 2.0));  // TODO(fergs): this is crazy
+    rclcpp::ParameterValue(costmap_size_x / 2.0));
   declare_parameter_if_not_declared(node, plugin_name_ + ".k_phi", rclcpp::ParameterValue(3.0));
   declare_parameter_if_not_declared(node, plugin_name_ + ".k_delta", rclcpp::ParameterValue(2.0));
   declare_parameter_if_not_declared(node, plugin_name_ + ".beta", rclcpp::ParameterValue(0.2));
@@ -66,6 +66,8 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".rotation_scaling_factor", rclcpp::ParameterValue(0.5));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".allow_backward", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".add_orientations", rclcpp::ParameterValue(false));
 
   node->get_parameter(plugin_name_ + ".transform_tolerance", params_.transform_tolerance);
   node->get_parameter(plugin_name_ + ".min_lookahead", params_.min_lookahead);
@@ -96,6 +98,7 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(plugin_name_ + ".prefer_final_rotation", params_.prefer_final_rotation);
   node->get_parameter(plugin_name_ + ".rotation_scaling_factor", params_.rotation_scaling_factor);
   node->get_parameter(plugin_name_ + ".allow_backward", params_.allow_backward);
+  node->get_parameter(plugin_name_ + ".add_orientations", params_.add_orientations);
 
   if ((params_.initial_rotation_tolerance > 0.0) && params_.allow_backward) {
     RCLCPP_WARN(
@@ -176,6 +179,8 @@ ParameterHandler::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
           continue;
         }
         params_.allow_backward = parameter.as_bool();
+      } else if (name == plugin_name_ + ".add_orientations") {
+        params_.add_orientations = parameter.as_bool();
       }
     }
   }

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -53,18 +53,11 @@ public:
   GMControllerFixture()
   : nav2_graceful_controller::GracefulController() {}
 
-  bool getInitialRotation() {return params_->initial_rotation;}
+  double getInitialRotationTolerance() {return params_->initial_rotation_tolerance;}
 
   bool getAllowBackward() {return params_->allow_backward;}
 
   nav_msgs::msg::Path getPlan() {return path_handler_->getPlan();}
-
-  geometry_msgs::msg::PoseStamped getMotionTarget(
-    const double & motion_target_distance, const nav_msgs::msg::Path & plan)
-  {
-    return nav2_graceful_controller::GracefulController::getMotionTarget(
-      motion_target_distance, plan);
-  }
 
   geometry_msgs::msg::PointStamped createMotionTargetMsg(
     const geometry_msgs::msg::PoseStamped & motion_target)
@@ -84,16 +77,6 @@ public:
   {
     return nav2_graceful_controller::GracefulController::rotateToTarget(
       angle_to_target);
-  }
-
-  bool simulateTrajectory(
-    const geometry_msgs::msg::PoseStamped & robot_pose,
-    const geometry_msgs::msg::PoseStamped & motion_target,
-    const geometry_msgs::msg::TransformStamped & costmap_transform,
-    nav_msgs::msg::Path & trajectory, const bool & backward)
-  {
-    return nav2_graceful_controller::GracefulController::simulateTrajectory(
-      robot_pose, motion_target, costmap_transform, trajectory, backward);
   }
 
   double getSpeedLinearMax() {return params_->v_linear_max;}
@@ -289,7 +272,8 @@ TEST(GracefulControllerTest, dynamicParameters) {
   // Set parameters
   auto results = params->set_parameters_atomically(
     {rclcpp::Parameter("test.transform_tolerance", 1.0),
-      rclcpp::Parameter("test.motion_target_dist", 2.0),
+      rclcpp::Parameter("test.min_lookahead", 1.0),
+      rclcpp::Parameter("test.max_lookahead", 2.0),
       rclcpp::Parameter("test.k_phi", 4.0),
       rclcpp::Parameter("test.k_delta", 5.0),
       rclcpp::Parameter("test.beta", 6.0),
@@ -298,9 +282,8 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.v_linear_max", 9.0),
       rclcpp::Parameter("test.v_angular_max", 10.0),
       rclcpp::Parameter("test.slowdown_radius", 11.0),
-      rclcpp::Parameter("test.initial_rotation", false),
-      rclcpp::Parameter("test.initial_rotation_min_angle", 12.0),
-      rclcpp::Parameter("test.final_rotation", false),
+      rclcpp::Parameter("test.initial_rotation_tolerance", 0.0),
+      rclcpp::Parameter("test.prefer_final_rotation", false),
       rclcpp::Parameter("test.rotation_scaling_factor", 13.0),
       rclcpp::Parameter("test.allow_backward", true)});
 
@@ -309,7 +292,8 @@ TEST(GracefulControllerTest, dynamicParameters) {
 
   // Check parameters
   EXPECT_EQ(node->get_parameter("test.transform_tolerance").as_double(), 1.0);
-  EXPECT_EQ(node->get_parameter("test.motion_target_dist").as_double(), 2.0);
+  EXPECT_EQ(node->get_parameter("test.min_lookahead").as_double(), 1.0);
+  EXPECT_EQ(node->get_parameter("test.max_lookahead").as_double(), 2.0);
   EXPECT_EQ(node->get_parameter("test.k_phi").as_double(), 4.0);
   EXPECT_EQ(node->get_parameter("test.k_delta").as_double(), 5.0);
   EXPECT_EQ(node->get_parameter("test.beta").as_double(), 6.0);
@@ -318,92 +302,41 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.v_linear_max").as_double(), 9.0);
   EXPECT_EQ(node->get_parameter("test.v_angular_max").as_double(), 10.0);
   EXPECT_EQ(node->get_parameter("test.slowdown_radius").as_double(), 11.0);
-  EXPECT_EQ(node->get_parameter("test.initial_rotation").as_bool(), false);
-  EXPECT_EQ(node->get_parameter("test.initial_rotation_min_angle").as_double(), 12.0);
-  EXPECT_EQ(node->get_parameter("test.final_rotation").as_bool(), false);
+  EXPECT_EQ(node->get_parameter("test.initial_rotation_tolerance").as_double(), 0.0);
+  EXPECT_EQ(node->get_parameter("test.prefer_final_rotation").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.rotation_scaling_factor").as_double(), 13.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), true);
 
   // Set initial rotation to true
   results = params->set_parameters_atomically(
-    {rclcpp::Parameter("test.initial_rotation", true)});
+    {rclcpp::Parameter("test.initial_rotation_tolerance", 1.0)});
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
-  // Check parameters. Initial rotation should be false as both cannot be true at the same time
-  EXPECT_EQ(controller->getInitialRotation(), false);
+  // Check parameters. Initial rotation should not be set as both cannot be true at the same time
+  EXPECT_EQ(controller->getInitialRotationTolerance(), 0.0);
   EXPECT_EQ(controller->getAllowBackward(), true);
 
   // Set both initial rotation and allow backward to false
   results = params->set_parameters_atomically(
-    {rclcpp::Parameter("test.initial_rotation", false),
+    {rclcpp::Parameter("test.initial_rotation_tolerance", 0.0),
       rclcpp::Parameter("test.allow_backward", false)});
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
   // Check parameters.
-  EXPECT_EQ(node->get_parameter("test.initial_rotation").as_bool(), false);
+  EXPECT_EQ(node->get_parameter("test.initial_rotation_tolerance").as_double(), 0.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), false);
 
   // Set initial rotation to true
   results = params->set_parameters_atomically(
-    {rclcpp::Parameter("test.initial_rotation", true)});
+    {rclcpp::Parameter("test.initial_rotation_tolerance", 1.0)});
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
-  EXPECT_EQ(controller->getInitialRotation(), true);
+  EXPECT_EQ(controller->getInitialRotationTolerance(), 1.0);
 
   // Set allow backward to true
   results = params->set_parameters_atomically(
     {rclcpp::Parameter("test.allow_backward", true)});
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
   // Check parameters. Now allow backward should be false as both cannot be true at the same time
-  EXPECT_EQ(controller->getInitialRotation(), true);
+  EXPECT_EQ(controller->getInitialRotationTolerance(), 1.0);
   EXPECT_EQ(controller->getAllowBackward(), false);
-}
-
-TEST(GracefulControllerTest, getDifferentMotionTargets) {
-  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("testGraceful");
-  auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
-
-  // Create controller
-  auto controller = std::make_shared<GMControllerFixture>();
-  costmap_ros->on_configure(rclcpp_lifecycle::State());
-  controller->configure(node, "test", tf, costmap_ros);
-  controller->activate();
-
-  // Set the plan
-  nav_msgs::msg::Path plan;
-  plan.header.frame_id = "map";
-  plan.poses.resize(3);
-  plan.poses[0].header.frame_id = "map";
-  plan.poses[0].pose.position.x = 1.0;
-  plan.poses[0].pose.position.y = 2.0;
-  plan.poses[0].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
-  plan.poses[1].header.frame_id = "map";
-  plan.poses[1].pose.position.x = 3.0;
-  plan.poses[1].pose.position.y = 4.0;
-  plan.poses[1].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
-  plan.poses[2].header.frame_id = "map";
-  plan.poses[2].pose.position.x = 5.0;
-  plan.poses[2].pose.position.y = 6.0;
-  plan.poses[2].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
-  controller->setPlan(plan);
-
-  // Set distance and get motion target
-  double motion_target_distance = 3.5;
-  auto motion_target = controller->getMotionTarget(motion_target_distance, plan);
-
-  // Check results, should be the second one
-  EXPECT_EQ(motion_target.header.frame_id, "map");
-  EXPECT_EQ(motion_target.pose.position.x, 3.0);
-  EXPECT_EQ(motion_target.pose.position.y, 4.0);
-  EXPECT_EQ(motion_target.pose.orientation, tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0)));
-
-  // Set a new distance greater than the path length and get motion target
-  motion_target_distance = 10.0;
-  motion_target = controller->getMotionTarget(motion_target_distance, plan);
-
-  // Check results: should be the last one
-  EXPECT_EQ(motion_target.header.frame_id, "map");
-  EXPECT_EQ(motion_target.pose.position.x, 5.0);
-  EXPECT_EQ(motion_target.pose.position.y, 6.0);
-  EXPECT_EQ(motion_target.pose.orientation, tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0)));
 }
 
 TEST(GracefulControllerTest, createMotionTargetMsg) {
@@ -937,12 +870,12 @@ TEST(GracefulControllerTest, computeVelocityCommandRotate) {
   plan.poses[0].pose.position.y = 0.0;
   plan.poses[0].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
   plan.poses[1].header.frame_id = "test_global_frame";
-  plan.poses[1].pose.position.x = 1.0;
-  plan.poses[1].pose.position.y = 1.0;
+  plan.poses[1].pose.position.x = 0.5;
+  plan.poses[1].pose.position.y = 0.5;
   plan.poses[1].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
   plan.poses[2].header.frame_id = "test_global_frame";
-  plan.poses[2].pose.position.x = 2.0;
-  plan.poses[2].pose.position.y = 2.0;
+  plan.poses[2].pose.position.x = 1.0;
+  plan.poses[2].pose.position.y = 1.0;
   plan.poses[2].pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
   controller->setPlan(plan);
 
@@ -960,8 +893,8 @@ TEST(GracefulControllerTest, computeVelocityCommandRotate) {
   // Check results: the robot should rotate in place.
   // So, linear velocity should be zero and angular velocity should be a positive value below 0.5.
   EXPECT_EQ(cmd_vel.twist.linear.x, 0.0);
-  EXPECT_GE(cmd_vel.twist.angular.x, 0.0);
-  EXPECT_LE(cmd_vel.twist.angular.x, 0.5);
+  EXPECT_GT(cmd_vel.twist.angular.z, 0.0);
+  EXPECT_LE(cmd_vel.twist.angular.z, 0.5);
 }
 
 TEST(GracefulControllerTest, computeVelocityCommandRegular) {
@@ -1045,7 +978,7 @@ TEST(GracefulControllerTest, computeVelocityCommandRegularBackwards) {
 
   // Set initial rotation false and allow backward to true
   nav2_util::declare_parameter_if_not_declared(
-    node, "test.initial_rotation", rclcpp::ParameterValue(false));
+    node, "test.initial_rotation_tolerance", rclcpp::ParameterValue(0.0));
   nav2_util::declare_parameter_if_not_declared(
     node, "test.allow_backward", rclcpp::ParameterValue(true));
 

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -285,6 +285,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.initial_rotation_tolerance", 0.0),
       rclcpp::Parameter("test.prefer_final_rotation", false),
       rclcpp::Parameter("test.rotation_scaling_factor", 13.0),
+      rclcpp::Parameter("test.v_angular_min_in_place", 14.0),
       rclcpp::Parameter("test.allow_backward", true)});
 
   // Spin
@@ -305,6 +306,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.initial_rotation_tolerance").as_double(), 0.0);
   EXPECT_EQ(node->get_parameter("test.prefer_final_rotation").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.rotation_scaling_factor").as_double(), 13.0);
+  EXPECT_EQ(node->get_parameter("test.v_angular_min_in_place").as_double(), 14.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), true);
 
   // Set initial rotation to true

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -288,7 +288,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.prefer_final_rotation", false),
       rclcpp::Parameter("test.rotation_scaling_factor", 13.0),
       rclcpp::Parameter("test.allow_backward", true),
-      rclcpp::Parameter("test.in_place_collision_tolerance", 15.0)});
+      rclcpp::Parameter("test.in_place_collision_resolution", 15.0)});
 
   // Spin
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
@@ -311,7 +311,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.prefer_final_rotation").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.rotation_scaling_factor").as_double(), 13.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), true);
-  EXPECT_EQ(node->get_parameter("test.in_place_collision_tolerance").as_double(), 15.0);
+  EXPECT_EQ(node->get_parameter("test.in_place_collision_resolution").as_double(), 15.0);
 
   // Set initial rotation to true
   results = params->set_parameters_atomically(

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -251,7 +251,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
 
   // Set initial rotation and allow backward to true so it warns and allow backward is false
   nav2_util::declare_parameter_if_not_declared(
-    node, "test.initial_rotation", rclcpp::ParameterValue(true));
+    node, "test.initial_rotation_tolerance", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
     node, "test.allow_backward", rclcpp::ParameterValue(true));
 
@@ -828,6 +828,8 @@ TEST(GracefulControllerTest, computeVelocityCommandRotate) {
     node, "test.v_angular_max", rclcpp::ParameterValue(1.0));
   nav2_util::declare_parameter_if_not_declared(
     node, "test.rotation_scaling_factor", rclcpp::ParameterValue(0.5));
+  nav2_util::declare_parameter_if_not_declared(
+    node, "test.add_orientations", rclcpp::ParameterValue(true));
 
   // Create a costmap of 10x10 meters
   auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
@@ -1137,8 +1139,8 @@ TEST(GracefulControllerTest, computeVelocityCommandFinal) {
   // Check results: the robot should do a final rotation near the target.
   // So, linear velocity should be zero and angular velocity should be a positive value below 0.5.
   EXPECT_EQ(cmd_vel.twist.linear.x, 0.0);
-  EXPECT_GE(cmd_vel.twist.angular.x, 0.0);
-  EXPECT_LE(cmd_vel.twist.angular.x, 0.5);
+  EXPECT_GT(cmd_vel.twist.angular.z, 0.0);
+  EXPECT_LE(cmd_vel.twist.angular.z, 0.5);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -286,7 +286,8 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.prefer_final_rotation", false),
       rclcpp::Parameter("test.rotation_scaling_factor", 13.0),
       rclcpp::Parameter("test.v_angular_min_in_place", 14.0),
-      rclcpp::Parameter("test.allow_backward", true)});
+      rclcpp::Parameter("test.allow_backward", true),
+      rclcpp::Parameter("test.add_orientations", true)});
 
   // Spin
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
@@ -308,6 +309,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.rotation_scaling_factor").as_double(), 13.0);
   EXPECT_EQ(node->get_parameter("test.v_angular_min_in_place").as_double(), 14.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), true);
+  EXPECT_EQ(node->get_parameter("test.add_orientations").as_bool(), true);
 
   // Set initial rotation to true
   results = params->set_parameters_atomically(


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4115 |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | UBR-1 |
| Does this PR contain AI generated software? | No, only real intelligence was used |

---

## Description of contribution in a few bullet points

 * Iteratively selects a valid target pose to use with the control law. This is done by forward simulating the control law towards the target pose and rejecting the target pose if there is a collision detected.
 * Adds collision checking to the "final_rotation". If this fails, we will attempt to roll out further movement via the control law (this is especially important for non-circular robots!). With this in mind, the parameter `final_rotation` has been renamed to `prefer_final_rotation`.
 * Modifies how `final_rotation` is done a bit - this is closer to how the `graceful_controller` did it. When `prefer_final_rotation` is true, we ignore the rotation of the final pose in the path and drive straight towards (and then do an in-place rotation). Previously, this code was simply using `final_rotation` as "do we latch and rotate", which is only half the battle if you aren't using a kinematically aware planner.

## Description of documentation updates required from your changes

 * Replaces `motion_target_dist` parameter with two new parameters: `min_lookahead` and `max_lookahead`.
 * Renames `final_rotation` to `prefer_final_rotation` (to match `graceful_controller` and also indicate that this doesn't actually ensure there is a final rotation, just that the controller will prefer to generate one if it is collision free)
 * Replace boolean `initial_rotation` and double `initial_rotation_min_angle` with `initial_rotation_tolerance` which is a better name for what this parameter does (and avoids needing two parameters to do one thing). This also involved a number of tests updates to ensure that `initial_rotation_tolerance` cannot conflict with `allow_backward`.
 * Adds parameter `v_angular_min_in_place` to make sure that  rotation commands actually work.
 * Fixed a test that was erroneously looking at `twist.angular.x`

## Future work that may be required in bullet points

These will be done before this converts from DRAFT:

 - [x] This still needs to be tested on robot (I'm simply opening for visibility and to see where we are in terms of code coverage)
 - [x] ~~There is a TODO around returning cmd_vel when TF fails - this seems like the wrong thing to do, need to look at it closer~~ - updated this to throw, similar to no command found
 - [x] ~~Review parameter `max_robot_pose_search_dist` - seems to be a potentially VERY large number?~~ This is consistent with other controllers in nav2
 - [x] Port orientation filter (at least NavfnPlanner doesn't set orientations)
 
#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
