### PR TITLE
dwb_critics flaky test - lineCost coordinates must be within costmap 

### DIFF
--- a/nav2_dwb_controller/dwb_critics/test/obstacle_footprint_test.cpp
+++ b/nav2_dwb_controller/dwb_critics/test/obstacle_footprint_test.cpp
@@ -248,7 +248,9 @@ TEST(ObstacleFootprint, LineCost)
   costmap_ros->getCostmap()->setCost(4, 3, 100);
   costmap_ros->getCostmap()->setCost(4, 4, 100);
 
-  ASSERT_EQ(critic->lineCost(3, 3, 0, 50), 50);   // all 50
+  auto max_y_in_grid_coordinates = costmap_ros->getCostmap()->getSizeInCellsY() - 1;
+  ASSERT_EQ(max_y_in_grid_coordinates, 49);
+  ASSERT_EQ(critic->lineCost(3, 3, 0, max_y_in_grid_coordinates), 50);   // all 50
   ASSERT_EQ(critic->lineCost(4, 4, 0, 10), 100);  // all 100
   ASSERT_EQ(critic->lineCost(0, 50, 3, 3), 100);  // pass 50 and 100
 }


### PR DESCRIPTION


<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#4884) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | laptop |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

There is no protection/checks in the pathway from lineCost to costmap_2d::getIndex(mx, my) for grid coordinates that exceed the of bounds of the allocated costmap. (presumably for speed)

This test was triggering an off by one error attempting to read the the 2500 byte costmap at byte 2503

costmap size 50x50.

getIndex(3, 50)
= my * size_x_ + mx;
= 50 * 50 + 3;
= 2503

## Description of documentation updates required from your changes

n/a

## Description of how this change was tested

gdb -ex run --args build/dwb_critics/test/obstacle_footprint_tests --gtest_break_on_failure --gtest_catch_exceptions=0 --gtest_repeat=1000

---

## Future work that may be required in bullet points

The costmap_2d could use a vector rather than a raw buffer which provides greater detection of out of bounds errors. Albeit with the performance penalty in debug.

I did explore that for education purposes https://github.com/ewak/navigation2/tree/feature/mw/costmap2d_vectors 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
