### PR TITLE
nav2_collision_monitor: Obstacle detection topic (True if an obstacle is detected by the collision monitor) for Humble branch

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -21,6 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "std_msgs/msg/bool.hpp"
 
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
@@ -111,7 +112,9 @@ protected:
    */
   bool getParameters(
     std::string & cmd_vel_in_topic,
-    std::string & cmd_vel_out_topic);
+    std::string & cmd_vel_out_topic,
+    std::string & obstacle_detection_topic,
+    double& obstacle_det_hz);
   /**
    * @brief Supporting routine creating and configuring all polygons
    * @param base_frame_id Robot base frame ID
@@ -178,9 +181,14 @@ protected:
    * @param robot_action Robot action to print
    * @param action_polygon Pointer to a polygon causing a selected action
    */
+
+  void publishAction(
+    const Action & robot_action) const;
+
+  void publishObstacleDetected() const;
+
   void printAction(
     const Action & robot_action, const std::shared_ptr<Polygon> action_polygon) const;
-
   /**
    * @brief Polygons publishing routine. Made for visualization.
    */
@@ -205,8 +213,16 @@ protected:
   /// @brief Output cmd_vel publisher
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
 
+  /// @brief Obstacle detection flag publisher
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr obstacle_detected_pub_;
+
+  rclcpp::TimerBase::SharedPtr obstacle_publish_timer_;
+
+
   /// @brief Whether main routine is active
   bool process_active_;
+
+  mutable bool obstacle_detected_;
 
   /// @brief Previous robot action
   Action robot_action_prev_;

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -9,6 +9,8 @@ collision_monitor:
     source_timeout: 5.0
     base_shift_correction: True
     stop_pub_timeout: 2.0
+    obstacle_detection_topic: "obstacle_detection"   # Topic for obstcle detection
+    obstacle_det_hz: 30.0                            # Frequency for obstcle detection
     # Polygons represent zone around the robot for "stop" and "slowdown" action types,
     # and robot footprint for "approach" action type.
     # Footprint could be "polygon" type with dynamically set footprint from footprint_topic


### PR DESCRIPTION

## Basic Info

| Ticket(s) this addresses | N/A |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | (Wonbot) |
| Does this PR contain AI generated software? | (No) |

## Description of contribution 

Added a std_msgs::msg::Bool flag called obstacle_detected to the nav2_collision_monitor node for ROS 2 Humble.
Published the obstacle_detected flag as a ROS 2 topic whenever an obstacle is detected based on the collision polygons.
Implemented continuous publishing of the flag using a reentrant timer at 30 Hz within the same node.
This change simplifies the process by integrating the detection and flag publication into a single node, unlike in the Jazzy version, where a separate detection node was required.
Additionally, added two parameters:

obstacle_detection_topic: Used to set the topic for obstacle detection.
obstacle_det_hz: Used to set the frequency at which the flag is published.


## Description of documentation updates 

Add the new obstacle_detected topic to the nav2_collision_monitor documentation, including details about its purpose and publishing frequency.
Document the removal of the need for a separate detector node, as the flag is now published directly by the collision monitor.
Document about this two parameters obstacle_detection_topic, obstacle_det_hz.

## Future work that may be required in bullet points

Test this feature on a wider variety of robotic platforms, including omnidirectional robots, to ensure consistent behavior.
Explore the possibility of customizing the obstacle_detected topic publishing frequency through a parameter.
Add more detailed logging for easier debugging of obstacles detected by specific polygons.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists.

## Additional Notes

This PR addresses a missing feature in the ROS 2 Humble version of nav2_collision_monitor that was present in the Jazzy version.
