### PR TITLE
fix bug in use of v_angular_min_in_place

### DIFF
--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -367,7 +367,7 @@ geometry_msgs::msg::Twist GracefulController::rotateToTarget(double angle_to_tar
   geometry_msgs::msg::Twist vel;
   vel.linear.x = 0.0;
   vel.angular.z = params_->rotation_scaling_factor * angle_to_target * params_->v_angular_max;
-  vel.angular.z = std::copysign(1.0, vel.angular.z) * std::min(abs(vel.angular.z),
+  vel.angular.z = std::copysign(1.0, vel.angular.z) * std::max(abs(vel.angular.z),
       params_->v_angular_min_in_place);
   return vel;
 }

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -461,6 +461,19 @@ TEST(GracefulControllerTest, rotateToTarget) {
   // Check results: it must be a negative rotation
   EXPECT_EQ(cmd_vel.linear.x, 0.0);
   EXPECT_EQ(cmd_vel.angular.z, -0.25);
+
+  // Set very high v_angular_min_in_place velocity
+  results = params->set_parameters_atomically(
+    {rclcpp::Parameter("test.v_angular_min_in_place", 1.0)});
+  rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
+
+  // Set a new angle to target
+  angle_to_target = 0.5;
+  cmd_vel = controller->rotateToTarget(angle_to_target);
+
+  // Check results: positive velocity, at least as high as min_in_place
+  EXPECT_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_EQ(cmd_vel.angular.z, 1.0);
 }
 
 TEST(GracefulControllerTest, setSpeedLimit) {


### PR DESCRIPTION
As I was pulling the documentation together for #4795 - I noticed this logic was backwards. I added test first (which failed of course) and then fixed the bug.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | UBR-1 |
| Does this PR contain AI generated software? |No |

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
