### PR TITLE
Fix unstable test in nav2 util

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -148,8 +148,11 @@ public:
     std::shared_ptr<const typename ActionT::Goal>/*goal*/)
   {
     std::lock_guard<std::recursive_mutex> lock(update_mutex_);
-
+    
     if (!server_active_) {
+      RCLCPP_INFO(
+        node_logging_interface_->get_logger(),
+        "Action server is inactive. Rejecting the goal.");
       return rclcpp_action::GoalResponse::REJECT;
     }
 

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -148,7 +148,7 @@ public:
     std::shared_ptr<const typename ActionT::Goal>/*goal*/)
   {
     std::lock_guard<std::recursive_mutex> lock(update_mutex_);
-    
+
     if (!server_active_) {
       RCLCPP_INFO(
         node_logging_interface_->get_logger(),

--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -258,6 +258,7 @@ protected:
 
 TEST_F(ActionTest, test_simple_action)
 {
+  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
   node_->activate_server();
 
   // The goal for this invocation
@@ -272,6 +273,7 @@ TEST_F(ActionTest, test_simple_action)
       future_goal_handle), rclcpp::FutureReturnCode::SUCCESS);
 
   auto goal_handle = future_goal_handle.get();
+  EXPECT_NE(goal_handle, nullptr);
 
   // Wait for the result
   auto future_result = node_->action_client_->async_get_result(goal_handle);
@@ -320,6 +322,7 @@ TEST_F(ActionTest, test_simple_action_with_feedback)
       future_goal_handle), rclcpp::FutureReturnCode::SUCCESS);
 
   auto goal_handle = future_goal_handle.get();
+  EXPECT_NE(goal_handle, nullptr);
 
   // Wait for the result
   auto future_result = node_->action_client_->async_get_result(goal_handle);
@@ -364,6 +367,7 @@ TEST_F(ActionTest, test_simple_action_activation_cycling)
   node_->deactivate_server();
 
   auto goal_handle = future_goal_handle.get();
+  EXPECT_NE(goal_handle, nullptr);
 
   // Wait for the result
   auto future_result = node_->action_client_->async_get_result(goal_handle);
@@ -430,6 +434,7 @@ TEST_F(ActionTest, test_simple_action_preemption)
       future_goal_handle), rclcpp::FutureReturnCode::SUCCESS);
 
   auto goal_handle = future_goal_handle.get();
+  EXPECT_NE(goal_handle, nullptr);
 
   // Wait for the result
   auto future_result = node_->action_client_->async_get_result(goal_handle);
@@ -478,6 +483,7 @@ TEST_F(ActionTest, test_simple_action_preemption_after_succeeded)
 
   // Get the results
   auto goal_handle = future_goal_handle.get();
+  EXPECT_NE(goal_handle, nullptr);
 
   // Wait for the result of initial goal
   auto future_result = node_->action_client_->async_get_result(goal_handle);

--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -258,7 +258,7 @@ protected:
 
 TEST_F(ActionTest, test_simple_action)
 {
-  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   node_->activate_server();
 
   // The goal for this invocation


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4893  |
| Primary OS tested on | Ubuntu24.04 |
| Robotic platform tested on | Custom env |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Fix unstable test as mentioned in the issue, this is due to the inactiveness of the server that causes the goal handle to be a nullptr, which is throwing the exception of `C++ exception with description "Goal handle is not known to this client.`. Thus, I am adding an `EXPECT_NE` for the goal handle, and add a short delay before we activate the server

## Description of documentation updates required from your changes
None

## Description of how this change was tested

Running the test for 1000 times independently

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
