### PR TITLE
Add acceleration limits to DriveOnHeading and BackUp behaviors

### DIFF
--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -266,6 +266,11 @@ protected:
     node->get_parameter(this->behavior_name_ + ".acceleration_limit", acceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".deceleration_limit", deceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".minimum_speed", minimum_speed_);
+    if (acceleration_limit_ < 0.0 || deceleration_limit_ > 0.0) {
+      RCLCPP_ERROR(this->logger_, "DriveOnHeading: acceleration_limit and deceleration_limit must be "
+        "positive and negative respectively");
+      throw std::runtime_error{"Invalid parameter: acceleration_limit or deceleration_limit"};
+    }
   }
 
   typename ActionT::Feedback::SharedPtr feedback_;

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <memory>
 #include <utility>
+#include <limits>
 
 #include "nav2_behaviors/timed_behavior.hpp"
 #include "nav2_msgs/action/drive_on_heading.hpp"

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -187,15 +187,9 @@ public:
    */
   CostmapInfoType getResourceInfo() override {return CostmapInfoType::LOCAL;}
 
-  void onCleanup() override
-  {
-    last_vel_.reset();
-  }
+  void onCleanup() override {last_vel_.reset();}
 
-  void onActionCompletion() override
-  {
-    last_vel_.reset();
-  }
+  void onActionCompletion() override {last_vel_.reset();}
 
 protected:
   /**

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -261,7 +261,7 @@ protected:
       rclcpp::ParameterValue(-2.5));
     nav2_util::declare_parameter_if_not_declared(
       node, this->behavior_name_ + ".minimum_speed",
-      rclcpp::ParameterValue(0.01));
+      rclcpp::ParameterValue(0.10));
     node->get_parameter(this->behavior_name_ + ".acceleration_limit", acceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".deceleration_limit", deceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".minimum_speed", minimum_speed_);

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -135,6 +135,7 @@ public:
     cmd_vel->twist.linear.y = 0.0;
     cmd_vel->twist.angular.z = 0.0;
     if (acceleration_limit_ <= 0.0 || deceleration_limit_ >= 0.0) {
+      RCLCPP_INFO_ONCE(this->logger_, "DriveOnHeading: no acceleration or deceleration limits set");
       cmd_vel->twist.linear.x = command_speed_;
     } else {
       double current_speed = last_vel_ == std::numeric_limits<double>::max() ? 0.0 : last_vel_;

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -260,7 +260,7 @@ protected:
     node->get_parameter(this->behavior_name_ + ".acceleration_limit", acceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".deceleration_limit", deceleration_limit_);
     node->get_parameter(this->behavior_name_ + ".minimum_speed", minimum_speed_);
-    if (acceleration_limit_ < 0.0 || deceleration_limit_ > 0.0) {
+    if (acceleration_limit_ <= 0.0 || deceleration_limit_ >= 0.0) {
       RCLCPP_ERROR(this->logger_,
         "DriveOnHeading: acceleration_limit and deceleration_limit must be "
         "positive and negative respectively");

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -150,12 +150,12 @@ public:
 
       // Check if we need to slow down to avoid overshooting
       bool forward = command_speed_ > 0.0 ? true : false;
-      if ((forward && deceleration_limit_ > 0.0)) {
+      if (forward && deceleration_limit_ > 0.0) {
         double max_vel_to_stop = std::sqrt(2.0 * deceleration_limit_ * remaining_distance);
         if (max_vel_to_stop < cmd_vel->twist.linear.x) {
           cmd_vel->twist.linear.x = max_vel_to_stop;
         }
-      } else if ((!forward && acceleration_limit_ > 0.0)) {
+      } else if (!forward && acceleration_limit_ > 0.0) {
         double max_vel_to_stop = -std::sqrt(2.0 * acceleration_limit_ * remaining_distance);
         if (max_vel_to_stop > cmd_vel->twist.linear.x) {
           cmd_vel->twist.linear.x = max_vel_to_stop;

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -264,7 +264,8 @@ protected:
       RCLCPP_ERROR(this->logger_,
         "DriveOnHeading: acceleration_limit and deceleration_limit must be "
         "positive and negative respectively");
-      throw std::runtime_error{"Invalid parameter: acceleration_limit or deceleration_limit"};
+      acceleration_limit_ = std::abs(acceleration_limit_);
+      deceleration_limit_ = -std::abs(deceleration_limit_);
     }
   }
 

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -184,7 +184,11 @@ public:
 
   void onCleanup() override {last_vel_ = std::numeric_limits<double>::max();}
 
-  void onActionCompletion() override {last_vel_ = std::numeric_limits<double>::max();}
+  void onActionCompletion(std::shared_ptr<typename ActionT::Result>/*result*/)
+  override
+  {
+    last_vel_ = std::numeric_limits<double>::max();
+  }
 
 protected:
   /**

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -134,29 +134,23 @@ public:
     cmd_vel->header.frame_id = this->robot_base_frame_;
     cmd_vel->twist.linear.y = 0.0;
     cmd_vel->twist.angular.z = 0.0;
-    if (acceleration_limit_ <= 0.0 && deceleration_limit_ <= 0.0) {
+    if (acceleration_limit_ <= 0.0 || deceleration_limit_ <= 0.0) {
       cmd_vel->twist.linear.x = command_speed_;
     } else {
       double current_speed = last_vel_ == std::numeric_limits<double>::max() ? 0.0 : last_vel_;
-      auto remaining_distance = std::fabs(command_x_) - distance;
-      double min_feasible_speed = -std::numeric_limits<double>::infinity();
-      double max_feasible_speed = std::numeric_limits<double>::infinity();
-      if (deceleration_limit_ > 0.0) {
-        min_feasible_speed = current_speed - deceleration_limit_ / this->cycle_frequency_;
-      }
-      if (acceleration_limit_ > 0.0) {
-        max_feasible_speed = current_speed + acceleration_limit_ / this->cycle_frequency_;
-      }
+
+      double min_feasible_speed = current_speed - deceleration_limit_ / this->cycle_frequency_;
+      double max_feasible_speed = current_speed + acceleration_limit_ / this->cycle_frequency_;
       cmd_vel->twist.linear.x = std::clamp(command_speed_, min_feasible_speed, max_feasible_speed);
 
       // Check if we need to slow down to avoid overshooting
-      bool forward = command_speed_ > 0.0;
-      if (forward && deceleration_limit_ > 0.0) {
+      auto remaining_distance = std::fabs(command_x_) - distance;
+      if (command_speed_ > 0.0) {
         double max_vel_to_stop = std::sqrt(2.0 * deceleration_limit_ * remaining_distance);
         if (max_vel_to_stop < cmd_vel->twist.linear.x) {
           cmd_vel->twist.linear.x = max_vel_to_stop;
         }
-      } else if (!forward && acceleration_limit_ > 0.0) {
+      } else {
         double max_vel_to_stop = -std::sqrt(2.0 * acceleration_limit_ * remaining_distance);
         if (max_vel_to_stop > cmd_vel->twist.linear.x) {
           cmd_vel->twist.linear.x = max_vel_to_stop;

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -319,10 +319,12 @@ behavior_server:
       plugin: "nav2_behaviors::BackUp"
       acceleration_limit: 2.5
       deceleration_limit: -2.5
+      minimum_speed: 0.01
     drive_on_heading:
       plugin: "nav2_behaviors::DriveOnHeading"
       acceleration_limit: 2.5
       deceleration_limit: -2.5
+      minimum_speed: 0.01
     wait:
       plugin: "nav2_behaviors::Wait"
     assisted_teleop:

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -317,8 +317,12 @@ behavior_server:
       plugin: "nav2_behaviors::Spin"
     backup:
       plugin: "nav2_behaviors::BackUp"
+      acceleration_limit: 2.5
+      deceleration_limit: -2.5
     drive_on_heading:
       plugin: "nav2_behaviors::DriveOnHeading"
+      acceleration_limit: 2.5
+      deceleration_limit: -2.5
     wait:
       plugin: "nav2_behaviors::Wait"
     assisted_teleop:

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -319,12 +319,12 @@ behavior_server:
       plugin: "nav2_behaviors::BackUp"
       acceleration_limit: 2.5
       deceleration_limit: -2.5
-      minimum_speed: 0.01
+      minimum_speed: 0.10
     drive_on_heading:
       plugin: "nav2_behaviors::DriveOnHeading"
       acceleration_limit: 2.5
       deceleration_limit: -2.5
-      minimum_speed: 0.01
+      minimum_speed: 0.10
     wait:
       plugin: "nav2_behaviors::Wait"
     assisted_teleop:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | own robot hardware |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
 Added two params: `acceleration_limit` and `deceleration_limit` for DriveOnHeading and BackUp behaviors.

## Description of documentation updates required from your changes
Added new parameter, so need to add that to default configs and documentation page

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
