### PR TITLE
intraprocess bond::Bond::BondStatusCB use after free

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_cloud.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_cloud.cpp
@@ -193,15 +193,13 @@ void voxelCallback(const nav2_msgs::msg::VoxelGrid::ConstSharedPtr grid)
   pcl_header.frame_id = frame_id;
   pcl_header.stamp = stamp;
 
-  if (pub_marked->get_subscription_count() > 0)
-  {
+  if (pub_marked->get_subscription_count() > 0) {
     auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
     pointCloud2Helper(cloud, num_marked, pcl_header, g_marked);
     pub_marked->publish(std::move(cloud));
   }
 
-  if (pub_unknown->get_subscription_count() > 0)
-  {
+  if (pub_unknown->get_subscription_count() > 0) {
     auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
     pointCloud2Helper(cloud, num_unknown, pcl_header, g_unknown);
     pub_unknown->publish(std::move(cloud));

--- a/nav2_graceful_controller/include/nav2_graceful_controller/utils.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/utils.hpp
@@ -15,6 +15,8 @@
 #ifndef NAV2_GRACEFUL_CONTROLLER__UTILS_HPP_
 #define NAV2_GRACEFUL_CONTROLLER__UTILS_HPP_
 
+#include <memory>
+
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "visualization_msgs/msg/marker.hpp"

--- a/nav2_lifecycle_manager/test/test_bond.cpp
+++ b/nav2_lifecycle_manager/test/test_bond.cpp
@@ -90,7 +90,7 @@ public:
 
   void breakBond()
   {
-    bond_->breakBond();
+    bond_.reset();
   }
 
   std::string getState()

--- a/nav2_lifecycle_manager/test/test_bond.cpp
+++ b/nav2_lifecycle_manager/test/test_bond.cpp
@@ -170,7 +170,7 @@ TEST(LifecycleBondTest, POSITIVE)
 
 TEST(LifecycleBondTest, NEGATIVE)
 {
-  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_service_client");
+  auto node = nav2_util::generate_internal_node("lifecycle_manager_test_service_client");
   nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test", node);
 
   // create node, now without bond setup to connect to. Should fail because no bond

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -210,7 +210,7 @@ protected:
   void runCleanups();
 
   // Connection to tell that server is still up
-  std::unique_ptr<bond::Bond> bond_{nullptr};
+  std::shared_ptr<bond::Bond> bond_{nullptr};
   double bond_heartbeat_period;
   rclcpp::TimerBase::SharedPtr autostart_timer_;
 };

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -73,7 +73,7 @@ void LifecycleNode::createBond()
   if (bond_heartbeat_period > 0.0) {
     RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
 
-    bond_ = std::make_unique<bond::Bond>(
+    bond_ = std::make_shared<bond::Bond>(
       std::string("bond"),
       this->get_name(),
       shared_from_this());

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -149,7 +149,7 @@ void LifecycleNode::destroyBond()
     RCLCPP_INFO(get_logger(), "Destroying bond (%s) to lifecycle manager.", this->get_name());
 
     if (bond_) {
-      bond_.reset();
+      bond_->breakBond();
     }
   }
 }

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -11,18 +11,18 @@ repositories:
   #   type: git
   #   url: https://github.com/ros-perception/vision_opencv.git
   #   version: rolling
-  # ros/bond_core:
-  #   type: git
-  #   url: https://github.com/ros/bond_core.git
-  #   version: ros2
+  ros/bond_core:
+    type: git
+    url: https://github.com/ewak/bond_core.git
+    version: feature/mw/memory_safe_subscription_callback
   # ros/diagnostics:
   #   type: git
   #   url: https://github.com/ros/diagnostics.git
-  #   version: ros2-devel   
+  #   version: ros2-devel
   # ros/geographic_info:
   #   type: git
   #   url: https://github.com/ros-geographic-info/geographic_info.git
-  #   version: ros2      
+  #   version: ros2
   # ompl/ompl:
   #   type: git
   #   url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
The Bond mechanism includes creation of a subscription using a reference to a member function(bondStatusCB) of the Bond class.

This member function operates on member variables.

The lifecycle_node was calling bond_.reset() which releases the memory as far as the lifecycle_node
is concerned but this is not immediately released
from the rclcpp internal mechanisms (especially intraprocess). As a result the bondStatusCB function can called after it has been freed.  This use after free shows up reliably with asan when running the test_bond test.

This change allows the test_bond to suceed by
calling bond_->breakBond() (rather than bond_.reset()) to break the bond rather than expecting it to
be done cleanly by the ~Bond() destructor.

Is it enough is TBC.

Other possibilities might be to get the Bond to
inherit from std::enable_shared_from_this(), as Ros2 Nodes do, so that the pointer to the Bond member function bondStatusCB function remains valid until the subscription is released during destruction.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4691 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | none |
| Does this PR contain AI generated software? | no |

---

## Description of contribution in a few bullet points

Call bond_->breakBond() in on_deactivate rather than bond_.reset() to avoid use after free caused by dangling pointer held by rclcpp intraprocess subscription callback mechanism.

## Description of documentation updates required from your changes

none

---

## Future work that may be required in bullet points

* Consider effect of only using breakBond() rather than reset().  
* Should LifeCycleNode::destroyBond() wait for some timeout for the bond->breakBond() to take affect using waitUntilBroken() ?
* Figure out an improvement to rclcpp intraprocess subscription mechanism to check for memory lifetime of passed in callback function.
* Maybe make changes to bondcpp to have Bond inherit from std::enable_shared_from_this() to extend the lifetime of the subscription callback function.
* Consider creating the bond_ as a shared_ptr rather than a unique_ptr to allow the internal mechanisms of rclcpp to hold onto valid memory until they have a chance to cleanup properly.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
