### PR TITLE
Creating auto-transition option for nav2_util::LifecycleNode nodes without the need of a lifecycle manager

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -169,6 +169,11 @@ public:
   }
 
   /**
+   * @brief Automatically configure and active the node
+   */
+  void autostart();
+
+  /**
    * @brief Perform preshutdown activities before our Context is shutdown.
    * Note that this is related to our Context's shutdown sequence, not the
    * lifecycle node state machine.
@@ -207,6 +212,7 @@ protected:
   // Connection to tell that server is still up
   std::unique_ptr<bond::Bond> bond_{nullptr};
   double bond_heartbeat_period;
+  rclcpp::TimerBase::SharedPtr autostart_timer_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -26,6 +26,27 @@ public:
 };
 RclCppFixture g_rclcppfixture;
 
+class LifecycleTransitionTestNode : public nav2_util::LifecycleNode
+{
+public:
+  explicit LifecycleTransitionTestNode(rclcpp::NodeOptions options)
+  : nav2_util::LifecycleNode("test_node", "", options) {}
+
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State &) override
+  {
+    configured = true;
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State &) override
+  {
+    activated = true;
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  bool configured{false};
+  bool activated{false};
+};
+
 // For the following two tests, if the LifecycleNode doesn't shut down properly,
 // the overall test will hang since the rclcpp thread will still be running,
 // preventing the executable from exiting (the test will hang)
@@ -46,6 +67,30 @@ TEST(LifecycleNode, MultipleRclcppNodesExitCleanly)
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
   SUCCEED();
+}
+
+TEST(LifecycleNode, AutostartTransitions)
+{
+  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<LifecycleTransitionTestNode>(options);
+  executor->add_node(node->get_node_base_interface());
+  executor->spin_some();
+  EXPECT_FALSE(node->configured);
+  EXPECT_FALSE(node->activated);
+  executor.reset();
+  node.reset();
+
+
+  executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  options.parameter_overrides({{"autostart_node", true}});
+  node = std::make_shared<LifecycleTransitionTestNode>(options);
+  executor->add_node(node->get_node_base_interface());
+  executor->spin_some();
+  EXPECT_TRUE(node->configured);
+  EXPECT_TRUE(node->activated);
+  executor.reset();
+  node.reset();
 }
 
 TEST(LifecycleNode, OnPreshutdownCbFires)


### PR DESCRIPTION
seems like a useful widget for users!