### PR TITLE
Nav2 route server goal orientation scorer

### DIFF
--- a/nav2_route/CMakeLists.txt
+++ b/nav2_route/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(edge_scorers SHARED
   src/plugins/edge_cost_functions/penalty_scorer.cpp
   src/plugins/edge_cost_functions/costmap_scorer.cpp
   src/plugins/edge_cost_functions/semantic_scorer.cpp
+  src/plugins/edge_cost_functions/goal_orientation_scorer.cpp
 )
 
 ament_target_dependencies(edge_scorers

--- a/nav2_route/include/nav2_route/edge_scorer.hpp
+++ b/nav2_route/include/nav2_route/edge_scorer.hpp
@@ -26,7 +26,7 @@
 #include "nav2_route/types.hpp"
 #include "nav2_route/utils.hpp"
 #include "nav2_route/interfaces/edge_cost_function.hpp"
-
+#include "geometry_msgs/msg/pose_stamped.hpp"
 namespace nav2_route
 {
 
@@ -57,10 +57,12 @@ public:
   /**
    * @brief Score the edge with the set of plugins
    * @param edge Ptr to edge for scoring
+   * @param goal_pose Pose Stamped of desired goal
    * @param score of edge
+   * @param final_edge whether this edge brings us to the goal or not
    * @return If edge is valid
    */
-  bool score(const EdgePtr edge, float & score);
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & score, bool final_edge);
 
   /**
    * @brief Provide the number of plugisn in the scorer loaded

--- a/nav2_route/include/nav2_route/edge_scorer.hpp
+++ b/nav2_route/include/nav2_route/edge_scorer.hpp
@@ -62,7 +62,9 @@ public:
    * @param final_edge whether this edge brings us to the goal or not
    * @return If edge is valid
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & score, bool final_edge);
+  bool score(
+    const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge,
+    float & score);
 
   /**
    * @brief Provide the number of plugisn in the scorer loaded

--- a/nav2_route/include/nav2_route/interfaces/edge_cost_function.hpp
+++ b/nav2_route/include/nav2_route/interfaces/edge_cost_function.hpp
@@ -62,7 +62,7 @@ public:
    * @param edge The edge pointer to score, which has access to the
    * start/end nodes and their associated metadata and actions
    */
-  virtual bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) = 0;
+  virtual bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) = 0;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/interfaces/edge_cost_function.hpp
+++ b/nav2_route/include/nav2_route/interfaces/edge_cost_function.hpp
@@ -22,6 +22,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "nav2_route/types.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 
 namespace nav2_route
 {
@@ -61,7 +62,7 @@ public:
    * @param edge The edge pointer to score, which has access to the
    * start/end nodes and their associated metadata and actions
    */
-  virtual bool score(const EdgePtr edge, float & cost) = 0;
+  virtual bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) = 0;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/adjust_edges_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/adjust_edges_scorer.hpp
@@ -61,7 +61,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/adjust_edges_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/adjust_edges_scorer.hpp
@@ -61,7 +61,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/costmap_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/costmap_scorer.hpp
@@ -60,7 +60,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/costmap_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/costmap_scorer.hpp
@@ -60,7 +60,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/distance_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/distance_scorer.hpp
@@ -58,7 +58,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/distance_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/distance_scorer.hpp
@@ -58,7 +58,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
@@ -26,13 +26,14 @@
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/utils.h"
+#include "angles/angles.h"
 
 namespace nav2_route
 {
 
 /**
  * @class GoalOrientationScorer
- * @brief Scores final edge by comparing the 
+ * @brief Scores final edge by comparing the
  */
 class GoalOrientationScorer : public EdgeCostFunction
 {
@@ -61,7 +62,9 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(
+    const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost,
+    bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2024, Polymath Robotics Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_ROUTE__PLUGINS__EDGE_COST_FUNCTIONS__GOAl_ORIENTATION_SCORER_HPP_
+#define NAV2_ROUTE__PLUGINS__EDGE_COST_FUNCTIONS__GOAL_ORIENTATION_SCORER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "nav2_route/interfaces/edge_cost_function.hpp"
+#include "nav2_util/line_iterator.hpp"
+#include "nav2_util/node_utils.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/utils.h"
+
+namespace nav2_route
+{
+
+/**
+ * @class GoalOrientationScorer
+ * @brief Scores final edge by comparing the 
+ */
+class GoalOrientationScorer : public EdgeCostFunction
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  GoalOrientationScorer() = default;
+
+  /**
+   * @brief destructor
+   */
+  virtual ~GoalOrientationScorer() = default;
+
+  /**
+   * @brief Configure
+   */
+  void configure(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+    const std::string & name) override;
+
+  /**
+   * @brief Main scoring plugin API
+   * @param edge The edge pointer to score, which has access to the
+   * start/end nodes and their associated metadata and actions
+   * @param cost of the edge scored
+   * @return bool if this edge is open valid to traverse
+   */
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+
+  /**
+   * @brief Get name of the plugin for parameter scope mapping
+   * @return Name
+   */
+  std::string getName() override;
+
+protected:
+  rclcpp::Logger logger_{rclcpp::get_logger("GoalOrientationScorer")};
+  std::string name_;
+  double orientation_tolerance_;
+};
+
+}  // namespace nav2_route
+
+#endif  // NAV2_ROUTE__PLUGINS__EDGE_COST_FUNCTIONS__GOAL_ORIENTATION_SCORER_HPP_

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp
@@ -62,9 +62,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(
-    const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost,
-    bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/penalty_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/penalty_scorer.hpp
@@ -57,7 +57,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/penalty_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/penalty_scorer.hpp
@@ -57,7 +57,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/semantic_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/semantic_scorer.hpp
@@ -59,7 +59,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Scores graph object based on metadata's semantic value at key

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/semantic_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/semantic_scorer.hpp
@@ -59,7 +59,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Scores graph object based on metadata's semantic value at key

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/time_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/time_scorer.hpp
@@ -59,7 +59,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, float & cost) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/plugins/edge_cost_functions/time_scorer.hpp
+++ b/nav2_route/include/nav2_route/plugins/edge_cost_functions/time_scorer.hpp
@@ -59,7 +59,7 @@ public:
    * @param cost of the edge scored
    * @return bool if this edge is open valid to traverse
    */
-  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge) override;
+  bool score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & cost) override;
 
   /**
    * @brief Get name of the plugin for parameter scope mapping

--- a/nav2_route/include/nav2_route/route_planner.hpp
+++ b/nav2_route/include/nav2_route/route_planner.hpp
@@ -26,6 +26,7 @@
 #include "nav2_route/utils.hpp"
 #include "nav2_route/edge_scorer.hpp"
 #include "nav2_core/route_exceptions.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 
 namespace nav2_route
 {
@@ -61,8 +62,9 @@ public:
    * @return Route object containing the navigation graph route
    */
   Route findRoute(
-    Graph & graph, unsigned int start, unsigned int goal,
-    const std::vector<unsigned int> & blocked_ids);
+    Graph & graph, unsigned int start_index, unsigned int goal_index,
+    const std::vector<unsigned int> & blocked_ids,
+    const geometry_msgs::msg::PoseStamped goal);
 
 protected:
   /**
@@ -79,8 +81,9 @@ protected:
    * @param blocked_ids A set of blocked node and edge IDs not to traverse
    */
   void findShortestGraphTraversal(
-    Graph & graph, const NodePtr start, const NodePtr goal,
-    const std::vector<unsigned int> & blocked_ids);
+    Graph & graph, const NodePtr start_node, const NodePtr goal_node,
+    const std::vector<unsigned int> & blocked_ids,
+    const geometry_msgs::msg::PoseStamped goal);
 
   /**
    * @brief Gets the traversal cost for an edge using edge scorers
@@ -90,7 +93,7 @@ protected:
    * @return if this edge is valid for search
    */
   inline bool getTraversalCost(
-    const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids);
+    const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids, const geometry_msgs::msg::PoseStamped goal);
 
   /**
    * @brief Gets the next node in the priority queue for search

--- a/nav2_route/include/nav2_route/route_planner.hpp
+++ b/nav2_route/include/nav2_route/route_planner.hpp
@@ -64,7 +64,7 @@ public:
   Route findRoute(
     Graph & graph, unsigned int start_index, unsigned int goal_index,
     const std::vector<unsigned int> & blocked_ids,
-    const geometry_msgs::msg::PoseStamped goal);
+    const geometry_msgs::msg::PoseStamped & goal);
 
 protected:
   /**
@@ -83,7 +83,7 @@ protected:
   void findShortestGraphTraversal(
     Graph & graph, const NodePtr start_node, const NodePtr goal_node,
     const std::vector<unsigned int> & blocked_ids,
-    const geometry_msgs::msg::PoseStamped goal);
+    const geometry_msgs::msg::PoseStamped & goal);
 
   /**
    * @brief Gets the traversal cost for an edge using edge scorers
@@ -93,7 +93,8 @@ protected:
    * @return if this edge is valid for search
    */
   inline bool getTraversalCost(
-    const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids, const geometry_msgs::msg::PoseStamped goal);
+    const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids,
+    const geometry_msgs::msg::PoseStamped & goal);
 
   /**
    * @brief Gets the next node in the priority queue for search

--- a/nav2_route/plugins.xml
+++ b/nav2_route/plugins.xml
@@ -29,6 +29,11 @@
       <description>Cost function for adding costs to edges time to complete the edge based on previous runs and/or estimation with absolute speed limits.</description>
     </class>
   </library>
+  <library path="edge_scorers">
+    <class type="nav2_route::GoalOrientationScorer" base_class_type="nav2_route::EdgeCostFunction">
+      <description>Cost function for checking if the orientation of route matches orientation of the goal</description>
+    </class>
+  </library>
 
   <library path="route_operations">
     <class type="nav2_route::AdjustSpeedLimit" base_class_type="nav2_route::RouteOperation">

--- a/nav2_route/src/edge_scorer.cpp
+++ b/nav2_route/src/edge_scorer.cpp
@@ -60,7 +60,7 @@ EdgeScorer::EdgeScorer(nav2_util::LifecycleNode::SharedPtr node)
   }
 }
 
-bool EdgeScorer::score(const EdgePtr edge, float & total_score)
+bool EdgeScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & total_score, bool final_edge)
 {
   total_score = 0.0;
   float curr_score = 0.0;
@@ -71,7 +71,7 @@ bool EdgeScorer::score(const EdgePtr edge, float & total_score)
 
   for (auto & plugin : plugins_) {
     curr_score = 0.0;
-    if (plugin->score(edge, curr_score)) {
+    if (plugin->score(edge, goal_pose, curr_score, final_edge)) {
       total_score += curr_score;
     } else {
       return false;

--- a/nav2_route/src/edge_scorer.cpp
+++ b/nav2_route/src/edge_scorer.cpp
@@ -60,7 +60,9 @@ EdgeScorer::EdgeScorer(nav2_util::LifecycleNode::SharedPtr node)
   }
 }
 
-bool EdgeScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & total_score, bool final_edge)
+bool EdgeScorer::score(
+  const EdgePtr edge, const geometry_msgs::msg::PoseStamped & goal_pose,
+  bool final_edge, float & total_score)
 {
   total_score = 0.0;
   float curr_score = 0.0;

--- a/nav2_route/src/edge_scorer.cpp
+++ b/nav2_route/src/edge_scorer.cpp
@@ -73,7 +73,7 @@ bool EdgeScorer::score(
 
   for (auto & plugin : plugins_) {
     curr_score = 0.0;
-    if (plugin->score(edge, goal_pose, curr_score, final_edge)) {
+    if (plugin->score(edge, goal_pose, final_edge, curr_score)) {
       total_score += curr_score;
     } else {
       return false;

--- a/nav2_route/src/plugins/edge_cost_functions/adjust_edges_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/adjust_edges_scorer.cpp
@@ -63,7 +63,7 @@ void AdjustEdgesScorer::closedEdgesCb(
   response->success = true;
 }
 
-bool AdjustEdgesScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool AdjustEdgesScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   // Find if this edge is in the closed set of edges
   if (closed_edges_.find(edge->edgeid) != closed_edges_.end()) {

--- a/nav2_route/src/plugins/edge_cost_functions/adjust_edges_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/adjust_edges_scorer.cpp
@@ -63,7 +63,7 @@ void AdjustEdgesScorer::closedEdgesCb(
   response->success = true;
 }
 
-bool AdjustEdgesScorer::score(const EdgePtr edge, float & cost)
+bool AdjustEdgesScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   // Find if this edge is in the closed set of edges
   if (closed_edges_.find(edge->edgeid) != closed_edges_.end()) {

--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -74,7 +74,7 @@ void CostmapScorer::prepare()
 
 // TODO(sm) does this critic make efficiency sense at a
 // reasonable sized graph / node distance? Lower iterator density?
-bool CostmapScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool CostmapScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   if (!costmap_) {
     RCLCPP_WARN(logger_, "No costmap yet received!");

--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -74,7 +74,7 @@ void CostmapScorer::prepare()
 
 // TODO(sm) does this critic make efficiency sense at a
 // reasonable sized graph / node distance? Lower iterator density?
-bool CostmapScorer::score(const EdgePtr edge, float & cost)
+bool CostmapScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   if (!costmap_) {
     RCLCPP_WARN(logger_, "No costmap yet received!");

--- a/nav2_route/src/plugins/edge_cost_functions/distance_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/distance_scorer.cpp
@@ -38,7 +38,7 @@ void DistanceScorer::configure(
   weight_ = static_cast<float>(node->get_parameter(getName() + ".weight").as_double());
 }
 
-bool DistanceScorer::score(const EdgePtr edge, float & cost)
+bool DistanceScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   // Get the speed limit, if set for an edge
   float speed_val = 1.0f;

--- a/nav2_route/src/plugins/edge_cost_functions/distance_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/distance_scorer.cpp
@@ -38,7 +38,7 @@ void DistanceScorer::configure(
   weight_ = static_cast<float>(node->get_parameter(getName() + ".weight").as_double());
 }
 
-bool DistanceScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool DistanceScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   // Get the speed limit, if set for an edge
   float speed_val = 1.0f;

--- a/nav2_route/src/plugins/edge_cost_functions/goal_orientation_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/goal_orientation_scorer.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2024, Polymath Robotics Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "nav2_route/plugins/edge_cost_functions/goal_orientation_scorer.hpp"
+
+namespace nav2_route
+{
+
+void GoalOrientationScorer::configure(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+  const std::string & name)
+{
+  RCLCPP_INFO(node->get_logger(), "Configuring goal orientation scorer.");
+  name_ = name;
+  logger_ = node->get_logger();
+
+  nav2_util::declare_parameter_if_not_declared(
+    node, getName() + ".orientation_tolerance", rclcpp::ParameterValue(2*M_PI));
+  orientation_tolerance_ = node->get_parameter(getName() + ".orientation_tolerance").as_double();
+
+}
+
+bool GoalOrientationScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped goal_pose, float & cost, bool final_edge)
+{
+  if(final_edge){
+
+    double d_yaw = std::abs(std::atan2(edge->end->coords.y - edge->start->coords.y, edge->end->coords.x - edge->start->coords.x)-tf2::getYaw(goal_pose.pose.orientation));
+
+    if(d_yaw > M_PI){
+      d_yaw = 2*M_PI-d_yaw;
+    }
+
+    if(d_yaw > orientation_tolerance_){
+      cost = 255.0;
+      return false;
+    }
+
+  }
+  return true;
+}
+
+std::string GoalOrientationScorer::getName()
+{
+  return name_;
+}
+
+}  // namespace nav2_route
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(nav2_route::GoalOrientationScorer, nav2_route::EdgeCostFunction)

--- a/nav2_route/src/plugins/edge_cost_functions/goal_orientation_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/goal_orientation_scorer.cpp
@@ -29,14 +29,13 @@ void GoalOrientationScorer::configure(
   logger_ = node->get_logger();
 
   nav2_util::declare_parameter_if_not_declared(
-    node, getName() + ".orientation_tolerance", rclcpp::ParameterValue(M_PI));
+    node, getName() + ".orientation_tolerance", rclcpp::ParameterValue(M_PI/2.0));
   orientation_tolerance_ = node->get_parameter(getName() + ".orientation_tolerance").as_double();
 }
 
 bool GoalOrientationScorer::score(
   const EdgePtr edge,
-  const geometry_msgs::msg::PoseStamped goal_pose, float & /*cost*/,
-  bool final_edge)
+  const geometry_msgs::msg::PoseStamped & goal_pose, bool final_edge, float & /*cost*/)
 {
   if (final_edge) {
     double edge_orientation = std::atan2(

--- a/nav2_route/src/plugins/edge_cost_functions/penalty_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/penalty_scorer.cpp
@@ -38,7 +38,7 @@ void PenaltyScorer::configure(
   weight_ = static_cast<float>(node->get_parameter(getName() + ".weight").as_double());
 }
 
-bool PenaltyScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool PenaltyScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   // Get the speed limit, if set for an edge
   float penalty_val = 0.0f;

--- a/nav2_route/src/plugins/edge_cost_functions/penalty_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/penalty_scorer.cpp
@@ -38,7 +38,7 @@ void PenaltyScorer::configure(
   weight_ = static_cast<float>(node->get_parameter(getName() + ".weight").as_double());
 }
 
-bool PenaltyScorer::score(const EdgePtr edge, float & cost)
+bool PenaltyScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   // Get the speed limit, if set for an edge
   float penalty_val = 0.0f;

--- a/nav2_route/src/plugins/edge_cost_functions/semantic_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/semantic_scorer.cpp
@@ -69,7 +69,7 @@ void SemanticScorer::metadataValueScorer(Metadata & mdata, float & score)
   }
 }
 
-bool SemanticScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool SemanticScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   float score = 0.0;
   Metadata & node_mdata = edge->end->metadata;

--- a/nav2_route/src/plugins/edge_cost_functions/semantic_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/semantic_scorer.cpp
@@ -69,7 +69,7 @@ void SemanticScorer::metadataValueScorer(Metadata & mdata, float & score)
   }
 }
 
-bool SemanticScorer::score(const EdgePtr edge, float & cost)
+bool SemanticScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   float score = 0.0;
   Metadata & node_mdata = edge->end->metadata;

--- a/nav2_route/src/plugins/edge_cost_functions/time_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/time_scorer.cpp
@@ -46,7 +46,7 @@ void TimeScorer::configure(
   max_vel_ = static_cast<float>(node->get_parameter(getName() + ".max_vel").as_double());
 }
 
-bool TimeScorer::score(const EdgePtr edge, float & cost)
+bool TimeScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
 {
   // We have a previous actual time to utilize for a refined estimate
   float time = 0.0;

--- a/nav2_route/src/plugins/edge_cost_functions/time_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/time_scorer.cpp
@@ -46,7 +46,7 @@ void TimeScorer::configure(
   max_vel_ = static_cast<float>(node->get_parameter(getName() + ".max_vel").as_double());
 }
 
-bool TimeScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped /* goal_pose */, float & cost, bool /* final_edge */)
+bool TimeScorer::score(const EdgePtr edge, const geometry_msgs::msg::PoseStamped & /* goal_pose */, bool /* final_edge */, float & cost)
 {
   // We have a previous actual time to utilize for a refined estimate
   float time = 0.0;

--- a/nav2_route/src/route_planner.cpp
+++ b/nav2_route/src/route_planner.cpp
@@ -38,8 +38,9 @@ void RoutePlanner::configure(nav2_util::LifecycleNode::SharedPtr node)
 }
 
 Route RoutePlanner::findRoute(
-  Graph & graph, unsigned int start, unsigned int goal,
-  const std::vector<unsigned int> & blocked_ids)
+  Graph & graph, unsigned int start_index, unsigned int goal_index,
+  const std::vector<unsigned int> & blocked_ids,
+  geometry_msgs::msg::PoseStamped goal_pose)
 {
   if (graph.empty()) {
     throw nav2_core::NoValidGraph("Graph is invalid for routing!");
@@ -48,9 +49,9 @@ Route RoutePlanner::findRoute(
   // Find the start and goal pointers, it is important in this function
   // that these are the actual pointers, so that copied addresses are
   // not lost in the route when this function goes out of scope.
-  const NodePtr & start_node = &graph.at(start);
-  const NodePtr & goal_node = &graph.at(goal);
-  findShortestGraphTraversal(graph, start_node, goal_node, blocked_ids);
+  const NodePtr & start_node = &graph.at(start_index);
+  const NodePtr & goal_node = &graph.at(goal_index);
+  findShortestGraphTraversal(graph, start_node, goal_node, blocked_ids, goal_pose);
 
   EdgePtr & parent_edge = goal_node->search_state.parent_edge;
   if (!parent_edge) {
@@ -80,14 +81,15 @@ void RoutePlanner::resetSearchStates(Graph & graph)
 }
 
 void RoutePlanner::findShortestGraphTraversal(
-  Graph & graph, const NodePtr start, const NodePtr goal,
-  const std::vector<unsigned int> & blocked_ids)
+  Graph & graph, const NodePtr start_node, const NodePtr goal_node,
+  const std::vector<unsigned int> & blocked_ids,
+  geometry_msgs::msg::PoseStamped goal_pose)
 {
   // Setup the Dijkstra's search
   resetSearchStates(graph);
-  goal_id_ = goal->nodeid;
-  start->search_state.integrated_cost = 0.0;
-  addNode(0.0, start);
+  goal_id_ = goal_node->nodeid;
+  start_node->search_state.integrated_cost = 0.0;
+  addNode(0.0, start_node);
 
   NodePtr neighbor{nullptr};
   EdgePtr edge{nullptr};
@@ -116,7 +118,7 @@ void RoutePlanner::findShortestGraphTraversal(
       neighbor = edge->end;
 
       // If edge is invalid (lane closed, occupied, etc), don't expand
-      if (!getTraversalCost(edge, traversal_cost, blocked_ids)) {
+      if (!getTraversalCost(edge, traversal_cost, blocked_ids, goal_pose)) {
         continue;
       }
 
@@ -139,7 +141,7 @@ void RoutePlanner::findShortestGraphTraversal(
 }
 
 bool RoutePlanner::getTraversalCost(
-  const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids)
+  const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids, const geometry_msgs::msg::PoseStamped goal)
 {
   // If edge or node is in the blocked list, as long as its not blocking the goal itself
   auto idBlocked = [&](unsigned int id) {return id == edge->edgeid || id == edge->end->nodeid;};
@@ -158,7 +160,7 @@ bool RoutePlanner::getTraversalCost(
     return true;
   }
 
-  return edge_scorer_->score(edge, score);
+  return edge_scorer_->score(edge, goal, score, isGoal(edge->end));
 }
 
 NodeElement RoutePlanner::getNextNode()

--- a/nav2_route/src/route_planner.cpp
+++ b/nav2_route/src/route_planner.cpp
@@ -40,7 +40,7 @@ void RoutePlanner::configure(nav2_util::LifecycleNode::SharedPtr node)
 Route RoutePlanner::findRoute(
   Graph & graph, unsigned int start_index, unsigned int goal_index,
   const std::vector<unsigned int> & blocked_ids,
-  geometry_msgs::msg::PoseStamped goal_pose)
+  const geometry_msgs::msg::PoseStamped & goal_pose)
 {
   if (graph.empty()) {
     throw nav2_core::NoValidGraph("Graph is invalid for routing!");
@@ -83,7 +83,7 @@ void RoutePlanner::resetSearchStates(Graph & graph)
 void RoutePlanner::findShortestGraphTraversal(
   Graph & graph, const NodePtr start_node, const NodePtr goal_node,
   const std::vector<unsigned int> & blocked_ids,
-  geometry_msgs::msg::PoseStamped goal_pose)
+  const geometry_msgs::msg::PoseStamped & goal_pose)
 {
   // Setup the Dijkstra's search
   resetSearchStates(graph);
@@ -141,7 +141,8 @@ void RoutePlanner::findShortestGraphTraversal(
 }
 
 bool RoutePlanner::getTraversalCost(
-  const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids, const geometry_msgs::msg::PoseStamped goal)
+  const EdgePtr edge, float & score, const std::vector<unsigned int> & blocked_ids,
+  const geometry_msgs::msg::PoseStamped & goal)
 {
   // If edge or node is in the blocked list, as long as its not blocking the goal itself
   auto idBlocked = [&](unsigned int id) {return id == edge->edgeid || id == edge->end->nodeid;};
@@ -160,7 +161,7 @@ bool RoutePlanner::getTraversalCost(
     return true;
   }
 
-  return edge_scorer_->score(edge, goal, score, isGoal(edge->end));
+  return edge_scorer_->score(edge, goal, isGoal(edge->end), score);
 }
 
 NodeElement RoutePlanner::getNextNode()

--- a/nav2_route/src/route_server.cpp
+++ b/nav2_route/src/route_server.cpp
@@ -215,7 +215,7 @@ Route RouteServer::findRoute(
     route.start_node = &graph_.at(start_route);
   } else {
     // Compute the route via graph-search, returns a node-edge sequence
-    route = route_planner_->findRoute(graph_, start_route, end_route, rerouting_info.blocked_ids);
+    route = route_planner_->findRoute(graph_, start_route, end_route, rerouting_info.blocked_ids, goal->goal);
   }
 
   return goal_intent_extractor_->pruneStartandGoal(route, goal, rerouting_info);

--- a/nav2_route/test/test_edge_scorers.cpp
+++ b/nav2_route/test/test_edge_scorers.cpp
@@ -61,17 +61,17 @@ TEST(EdgeScorersTest, test_api)
   const geometry_msgs::msg::PoseStamped goal_pose;
 
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // Because nodes coords are 0/0
 
   n1.coords.x = 1.0;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 1.0);  // Distance is now 1m
 
   // For full coverage, add in a speed limit tag to make sure it is applied appropriately
   float speed_limit = 0.8f;
   edge.metadata.setValue<float>("speed_limit", speed_limit);
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 1.25);  // 1m / 0.8 = 1.25
 }
 
@@ -126,17 +126,17 @@ TEST(EdgeScorersTest, test_invalid_edge_scoring)
   edge.start = &n1;
   edge.end = &n2;
 
-  const geometry_msgs::msg::PoseStamped goal_pose; 
+  const geometry_msgs::msg::PoseStamped goal_pose;
 
   // The score function should return false since closed
   float traversal_cost = -1;
-  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, false, traversal_cost));
 
   // The score function should return true since no longer the problematic edge ID
   // and edgeid 42 as the dynamic cost of 42 assigned to it
   traversal_cost = -1;
   edge.edgeid = 11;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 42.0);
 
   // Try to re-open this edge
@@ -148,7 +148,7 @@ TEST(EdgeScorersTest, test_invalid_edge_scoring)
   // The score function should return true since now opened up
   traversal_cost = -1;
   edge.edgeid = 10;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
 
   node_thread.reset();
 }
@@ -183,7 +183,7 @@ TEST(EdgeScorersTest, test_penalty_scoring)
 
   // The score function should return 10.0 from penalty value
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 10.0);
 }
 
@@ -216,7 +216,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
 
   // The score function should return false because no costmap given
   float traversal_cost = -1;
-  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, false, traversal_cost));
 
   // Create a demo costmap: * = 100, - = 0, / = 254
   // * * * * - - - - - - - -
@@ -256,7 +256,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.x = 8.0;
   n2.coords.y = 8.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   // Segment in freespace
   EXPECT_EQ(traversal_cost, 0.0);
 
@@ -265,7 +265,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.x = 2.0;
   n2.coords.y = 8.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   // Segment in 100 space
   EXPECT_NEAR(traversal_cost, 100.0 / 254.0, 0.01);
 
@@ -275,14 +275,14 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.y = 5.9;
   traversal_cost = -1;
   // Segment in lethal space, won't fill in
-  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, false, traversal_cost));
 
   n1.coords.x = 1.0;
   n1.coords.y = 1.0;
   n2.coords.x = 6.0;
   n2.coords.y = 1.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   // Segment in 0 and 100 space, use_max so 100 (normalized)
   EXPECT_NEAR(traversal_cost, 100.0 / 254.0, 0.01);
 
@@ -292,7 +292,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.y = 11.0;
   traversal_cost = -1;
   // Off map, so invalid
-  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, false, traversal_cost));
 
   node_thread.reset();
 }
@@ -371,7 +371,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.y = 11.0;
   float traversal_cost = -1;
   // Off map, so cannot score
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);
 
   n1.coords.x = 4.1;
@@ -380,7 +380,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.y = 5.9;
   traversal_cost = -1;
   // Segment in lethal space, so score is maximum (1)
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_NEAR(traversal_cost, 1.0, 0.01);
 
   n1.coords.x = 1.0;
@@ -388,7 +388,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.x = 6.0;
   n2.coords.y = 1.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   // Segment in 0 and 100 space, 3m @ 100, 2m @ 0, averaged is 60
   EXPECT_NEAR(traversal_cost, 60.0 / 254.0, 0.01);
 
@@ -426,26 +426,26 @@ TEST(EdgeScorersTest, test_time_scoring)
 
   // The score function should return 10.0 from time taken
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 10.0);  // 10.0 * 1.0 weight
 
   // Without time taken or abs speed limit set, uses default max speed of 0.5 m/s
   edge.metadata.data.clear();
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 2.0);  // 1.0 m / 0.5 m/s * 1.0 weight
 
   // Use speed limit if set
   float speed_limit = 0.85;
   edge.metadata.setValue<float>("abs_speed_limit", speed_limit);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_NEAR(traversal_cost, 1.1764, 0.001);  // 1.0 m / 0.85 m/s * 1.0 weight
 
   // Still use time taken measurements if given first
   edge.metadata.setValue<float>("abs_time_taken", time_taken);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 10.0);  // 10.0 * 1.0 weight
 }
 
@@ -492,21 +492,21 @@ TEST(EdgeScorersTest, test_semantic_scoring_key)
 
   // Should fail, since both nothing under key `class` nor metadata set at all
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // nothing is set in semantics
 
   // Should be valid under the right key
   std::string test_n = "Test1";
   edge.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 1.0);  // 1.0 * 1.0 weight
 
   test_n = "Test2";
   edge.metadata.setValue<std::string>("class", test_n);
   n2.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 4.0);  // (2.0 + 2.0) * 1.0 weight
 
   // Cannot find, doesn't exist
@@ -514,7 +514,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_key)
   edge.metadata.setValue<std::string>("class", test_n);
   n2.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 }
 
@@ -564,7 +564,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
 
   // Should fail, since both nothing under key `class` nor metadata set at all
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // nothing is set in semantics
 
   // Should fail, since under the class key when the semantic key is empty string
@@ -572,7 +572,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   std::string test_n = "Test1";
   edge.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 
   // Should succeed, since now actual class is a key, not a value of the `class` key
@@ -580,7 +580,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   edge.metadata.setValue<std::string>(test_n, test_n);
   n2.metadata.setValue<std::string>(test_n, test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 4.0);  // (2.0 + 2.0) * 1.0 weight
 
   // Cannot find, doesn't exist
@@ -589,7 +589,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   test_n = "Test4";
   edge.metadata.setValue<std::string>(test_n, test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, false, traversal_cost));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 }
 
@@ -599,7 +599,8 @@ TEST(EdgeScorersTest, test_goal_orientation_scoring)
   auto node = std::make_shared<nav2_util::LifecycleNode>("edge_scorer_test");
 
   node->declare_parameter(
-    "edge_cost_functions", rclcpp::ParameterValue(std::vector<std::string>{"GoalOrientationScorer"}));
+    "edge_cost_functions",
+    rclcpp::ParameterValue(std::vector<std::string>{"GoalOrientationScorer"}));
   nav2_util::declare_parameter_if_not_declared(
     node, "GoalOrientationScorer.plugin",
     rclcpp::ParameterValue(std::string{"nav2_route::GoalOrientationScorer"}));
@@ -609,7 +610,7 @@ TEST(EdgeScorersTest, test_goal_orientation_scoring)
 
   EdgeScorer scorer(node);
   EXPECT_EQ(scorer.numPlugins(), 1);  // GoalOrientationScorer
-  
+
   geometry_msgs::msg::PoseStamped goal_pose;
   goal_pose.pose.orientation.x = 0.0;
   goal_pose.pose.orientation.y = 0.0;
@@ -630,8 +631,13 @@ TEST(EdgeScorersTest, test_goal_orientation_scoring)
   edge.start = &n1;
   edge.end = &n2;
 
-  // The score function should return 10.0 from penalty value
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, true));
-  // EXPECT_EQ(traversal_cost, 10.0);
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, true, traversal_cost));
+  EXPECT_EQ(traversal_cost, -1);
+
+  edge.start = &n2;
+  edge.end = &n1;
+
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, true, traversal_cost));
+  EXPECT_EQ(traversal_cost, -1);
 }

--- a/nav2_route/test/test_edge_scorers.cpp
+++ b/nav2_route/test/test_edge_scorers.cpp
@@ -58,19 +58,20 @@ TEST(EdgeScorersTest, test_api)
   edge.edgeid = 10;
   edge.start = &n1;
   edge.end = &n2;
+  const geometry_msgs::msg::PoseStamped goal_pose;
 
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // Because nodes coords are 0/0
 
   n1.coords.x = 1.0;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 1.0);  // Distance is now 1m
 
   // For full coverage, add in a speed limit tag to make sure it is applied appropriately
   float speed_limit = 0.8f;
   edge.metadata.setValue<float>("speed_limit", speed_limit);
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 1.25);  // 1m / 0.8 = 1.25
 }
 
@@ -125,15 +126,17 @@ TEST(EdgeScorersTest, test_invalid_edge_scoring)
   edge.start = &n1;
   edge.end = &n2;
 
+  const geometry_msgs::msg::PoseStamped goal_pose; 
+
   // The score function should return false since closed
   float traversal_cost = -1;
-  EXPECT_FALSE(scorer.score(&edge, traversal_cost));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
 
   // The score function should return true since no longer the problematic edge ID
   // and edgeid 42 as the dynamic cost of 42 assigned to it
   traversal_cost = -1;
   edge.edgeid = 11;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 42.0);
 
   // Try to re-open this edge
@@ -145,7 +148,7 @@ TEST(EdgeScorersTest, test_invalid_edge_scoring)
   // The score function should return true since now opened up
   traversal_cost = -1;
   edge.edgeid = 10;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
 
   node_thread.reset();
 }
@@ -163,6 +166,7 @@ TEST(EdgeScorersTest, test_penalty_scoring)
 
   EdgeScorer scorer(node);
   EXPECT_EQ(scorer.numPlugins(), 1);  // PenaltyScorer
+  const geometry_msgs::msg::PoseStamped goal_pose;
 
   // Create edge to score
   Node n1, n2;
@@ -179,7 +183,7 @@ TEST(EdgeScorersTest, test_penalty_scoring)
 
   // The score function should return 10.0 from penalty value
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 10.0);
 }
 
@@ -208,10 +212,11 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   edge.edgeid = 10;
   edge.start = &n1;
   edge.end = &n2;
+  const geometry_msgs::msg::PoseStamped goal_pose;
 
   // The score function should return false because no costmap given
   float traversal_cost = -1;
-  EXPECT_FALSE(scorer.score(&edge, traversal_cost));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
 
   // Create a demo costmap: * = 100, - = 0, / = 254
   // * * * * - - - - - - - -
@@ -251,7 +256,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.x = 8.0;
   n2.coords.y = 8.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   // Segment in freespace
   EXPECT_EQ(traversal_cost, 0.0);
 
@@ -260,7 +265,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.x = 2.0;
   n2.coords.y = 8.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   // Segment in 100 space
   EXPECT_NEAR(traversal_cost, 100.0 / 254.0, 0.01);
 
@@ -270,14 +275,14 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.y = 5.9;
   traversal_cost = -1;
   // Segment in lethal space, won't fill in
-  EXPECT_FALSE(scorer.score(&edge, traversal_cost));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
 
   n1.coords.x = 1.0;
   n1.coords.y = 1.0;
   n2.coords.x = 6.0;
   n2.coords.y = 1.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   // Segment in 0 and 100 space, use_max so 100 (normalized)
   EXPECT_NEAR(traversal_cost, 100.0 / 254.0, 0.01);
 
@@ -287,7 +292,7 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   n2.coords.y = 11.0;
   traversal_cost = -1;
   // Off map, so invalid
-  EXPECT_FALSE(scorer.score(&edge, traversal_cost));
+  EXPECT_FALSE(scorer.score(&edge, goal_pose, traversal_cost, false));
 
   node_thread.reset();
 }
@@ -357,6 +362,8 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   rclcpp::Rate r(1);
   r.sleep();
 
+  const geometry_msgs::msg::PoseStamped goal_pose;
+
   // Off map
   n1.coords.x = -1.0;
   n1.coords.y = -1.0;
@@ -364,7 +371,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.y = 11.0;
   float traversal_cost = -1;
   // Off map, so cannot score
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);
 
   n1.coords.x = 4.1;
@@ -373,7 +380,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.y = 5.9;
   traversal_cost = -1;
   // Segment in lethal space, so score is maximum (1)
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_NEAR(traversal_cost, 1.0, 0.01);
 
   n1.coords.x = 1.0;
@@ -381,7 +388,7 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   n2.coords.x = 6.0;
   n2.coords.y = 1.0;
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   // Segment in 0 and 100 space, 3m @ 100, 2m @ 0, averaged is 60
   EXPECT_NEAR(traversal_cost, 60.0 / 254.0, 0.01);
 
@@ -415,28 +422,30 @@ TEST(EdgeScorersTest, test_time_scoring)
   float time_taken = 10.0f;
   edge.metadata.setValue<float>("abs_time_taken", time_taken);
 
+  const geometry_msgs::msg::PoseStamped goal_pose;
+
   // The score function should return 10.0 from time taken
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 10.0);  // 10.0 * 1.0 weight
 
   // Without time taken or abs speed limit set, uses default max speed of 0.5 m/s
   edge.metadata.data.clear();
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 2.0);  // 1.0 m / 0.5 m/s * 1.0 weight
 
   // Use speed limit if set
   float speed_limit = 0.85;
   edge.metadata.setValue<float>("abs_speed_limit", speed_limit);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_NEAR(traversal_cost, 1.1764, 0.001);  // 1.0 m / 0.85 m/s * 1.0 weight
 
   // Still use time taken measurements if given first
   edge.metadata.setValue<float>("abs_time_taken", time_taken);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 10.0);  // 10.0 * 1.0 weight
 }
 
@@ -468,6 +477,8 @@ TEST(EdgeScorersTest, test_semantic_scoring_key)
   EdgeScorer scorer(node);
   EXPECT_EQ(scorer.numPlugins(), 1);  // SemanticScorer
 
+  const geometry_msgs::msg::PoseStamped goal_pose;
+
   // Create edge to score
   Node n1, n2;
   n1.nodeid = 1;
@@ -481,21 +492,21 @@ TEST(EdgeScorersTest, test_semantic_scoring_key)
 
   // Should fail, since both nothing under key `class` nor metadata set at all
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // nothing is set in semantics
 
   // Should be valid under the right key
   std::string test_n = "Test1";
   edge.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 1.0);  // 1.0 * 1.0 weight
 
   test_n = "Test2";
   edge.metadata.setValue<std::string>("class", test_n);
   n2.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 4.0);  // (2.0 + 2.0) * 1.0 weight
 
   // Cannot find, doesn't exist
@@ -503,7 +514,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_key)
   edge.metadata.setValue<std::string>("class", test_n);
   n2.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 }
 
@@ -549,9 +560,11 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   edge.start = &n1;
   edge.end = &n2;
 
+  const geometry_msgs::msg::PoseStamped goal_pose;
+
   // Should fail, since both nothing under key `class` nor metadata set at all
   float traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // nothing is set in semantics
 
   // Should fail, since under the class key when the semantic key is empty string
@@ -559,7 +572,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   std::string test_n = "Test1";
   edge.metadata.setValue<std::string>("class", test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 
   // Should succeed, since now actual class is a key, not a value of the `class` key
@@ -567,7 +580,7 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   edge.metadata.setValue<std::string>(test_n, test_n);
   n2.metadata.setValue<std::string>(test_n, test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 4.0);  // (2.0 + 2.0) * 1.0 weight
 
   // Cannot find, doesn't exist
@@ -576,6 +589,6 @@ TEST(EdgeScorersTest, test_semantic_scoring_keys)
   test_n = "Test4";
   edge.metadata.setValue<std::string>(test_n, test_n);
   traversal_cost = -1;
-  EXPECT_TRUE(scorer.score(&edge, traversal_cost));
+  EXPECT_TRUE(scorer.score(&edge, goal_pose, traversal_cost, false));
   EXPECT_EQ(traversal_cost, 0.0);  // 0.0 * 1.0 weight
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Gazebo simulation of an agricultural client) |
| Does this PR contain AI generated software? | (No) |

---

## Description of contribution in a few bullet points
- Modified `route_server.cpp` and `route_planner.cpp` to pass the goal pose down to `getTraveralCost` method
- `edge_cost_function` base method `score` modified to take in the goal pose and also a bool indicating if its the final edge
- All edge scorers modified to accommodate those new arguments
- Added a new edge scorer `GoalOrientationScorer` that rejects a route if the route's final edge does not align to some angular threshold to the desired pose orientation
- Added a new test to test `GoalOrientationScorer`

## Description of documentation updates required from your changes
- Documentation will likely be added a long with the rest of route server when it gets released

## Description of how this change was tested
This was tested in a gazebo test environment for an agricultural client where the vehicle under test is summoned to some row in the field. This integrated testing was implemented via launch testing

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
