### PR TITLE
Fixes smac planner non-circular footprint search issue

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
@@ -127,7 +127,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::vector<nav2_costmap_2d::Footprint> oriented_footprints_;
   nav2_costmap_2d::Footprint unoriented_footprint_;
-  float footprint_cost_;
+  float center_cost_;
   bool footprint_is_radius_;
   std::vector<float> angles_;
   float possible_collision_cost_{-1};

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -437,14 +437,6 @@ public:
     const unsigned int & goal_x, const unsigned int & goal_y);
 
   /**
-   * @brief Using the inflation layer, find the footprint's adjusted cost
-   * if the robot is non-circular
-   * @param cost Cost to adjust
-   * @return float Cost adjusted
-   */
-  static float adjustedFootprintCost(const float & cost);
-
-  /**
    * @brief Retrieve all valid neighbors of a node.
    * @param validity_checker Functor for state validity checking
    * @param collision_checker Collision checker to use
@@ -471,7 +463,6 @@ public:
     */
   static void destroyStaticAssets()
   {
-    inflation_layer.reset();
     costmap_ros.reset();
   }
 
@@ -486,7 +477,6 @@ public:
   static ObstacleHeuristicQueue obstacle_heuristic_queue;
 
   static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
-  static std::shared_ptr<nav2_costmap_2d::InflationLayer> inflation_layer;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
   static LookupTable dist_heuristic_lookup_table;
   static float size_lookup;

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -41,7 +41,6 @@ HybridMotionTable NodeHybrid::motion_table;
 float NodeHybrid::size_lookup = 25;
 LookupTable NodeHybrid::dist_heuristic_lookup_table;
 std::shared_ptr<nav2_costmap_2d::Costmap2DROS> NodeHybrid::costmap_ros = nullptr;
-std::shared_ptr<nav2_costmap_2d::InflationLayer> NodeHybrid::inflation_layer = nullptr;
 
 ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
 
@@ -492,7 +491,6 @@ void NodeHybrid::resetObstacleHeuristic(
   // erosion of path quality after even modest smoothing. The error would be no more
   // than 0.05 * normalized cost. Since this is just a search prior, there's no loss in generality
   costmap_ros = costmap_ros_i;
-  inflation_layer = nav2_costmap_2d::InflationLayer::getInflationLayer(costmap_ros);
   auto costmap = costmap_ros->getCostmap();
 
   // Clear lookup table
@@ -539,29 +537,6 @@ void NodeHybrid::resetObstacleHeuristic(
   obstacle_heuristic_lookup_table[goal_index] = -0.00001f;
 }
 
-float NodeHybrid::adjustedFootprintCost(const float & cost)
-{
-  if (!inflation_layer) {
-    return cost;
-  }
-
-  const auto layered_costmap = costmap_ros->getLayeredCostmap();
-  const float scale_factor = inflation_layer->getCostScalingFactor();
-  const float min_radius = layered_costmap->getInscribedRadius();
-  float dist_to_obj = (scale_factor * min_radius - log(cost) + log(253.0f)) / scale_factor;
-
-  // Subtract minimum radius for edge cost
-  dist_to_obj -= min_radius;
-  if (dist_to_obj < 0.0f) {
-    dist_to_obj = 0.0f;
-  }
-
-  // Compute cost at this value
-  return static_cast<float>(
-    inflation_layer->computeCost(dist_to_obj / layered_costmap->getCostmap()->getResolution()));
-}
-
-
 float NodeHybrid::getObstacleHeuristic(
   const Coordinates & node_coords,
   const Coordinates &,
@@ -569,7 +544,6 @@ float NodeHybrid::getObstacleHeuristic(
 {
   // If already expanded, return the cost
   auto costmap = costmap_ros->getCostmap();
-  const bool is_circular = costmap_ros->getUseRadius();
   unsigned int size_x = 0u;
   unsigned int size_y = 0u;
   if (motion_table.downsample_obstacle_heuristic) {
@@ -671,13 +645,7 @@ float NodeHybrid::getObstacleHeuristic(
           cost = static_cast<float>(costmap->getCost(new_idx));
         }
 
-        if (!is_circular) {
-          // Adjust cost value if using SE2 footprint checks
-          cost = adjustedFootprintCost(cost);
-          if (cost >= OCCUPIED_COST) {
-            continue;
-          }
-        } else if (cost >= INSCRIBED_COST) {
+        if (cost >= INSCRIBED_COST) {
           continue;
         }
 

--- a/nav2_smac_planner/test/test_collision_checker.cpp
+++ b/nav2_smac_planner/test/test_collision_checker.cpp
@@ -152,17 +152,22 @@ TEST(collision_footprint, test_footprint_at_pose_with_movement)
   nav2_smac_planner::GridCollisionChecker collision_checker(costmap_ros, 72, node);
   collision_checker.setFootprint(footprint, false /*use footprint*/, 0.0);
 
-  collision_checker.inCollision(50, 50, 0.0, false);
+  EXPECT_FALSE(collision_checker.inCollision(50, 50, 0.0, false));
   float cost = collision_checker.getCost();
   EXPECT_NEAR(cost, 128.0, 0.001);
 
-  collision_checker.inCollision(50, 49, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(50, 49, 0.0, false));
   float up_value = collision_checker.getCost();
-  EXPECT_NEAR(up_value, 254.0, 0.001);
+  EXPECT_NEAR(up_value, 128.0, 0.001);  // center cost
 
-  collision_checker.inCollision(50, 52, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(50, 52, 0.0, false));
   float down_value = collision_checker.getCost();
-  EXPECT_NEAR(down_value, 254.0, 0.001);
+  EXPECT_NEAR(down_value, 128.0, 0.001);  // center cost
+
+  EXPECT_TRUE(collision_checker.inCollision(11, 11, 0.0, false));
+  float other_value = collision_checker.getCost();
+  EXPECT_NEAR(other_value, 254.0, 0.001);  // center cost
+
   delete costmap_;
 }
 
@@ -199,16 +204,21 @@ TEST(collision_footprint, test_point_and_line_cost)
   nav2_smac_planner::GridCollisionChecker collision_checker(costmap_ros, 72, node);
   collision_checker.setFootprint(footprint, false /*use footprint*/, 0.0);
 
-  collision_checker.inCollision(50, 50, 0.0, false);
+  EXPECT_FALSE(collision_checker.inCollision(50, 50, 0.0, false));
   float value = collision_checker.getCost();
   EXPECT_NEAR(value, 128.0, 0.001);
 
-  collision_checker.inCollision(49, 50, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(49, 50, 0.0, false));
   float left_value = collision_checker.getCost();
-  EXPECT_NEAR(left_value, 254.0, 0.001);
+  EXPECT_NEAR(left_value, 128.0, 0.001);  // center cost
 
-  collision_checker.inCollision(52, 50, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(52, 50, 0.0, false));
   float right_value = collision_checker.getCost();
-  EXPECT_NEAR(right_value, 254.0, 0.001);
+  EXPECT_NEAR(right_value, 128.0, 0.001);  // center cost
+
+  EXPECT_TRUE(collision_checker.inCollision(39, 60, 0.0, false));
+  float other_value = collision_checker.getCost();
+  EXPECT_NEAR(other_value, 254.0, 0.001);  // center cost
+
   delete costmap_;
 }


### PR DESCRIPTION
Resolves https://github.com/ros-navigation/navigation2/issues/4808  and https://github.com/ros-navigation/navigation2/issues/4314

The optimization was added to allow non-circular robots to use their full footprint costs in the traversibility function and heuristic function formulations. However, in confined settings, it doesn't work very well and its better to collision check using the full footprint **but** continue to use the center point costs for the traversal function / heuristic function formulations. 

Metrics outlined in https://github.com/ros-navigation/navigation2/issues/4808#issuecomment-2580686801 show that this not only fixes the issue but also doesn't impact speeds in open areas - but faster in confined areas due to the ambiguation of inscribed costs. 

TODO
- [x] benchmark
- [ ] backport