### PR TITLE
nav2_constrained_smoother: Use unsigned char instead of non-standard u_char type

### DIFF
--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother.hpp
@@ -142,10 +142,10 @@ private:
     std::vector<bool> & optimized)
   {
     // Create costmap grid
-    costmap_grid_ = std::make_shared<ceres::Grid2D<u_char>>(
+    costmap_grid_ = std::make_shared<ceres::Grid2D<unsigned char>>(
       costmap->getCharMap(), 0, costmap->getSizeInCellsY(), 0, costmap->getSizeInCellsX());
-    auto costmap_interpolator = std::make_shared<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>>(
-      *costmap_grid_);
+    auto costmap_interpolator =
+      std::make_shared<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>>(*costmap_grid_);
 
     // Create residual blocks
     const double cusp_half_length = params.cusp_zone_length / 2;
@@ -394,7 +394,7 @@ private:
 
   bool debug_;
   ceres::Solver::Options options_;
-  std::shared_ptr<ceres::Grid2D<u_char>> costmap_grid_;
+  std::shared_ptr<ceres::Grid2D<unsigned char>> costmap_grid_;
 };
 
 }  // namespace nav2_constrained_smoother

--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
@@ -57,7 +57,8 @@ public:
     double next_to_last_length_ratio,
     bool reversing,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>> & costmap_interpolator,
+    const std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>> &
+    costmap_interpolator,
     const SmootherParams & params,
     double costmap_weight)
   : original_pos_(original_pos),
@@ -244,7 +245,7 @@ protected:
   double costmap_weight_;
   Eigen::Vector2d costmap_origin_;
   double costmap_resolution_;
-  std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>> costmap_interpolator_;
+  std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>> costmap_interpolator_;
 };
 
 }  // namespace nav2_constrained_smoother

--- a/nav2_constrained_smoother/test/test_smoother_cost_function.cpp
+++ b/nav2_constrained_smoother/test/test_smoother_cost_function.cpp
@@ -33,7 +33,8 @@ public:
     double next_to_last_length_ratio,
     bool reversing,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>> & costmap_interpolator,
+    const std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>> &
+    costmap_interpolator,
     const nav2_constrained_smoother::SmootherParams & params,
     double costmap_weight)
   : SmootherCostFunction(
@@ -68,7 +69,7 @@ TEST_F(Test, testingCurvatureResidual)
   nav2_costmap_2d::Costmap2D costmap;
   TestableSmootherCostFunction fn(
     Eigen::Vector2d(1.0, 0.0), 1.0, false,
-    &costmap, std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>>(),
+    &costmap, std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>>(),
     nav2_constrained_smoother::SmootherParams(), 0.0
   );
 
@@ -81,7 +82,7 @@ TEST_F(Test, testingCurvatureResidual)
   params_no_min_turning_radius.max_curvature = 1.0f / 0.0;
   TestableSmootherCostFunction fn_no_min_turning_radius(
     Eigen::Vector2d(1.0, 0.0), 1.0, false,
-    &costmap, std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<u_char>>>(),
+    &costmap, std::shared_ptr<ceres::BiCubicInterpolator<ceres::Grid2D<unsigned char>>>(),
     params_no_min_turning_radius, 0.0
   );
   EXPECT_EQ(fn_no_min_turning_radius.getCurvatureResidual(1.0, pt, pt_other, pt_other), 0.0);


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No ticket. |
| Primary OS tested on | Windows. |
| Robotic platform tested on | This is just a compilation fix, no runtime changes. |
| Does this PR contain AI generated software? | No. |

---

## Description of contribution in a few bullet points

`u_char` is not a standard C or C++ data type, while `unsigned char` is equivalent to `u_char` and is a standard data type. This change permits to compile `nav2_constrained_smoother` on Windows.

## Description of documentation updates required from your changes

None.

## Description of how this change was tested

I checked if the compilation was successful.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
