### PR TITLE
Remove RVIZ_DEFAULT_PLUGINS_PUBLIC macro from nav2 rviz plugin

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/goal_tool.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/goal_tool.hpp
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include "rviz_default_plugins/tools/pose/pose_tool.hpp"
-#include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_common
 {
@@ -36,7 +35,7 @@ class StringProperty;
 namespace nav2_rviz_plugins
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC GoalTool : public rviz_default_plugins::tools::PoseTool
+class GoalTool : public rviz_default_plugins::tools::PoseTool
 {
   Q_OBJECT
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No ticket. |
| Primary OS tested on | Windows |
| Robotic platform tested on | None, linker problem.  |
| Does this PR contain AI generated software? | No. |

---

## Description of contribution in a few bullet points

The `RVIZ_DEFAULT_PLUGINS_PUBLIC` macro is meant for code contained in the `rviz_default_plugins` repos. Using it in another repo create linking errors on Windows, as the linker expects the `GoalTool` class to be defined somewhere else, as it is annotated with the `dllexport` decorator.

## Description of documentation updates required from your changes

None.

## Description of how this change was tested

I compiled on Windows with this fix.

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
