### PR TITLE
Fix goal pose stamp

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
@@ -92,9 +92,10 @@ public:
 
   /**
    * @brief Get the global goal pose transformed to the local frame
+   * @param stamp Time to get the goal pose at
    * @return Transformed goal pose
    */
-  geometry_msgs::msg::PoseStamped getTransformedGoal();
+  geometry_msgs::msg::PoseStamped getTransformedGoal(const builtin_interfaces::msg::Time & stamp);
 
 protected:
   /**

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -84,7 +84,7 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
 #endif
 
   std::lock_guard<std::mutex> param_lock(*parameters_handler_->getLock());
-  geometry_msgs::msg::Pose goal = path_handler_.getTransformedGoal().pose;
+  geometry_msgs::msg::Pose goal = path_handler_.getTransformedGoal(robot_pose.header.stamp).pose;
 
   nav_msgs::msg::Path transformed_plan = path_handler_.transformPath(robot_pose);
 

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -186,10 +186,12 @@ void PathHandler::prunePlan(nav_msgs::msg::Path & plan, const PathIterator end)
   plan.poses.erase(plan.poses.begin(), end);
 }
 
-geometry_msgs::msg::PoseStamped PathHandler::getTransformedGoal()
+geometry_msgs::msg::PoseStamped PathHandler::getTransformedGoal(
+  const builtin_interfaces::msg::Time & stamp)
 {
   auto goal = global_plan_.poses.back();
-  goal.header = global_plan_.header;
+  goal.header.frame_id = global_plan_.header.frame_id;
+  goal.header.stamp = stamp;
   if (goal.header.frame_id.empty()) {
     throw nav2_core::ControllerTFError("Goal pose has an empty frame_id");
   }


### PR DESCRIPTION
Follow-up on #4822

## Description of contribution in a few bullet points

* There was a bug in the previous PR: the MPPI critics goal pose now uses stamp from global_path, which gets outdated by the TF buffer, and then fails to transform the goal pose.
* This doesn't come up if the plan is replanned frequently.
* As a solution, this PR uses the `robot_pose.stamp`, which gets updated frequently.

## Description of documentation updates required from your changes

* None required

## Description of how this change was tested

* In a custom simulation and on real robot, on the `humble` branch.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
