### PR TITLE
Fix rviz crash issue if run later

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
@@ -110,7 +110,6 @@ private:
 
   // Flags to indicate if the plugins have been loaded
   bool plugins_loaded_ = false;
-  bool server_failed_ = false;
 
   QVBoxLayout * main_layout_{nullptr};
   QHBoxLayout * info_layout_{nullptr};

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
@@ -54,7 +54,6 @@ private:
   rclcpp::TimerBase::SharedPtr rclcpp_timer_;
 
   std::thread load_plugins_thread_;
-  std::mutex combo_box_mutex;
 
   QBasicTimer timer_;
   QVBoxLayout * main_layout_;

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
@@ -43,8 +43,7 @@ public:
   ~Selector();
 
 private:
-  // The (non-spinning) client node used to invoke the action client
-  void timerEvent(QTimerEvent * event) override;
+  void loadPlugins();
 
   rclcpp::Node::SharedPtr client_node_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_controller_;
@@ -54,9 +53,8 @@ private:
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_progress_checker_;
   rclcpp::TimerBase::SharedPtr rclcpp_timer_;
 
-  bool plugins_loaded_ = false;
-  bool server_failed_ = false;
-  bool tried_once_ = false;
+  std::thread load_plugins_thread_;
+  std::mutex combo_box_mutex;
 
   QBasicTimer timer_;
   QVBoxLayout * main_layout_;

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
@@ -35,7 +35,7 @@ namespace nav2_rviz_plugins
    * @param combo_box The combo box to add the loaded plugins to
    */
 void pluginLoader(
-  rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
+  rclcpp::Node::SharedPtr node, const std::string & server_name,
   const std::string & plugin_type, QComboBox * combo_box);
 
 // Create label string from goal status msg

--- a/nav2_rviz_plugins/src/docking_panel.cpp
+++ b/nav2_rviz_plugins/src/docking_panel.cpp
@@ -245,9 +245,10 @@ DockingPanel::DockingPanel(QWidget * parent)
     [this] {
       // Load the plugins if not already loaded
       if (!plugins_loaded_) {
+        dock_type_->addItem("Default");
         RCLCPP_INFO(client_node_->get_logger(), "Loading dock plugins");
         nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "docking_server", "dock_plugins", dock_type_);
+        client_node_, "docking_server", "dock_plugins", dock_type_);
         plugins_loaded_ = true;
       }
     });

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -24,7 +24,6 @@ void pluginLoader(
   rclcpp::Node::SharedPtr node, const std::string & server_name,
   const std::string & plugin_type, QComboBox * combo_box)
 {
-  RCLCPP_ERROR(node->get_logger(), "Loading plugins for %s", plugin_type.c_str());
   auto parameter_client = std::make_shared<rclcpp::SyncParametersClient>(node, server_name);
 
   // Wait for the service to be available before calling it
@@ -36,7 +35,6 @@ void pluginLoader(
   }
 
   auto parameters = parameter_client->get_parameters({plugin_type});
-  RCLCPP_ERROR(node->get_logger(), "Loaded %s plugins", plugin_type.c_str());
   auto str_arr = parameters[0].as_string_array();
   for (auto str : str_arr) {
     combo_box->addItem(QString::fromStdString(str));

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -21,36 +21,22 @@ namespace nav2_rviz_plugins
 {
 
 void pluginLoader(
-  rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
+  rclcpp::Node::SharedPtr node, const std::string & server_name,
   const std::string & plugin_type, QComboBox * combo_box)
 {
+  RCLCPP_ERROR(node->get_logger(), "Loading plugins for %s", plugin_type.c_str());
   auto parameter_client = std::make_shared<rclcpp::SyncParametersClient>(node, server_name);
 
-  // Do not load the plugins if the combo box is already populated
-  if (combo_box->count() > 0) {
-    return;
-  }
-
   // Wait for the service to be available before calling it
-  bool server_unavailable = false;
   while (!parameter_client->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
       rclcpp::shutdown();
     }
-    RCLCPP_INFO(node->get_logger(), "%s service not available", server_name.c_str());
-    server_unavailable = true;
-    server_failed = true;
-    break;
   }
 
-  // Loading the plugins into the combo box
-  // If server unavaialble, let the combo box be empty
-  if (server_unavailable) {
-    return;
-  }
-  combo_box->addItem("Default");
   auto parameters = parameter_client->get_parameters({plugin_type});
+  RCLCPP_ERROR(node->get_logger(), "Loaded %s plugins", plugin_type.c_str());
   auto str_arr = parameters[0].as_string_array();
   for (auto str : str_arr) {
     combo_box->addItem(QString::fromStdString(str));


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                                        | Please fill out this column |
| ------------------------------------------- | --------------------------- |
| Ticket(s) this addresses                    | #4754                       |
| Primary OS tested on                        | Ubuntu 24.04                |
| Robotic platform tested on                  | turtlebot 3 simulation      |
| Does this PR contain AI generated software? | No                          |

---

## Description of contribution in a few bullet points

On my machine, this not only stuck in getting parameter of planner, but also other plugins like controller, goal checker and so on. Thus, I did the following to solve this issue:
- Open a new thread to load plugins, to ensure that `get_parameter()` would not block the main thread
- Consequently, this new thread can also handle the case we start rviz first, and bringup later

## Description of documentation updates required from your changes

None

## Description of how this change was tested


Extensively tested on tb3 simulation

---

## Future work that may be required in bullet points

On the original implementation, the combo box will appear blank if it cannot get parameter from service, I now put it a "default" on those labels, I think this will be better (otherwise users will click on an empty label). 

I am not really familiar with QT, not sure if there is any problem in my implementation :)

Currently only tested on Jazzy, but I could build new images and test it on different distributions

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists