### PR TITLE
fix bug in orientation filtering

### DIFF
--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -426,12 +426,14 @@ void GracefulController::computeDistanceAlongPath(
 void GracefulController::validateOrientations(
   std::vector<geometry_msgs::msg::PoseStamped> & path)
 {
-  // This really shouldn't happen
-  if (path.empty()) {return;}
+  // We never change the orientation of the first & last pose
+  // So we need at least three poses to do anything here
+  if (path.size() < 3) {return;}
 
   // Check if we actually need to add orientations
-  for (size_t i = 1; i < path.size() - 1; ++i) {
-    if (tf2::getYaw(path[i].pose.orientation) != 0.0) {return;}
+  double initial_yaw = tf2::getYaw(path[1].pose.orientation);
+  for (size_t i = 2; i < path.size() - 1; ++i) {
+    if (tf2::getYaw(path[i].pose.orientation) != initial_yaw) {return;}
   }
 
   // For each pose, point at the next one

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 
+#include "angles/angles.h"
 #include "nav2_core/controller_exceptions.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_graceful_controller/graceful_controller.hpp"
@@ -433,7 +434,8 @@ void GracefulController::validateOrientations(
   // Check if we actually need to add orientations
   double initial_yaw = tf2::getYaw(path[1].pose.orientation);
   for (size_t i = 2; i < path.size() - 1; ++i) {
-    if (tf2::getYaw(path[i].pose.orientation) != initial_yaw) {return;}
+    double this_yaw = tf2::getYaw(path[i].pose.orientation);
+    if (angles::shortest_angular_distance(this_yaw, initial_yaw) > 1e-6) {return;}
   }
 
   // For each pose, point at the next one


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot sim |
| Does this PR contain AI generated software? |No |

---

## Description of contribution in a few bullet points

Some global planners output all zeros for orientation, however the plan is in the global frame. When transforming to the local frame, the orientation is no longer zero. Instead of comparing to zero, we simply check if all the orientations in the middle of the plan are equal.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
