### PR TITLE
Fix flaky ness of opennav_docking test_docking_server (#4878)

### DIFF
--- a/nav2_docking/opennav_docking/test/test_docking_server.py
+++ b/nav2_docking/opennav_docking/test/test_docking_server.py
@@ -19,12 +19,18 @@ import unittest
 from action_msgs.msg import GoalStatus
 from geometry_msgs.msg import TransformStamped, Twist, TwistStamped
 from launch import LaunchDescription
+# from launch.actions import SetEnvironmentVariable
 from launch_ros.actions import Node
 import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.util
 from nav2_msgs.action import DockRobot, NavigateToPose, UndockRobot
 import pytest
 import rclpy
-from rclpy.action import ActionClient, ActionServer
+from rclpy.action.client import ActionClient
+from rclpy.action.server import ActionServer
 from sensor_msgs.msg import BatteryState
 from tf2_ros import TransformBroadcaster
 
@@ -32,10 +38,18 @@ from tf2_ros import TransformBroadcaster
 # This test can be run standalone with:
 # python3 -u -m pytest test_docking_server.py -s
 
+# If python3-flaky is installed, you can run the test multiple times to
+# try to identify flaky ness.
+# python3 -u -m pytest --force-flaky --min-passes 3 --max-runs 5 -s -v test_docking_server.py
+
 @pytest.mark.rostest
+# @pytest.mark.flaky
+# @pytest.mark.flaky(max_runs=5, min_passes=3)
 def generate_test_description():
 
     return LaunchDescription([
+        # SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '1'),
+        # SetEnvironmentVariable('RCUTILS_LOGGING_USE_STDOUT', '1'),
         Node(
             package='opennav_docking',
             executable='opennav_docking',
@@ -74,20 +88,25 @@ class TestDockingServer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         rclpy.init()
-        # Latest odom -> base_link
-        cls.x = 0.0
-        cls.y = 0.0
-        cls.theta = 0.0
-        # Track charge state
-        cls.is_charging = False
-        # Latest command velocity
-        cls.command = Twist()
-        cls.node = rclpy.create_node('test_docking_server')
 
     @classmethod
     def tearDownClass(cls):
-        cls.node.destroy_node()
         rclpy.shutdown()
+
+    def setUp(self):
+        # Create a ROS node for tests
+        # Latest odom -> base_link
+        self.x = 0.0
+        self.y = 0.0
+        self.theta = 0.0
+        # Track charge state
+        self.is_charging = False
+        # Latest command velocity
+        self.command = Twist()
+        self.node = rclpy.create_node('test_docking_server')
+
+    def tearDown(self):
+        self.node.destroy_node()
 
     def command_velocity_callback(self, msg):
         self.node.get_logger().info('Command: %f %f' % (msg.twist.linear.x, msg.twist.angular.z))
@@ -175,12 +194,19 @@ class TestDockingServer(unittest.TestCase):
             'navigate_to_pose',
             self.nav_execute_callback)
 
-        # Spin once so that TF is published
-        rclpy.spin_once(self.node, timeout_sec=0.1)
+        # Publish transform
+        self.publish()
+
+        # Run for 1 seconds to allow tf to propogate
+        for _ in range(10):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            time.sleep(0.1)
 
         # Test docking action
         self.action_result = []
-        self.dock_action_client.wait_for_server(timeout_sec=5.0)
+        assert self.dock_action_client.wait_for_server(timeout_sec=5.0), \
+               'dock_robot service not available'
+
         goal = DockRobot.Goal()
         goal.use_dock_id = True
         goal.dock_id = 'test_dock'
@@ -188,11 +214,12 @@ class TestDockingServer(unittest.TestCase):
             goal, feedback_callback=self.action_feedback_callback)
         rclpy.spin_until_future_complete(self.node, future)
         self.goal_handle = future.result()
-        assert self.goal_handle.accepted
+        assert self.goal_handle is not None, 'goal_handle should not be None'
+        assert self.goal_handle.accepted, 'goal_handle not accepted'
         result_future_original = self.goal_handle.get_result_async()
 
         # Run for 2 seconds
-        for i in range(20):
+        for _ in range(20):
             rclpy.spin_once(self.node, timeout_sec=0.1)
             time.sleep(0.1)
 
@@ -201,7 +228,8 @@ class TestDockingServer(unittest.TestCase):
             goal, feedback_callback=self.action_feedback_callback)
         rclpy.spin_until_future_complete(self.node, future)
         self.goal_handle = future.result()
-        assert self.goal_handle.accepted
+        assert self.goal_handle is not None, 'goal_handle should not be None'
+        assert self.goal_handle.accepted, 'goal_handle not accepted'
         result_future = self.goal_handle.get_result_async()
         rclpy.spin_until_future_complete(self.node, result_future)
         self.action_result.append(result_future.result())
@@ -216,7 +244,7 @@ class TestDockingServer(unittest.TestCase):
         self.node.get_logger().info('Goal preempted')
 
         # Run for 0.5 seconds
-        for i in range(5):
+        for _ in range(5):
             rclpy.spin_once(self.node, timeout_sec=0.1)
             time.sleep(0.1)
 
@@ -230,7 +258,8 @@ class TestDockingServer(unittest.TestCase):
             goal, feedback_callback=self.action_feedback_callback)
         rclpy.spin_until_future_complete(self.node, future)
         self.goal_handle = future.result()
-        assert self.goal_handle.accepted
+        assert self.goal_handle is not None, 'goal_handle should not be None'
+        assert self.goal_handle.accepted, 'goal_handle not accepted'
         result_future = self.goal_handle.get_result_async()
         rclpy.spin_until_future_complete(self.node, result_future)
         self.action_result.append(result_future.result())
@@ -247,10 +276,19 @@ class TestDockingServer(unittest.TestCase):
         future = self.undock_action_client.send_goal_async(goal)
         rclpy.spin_until_future_complete(self.node, future)
         self.goal_handle = future.result()
-        assert self.goal_handle.accepted
+        assert self.goal_handle is not None, 'goal_handle should not be None'
+        assert self.goal_handle.accepted, 'goal_handle not accepted'
         result_future = self.goal_handle.get_result_async()
         rclpy.spin_until_future_complete(self.node, result_future)
         self.action_result.append(result_future.result())
 
         self.assertEqual(self.action_result[3].status, GoalStatus.STATUS_SUCCEEDED)
         self.assertTrue(self.action_result[3].result.success)
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+
+    def test_exit_code(self, proc_info):
+        # Check that all processes in the launch exit with code 0
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
Call publish() (odom -> base_link tf) at startup to kick things off and spin 10 times(1 second) TF, so that it has a chance to propogate to the docking_server so that it will accept an action request.

Previously it was only spinning once, hoping the timer would fire and call publish fast enough for it to propogate to the docking_server so that it is able to accept the first 'dock_robot' action request

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4878 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | dev laptop |
| Does this PR contain AI generated software? | No |

---
```
lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.1 LTS
Release:        24.04
Codename:       noble

uname -a
Linux dev-lt-wakem.home 6.5.0-1025-oem #26-Ubuntu SMP PREEMPT_DYNAMIC Tue Jun 18 12:35:22 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## Description of contribution in a few bullet points

Fixes flakiness but leaves behind hints to enable use of flaky plugin for pytest.

## Description of documentation updates required from your changes

n/a

## Description of how this change was tested
```
sudo apt install python3-flaky

python3 -u -m pytest --min-passes 30 --max-runs 35 --force-flaky  ~/nav2_ws/src/navigation2/nav2_docking/opennav_docking/test/test_docking_server.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /root/nav2_ws
plugins: launch-testing-3.7.1, launch-testing-ros-0.28.0, ament-xmllint-0.19.0, ament-lint-0.19.0, ament-copyright-0.19.0, ament-flake8-0.19.0, ament-pep257-0.19.0, typeguard-4.1.5, rerunfailures-12.0, flaky-3.7.0, colcon-core-0.18.4
collected 1 item

src/navigation2/nav2_docking/opennav_docking/test/test_docking_server.py                                                                                                                                  [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%] [100%]. [100%]
===Flaky Test Report===

test_docking_server passed 1 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 2 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 3 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 4 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 5 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 6 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 7 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 8 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 9 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 10 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 11 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 12 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 13 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 14 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 15 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 16 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 17 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 18 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 19 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 20 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 21 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 22 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 23 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 24 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 25 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 26 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 27 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 28 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 29 out of the required 30 times. Running test again until it passes 30 times.
test_docking_server passed 30 out of the required 30 times. Success!

===End Flaky Test Report===

========================================================================================= 1 passed in 529.28s (0:08:49) =========================================================================================
```
---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
