### PR TITLE
Fix for setting dynamically the footprint_clearing_enabled parameter in the StaticLayer costmap_2d plugin

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -496,9 +496,7 @@ StaticLayer::dynamicParametersCallback(
         height_ = size_y_;
         has_updated_data_ = true;
         current_ = false;
-      }
-    } else if (param_type == ParameterType::PARAMETER_BOOL) {
-      if (param_name == name_ + "." + "footprint_clearing_enabled") {
+      } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       }
     }


### PR DESCRIPTION
In the StaticLayer costmap2d_plugin , the parameter `footprint_clearing_enabled` was never changed dynamically in the callback, because the `else if` condition has a duplicated condition (same as in [line 490](https://github.com/ros-navigation/navigation2/blob/dcc5db5eae4566c30dfa886920e43d2acc01af7b/nav2_costmap_2d/plugins/static_layer.cpp#L490) and [line 500](https://github.com/ros-navigation/navigation2/blob/dcc5db5eae4566c30dfa886920e43d2acc01af7b/nav2_costmap_2d/plugins/static_layer.cpp#L500)), so it never executed setting that parameter.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
- Fixes the dynamical parameter change of the parameter `footprint_clearing_enabled` via a ros2 callback
- The `else if` condition was a duplicate of the one before, so it was never executed. This change is fixing it.

## Description of documentation updates required from your changes
Not needed.

## Description of how this change was tested 
`ros2 param set /local_costmap/local_costmap obstacle_layer.footprint_clearing_enabled False` or True to disable/enable it


## Future work that may be required in bullet points
None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
