### PR TITLE
[Smac Planner] expansion uses cell cost

### DIFF
--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -151,14 +151,14 @@ bool GridCollisionChecker::inCollision(
       current_footprint.push_back(new_pt);
     }
 
-    footprint_cost_ = static_cast<float>(footprintCost(current_footprint));
+    float footprint_cost = static_cast<float>(footprintCost(current_footprint));
 
-    if (footprint_cost_ == UNKNOWN_COST && traverse_unknown) {
+    if (footprint_cost == UNKNOWN_COST && traverse_unknown) {
       return false;
     }
 
     // if occupied or unknown and not to traverse unknown space
-    return footprint_cost_ >= OCCUPIED_COST;
+    return footprint_cost >= OCCUPIED_COST;
   } else {
     // if radius, then we can check the center of the cost assuming inflation is used
     footprint_cost_ = static_cast<float>(costmap_->getCost(

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -671,13 +671,7 @@ float NodeHybrid::getObstacleHeuristic(
           cost = static_cast<float>(costmap->getCost(new_idx));
         }
 
-        if (!is_circular) {
-          // Adjust cost value if using SE2 footprint checks
-          cost = adjustedFootprintCost(cost);
-          if (cost >= OCCUPIED_COST) {
-            continue;
-          }
-        } else if (cost >= INSCRIBED_COST) {
+        if (cost >= INSCRIBED_COST) {
           continue;
         }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #4808  |
| Primary OS tested on | ubuntu |
| Robotic platform tested on | our robot |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Don't update `footprint_cost_` in `inCollision()` method to keep it with costmap_->getCost() value
* Don't use `adjustedFootprintCost(cost)` in heuristic

This allows `_cell_cost = collision_checker->getCost();` to keep the real cell cost and not the footprint cost.


## Future work that may be required in bullet points

- Maybe change the name `footprint_cost_` as its not the footprint cost anymore.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
