### PR TITLE
fix fatal error: cv_bridge/cv_bridge.hpp: No such file or directory

### DIFF
--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
@@ -26,7 +26,7 @@
 #include "nav2_core/waypoint_task_executor.hpp"
 #include "opencv2/core.hpp"
 #include "opencv2/opencv.hpp"
-#include "cv_bridge/cv_bridge.hpp"
+#include "cv_bridge/cv_bridge.h"
 #include "image_transport/image_transport.hpp"
 
 


### PR DESCRIPTION
Does not address any ticket, encountered the bug while building from source
Tested on Ubuntu 24.04