### PR TITLE
Fix rviz crash if launch later

### DIFF
--- a/nav2_bringup/launch/rviz_launch.py
+++ b/nav2_bringup/launch/rviz_launch.py
@@ -90,4 +90,3 @@ def generate_launch_description():
     ld.add_action(exit_event_handler)
 
     return ld
-    

--- a/nav2_bringup/launch/rviz_launch.py
+++ b/nav2_bringup/launch/rviz_launch.py
@@ -36,7 +36,7 @@ def generate_launch_description():
     # Declare the launch arguments
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
-        default_value='',
+        default_value='navigation',
         description=(
             'Top-level namespace. The value will be used to replace the '
             '<robot_namespace> keyword on the rviz config file.'
@@ -60,7 +60,7 @@ def generate_launch_description():
         executable='rviz2',
         namespace=namespace,
         arguments=['-d', rviz_config_file],
-        output='log',
+        output='screen',
         parameters=[{'use_sim_time': use_sim_time}],
         remappings=[
             ('/tf', 'tf'),

--- a/nav2_bringup/launch/rviz_launch.py
+++ b/nav2_bringup/launch/rviz_launch.py
@@ -36,7 +36,7 @@ def generate_launch_description():
     # Declare the launch arguments
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
-        default_value='navigation',
+        default_value='',
         description=(
             'Top-level namespace. The value will be used to replace the '
             '<robot_namespace> keyword on the rviz config file.'
@@ -60,7 +60,7 @@ def generate_launch_description():
         executable='rviz2',
         namespace=namespace,
         arguments=['-d', rviz_config_file],
-        output='screen',
+        output='log',
         parameters=[{'use_sim_time': use_sim_time}],
         remappings=[
             ('/tf', 'tf'),

--- a/nav2_bringup/launch/rviz_launch.py
+++ b/nav2_bringup/launch/rviz_launch.py
@@ -90,3 +90,4 @@ def generate_launch_description():
     ld.add_action(exit_event_handler)
 
     return ld
+    

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/selector.hpp
@@ -16,7 +16,6 @@
 #define NAV2_RVIZ_PLUGINS__SELECTOR_HPP_
 
 #include <QtWidgets>
-#include <QBasicTimer>
 #include <QFrame>
 #include <QGridLayout>
 #include <QScrollArea>
@@ -43,8 +42,7 @@ public:
   ~Selector();
 
 private:
-  // The (non-spinning) client node used to invoke the action client
-  void timerEvent(QTimerEvent * event) override;
+  void loadPlugins();
 
   rclcpp::Node::SharedPtr client_node_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_controller_;
@@ -52,13 +50,12 @@ private:
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_goal_checker_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_smoother_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_progress_checker_;
-  rclcpp::TimerBase::SharedPtr rclcpp_timer_;
 
   bool plugins_loaded_ = false;
   bool server_failed_ = false;
-  bool tried_once_ = false;
 
-  QBasicTimer timer_;
+  std::thread load_plugins_thread_;
+
   QVBoxLayout * main_layout_;
   QHBoxLayout * row_1_layout_;
   QHBoxLayout * row_2_layout_;

--- a/nav2_rviz_plugins/src/selector.cpp
+++ b/nav2_rviz_plugins/src/selector.cpp
@@ -150,7 +150,7 @@ void
 Selector::loadPlugins()
 {
   load_plugins_thread_ = std::thread([this]() {
-        rclcpp::Rate rate(0.1);
+        rclcpp::Rate rate(0.2);
         while (rclcpp::ok() && !plugins_loaded_) {
           RCLCPP_INFO(client_node_->get_logger(), "Trying to load plugins...");
           nav2_rviz_plugins::pluginLoader(
@@ -172,6 +172,8 @@ Selector::loadPlugins()
           progress_checker_->count() > 0)
           {
             plugins_loaded_ = true;
+          } else {
+            RCLCPP_INFO(client_node_->get_logger(), "Failed to load plugins. Retrying...");
           }
           rate.sleep();
         }

--- a/nav2_rviz_plugins/src/selector.cpp
+++ b/nav2_rviz_plugins/src/selector.cpp
@@ -70,7 +70,7 @@ Selector::Selector(QWidget * parent)
   main_layout_->addLayout(row_3_layout_);
 
   setLayout(main_layout_);
-  timer_.start(200, this);
+  loadPlugins();
 
   connect(
     controller_, QOverload<int>::of(&QComboBox::activated), this,
@@ -115,7 +115,6 @@ void Selector::setSelection(
   msg.data = combo_box->currentText().toStdString();
 
   publisher->publish(msg);
-  timer_.start(200, this);
 }
 
 // Call setSelection() for controller
@@ -148,37 +147,35 @@ void Selector::setProgressChecker()
 }
 
 void
-Selector::timerEvent(QTimerEvent * event)
+Selector::loadPlugins()
 {
-  if (event->timerId() == timer_.timerId()) {
-    if (!plugins_loaded_) {
-      nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "controller_server", "controller_plugins", controller_);
-      nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "planner_server", "planner_plugins", planner_);
-      nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "controller_server", "goal_checker_plugins", goal_checker_);
-      nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "smoother_server", "smoother_plugins", smoother_);
-      nav2_rviz_plugins::pluginLoader(
-        client_node_, server_failed_, "controller_server", "progress_checker_plugins",
-        progress_checker_);
-
-      plugins_loaded_ = true;
-    }
-
-    // Restart the timer if the one of the server fails
-    if (server_failed_ && !tried_once_) {
-      RCLCPP_INFO(client_node_->get_logger(), "Retrying to connect to the failed server.");
-      server_failed_ = false;
-      plugins_loaded_ = false;
-      tried_once_ = true;
-      timer_.start(200, this);
-      return;
-    }
-
-    timer_.stop();
-  }
+  load_plugins_thread_ = std::thread([this]() {
+        rclcpp::Rate rate(0.1);
+        while (rclcpp::ok() && !plugins_loaded_) {
+          RCLCPP_INFO(client_node_->get_logger(), "Trying to load plugins...");
+          nav2_rviz_plugins::pluginLoader(
+            client_node_, server_failed_, "controller_server", "controller_plugins", controller_);
+          nav2_rviz_plugins::pluginLoader(
+            client_node_, server_failed_, "planner_server", "planner_plugins", planner_);
+          nav2_rviz_plugins::pluginLoader(
+            client_node_, server_failed_, "controller_server", "goal_checker_plugins",
+            goal_checker_);
+          nav2_rviz_plugins::pluginLoader(
+            client_node_, server_failed_, "smoother_server", "smoother_plugins", smoother_);
+          nav2_rviz_plugins::pluginLoader(
+            client_node_, server_failed_, "controller_server", "progress_checker_plugins",
+            progress_checker_);
+          if (controller_->count() > 0 &&
+          planner_->count() > 0 &&
+          goal_checker_->count() > 0 &&
+          smoother_->count() > 0 &&
+          progress_checker_->count() > 0)
+          {
+            plugins_loaded_ = true;
+          }
+          rate.sleep();
+        }
+  });
 }
 
 }  // namespace nav2_rviz_plugins

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -24,12 +24,12 @@ void pluginLoader(
   rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
   const std::string & plugin_type, QComboBox * combo_box)
 {
-  auto parameter_client = std::make_shared<rclcpp::SyncParametersClient>(node, server_name);
-
   // Do not load the plugins if the combo box is already populated
   if (combo_box->count() > 0) {
     return;
   }
+
+  auto parameter_client = std::make_shared<rclcpp::SyncParametersClient>(node, server_name);
 
   // Wait for the service to be available before calling it
   bool server_unavailable = false;
@@ -49,9 +49,9 @@ void pluginLoader(
   if (server_unavailable) {
     return;
   }
-  combo_box->addItem("Default");
   auto parameters = parameter_client->get_parameters({plugin_type});
   auto str_arr = parameters[0].as_string_array();
+  combo_box->addItem("Default");
   for (auto str : str_arr) {
     combo_box->addItem(QString::fromStdString(str));
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                                        | Please fill out this column |
| ------------------------------------------- | --------------------------- |
| Ticket(s) this addresses                    | #4754                       |
| Primary OS tested on                        | Ubuntu 24.04                |
| Robotic platform tested on                  | turtlebot 3 simulation      |
| Does this PR contain AI generated software? | No                          |

---

## Description of contribution in a few bullet points

Revival of #4871 targeting the main branch with improved code 

- Open a new thread to load plugins, to ensure that `get_parameter()` would not block the main thread. The combo box will now have value if it successfully gets the parameter, otherwise empty


## Description of documentation updates required from your changes

None

## Description of how this change was tested


Extensively tested on tb3 simulation and all tests passed

---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists