### PR TITLE
Explicit convert from std::filesystem::path to std::string for Windows compatibility

### DIFF
--- a/nav2_waypoint_follower/plugins/photo_at_waypoint.cpp
+++ b/nav2_waypoint_follower/plugins/photo_at_waypoint.cpp
@@ -119,7 +119,7 @@ bool PhotoAtWaypoint::processAtWaypoint(
     std::lock_guard<std::mutex> guard(global_mutex_);
     cv::Mat curr_frame_mat;
     deepCopyMsg2Mat(curr_frame_msg_, curr_frame_mat);
-    cv::imwrite(full_path_image_path.c_str(), curr_frame_mat);
+    cv::imwrite(full_path_image_path.string().c_str(), curr_frame_mat);
     RCLCPP_INFO(
       logger_,
       "Photo has been taken successfully at waypoint %i", curr_waypoint_index);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No ticket. |
| Primary OS tested on | Windows |
| Robotic platform tested on | Not tested on any robotic platform. |
| Does this PR contain AI generated software? | No |



## Description of contribution in a few bullet points

On Linux and macOS `std::filesystem::path` is implicitly convertible to `std::string`, while on Windows it is convertible to `std::wstring`, see https://en.cppreference.com/w/cpp/filesystem/path and https://stackoverflow.com/questions/57377349/implicit-conversion-between-stdfilesystempath-and-stdstring-should-it-hap . If we want to convert `std::filesystem::path` to `std::string` in a Windows-compatible way, it is then necessary to explicitly call the `.string()` method.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

I checked if the program compiled.

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
