### PR TITLE
MPPI: Do not set params success in dynamic params callback to allow changing params in other plugins

### DIFF
--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -70,7 +70,6 @@ ParametersHandler::dynamicParamsCallback(
     {
       callback->second(param, result);
     } else {
-      result.successful = false;
       if (!result.reason.empty()) {
         result.reason += "\n";
       }

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -69,11 +69,6 @@ ParametersHandler::dynamicParamsCallback(
       callback != get_param_callbacks_.end())
     {
       callback->second(param, result);
-    } else {
-      if (!result.reason.empty()) {
-        result.reason += "\n";
-      }
-      result.reason += "get_param_callback func for '" + param_name + "' not found.\n";
     }
   }
 

--- a/nav2_mppi_controller/test/parameter_handler_test.cpp
+++ b/nav2_mppi_controller/test/parameter_handler_test.cpp
@@ -267,13 +267,6 @@ TEST(ParameterHandlerTest, DynamicAndStaticParametersNotDeclaredTest)
   EXPECT_EQ(result.successful, true);
   EXPECT_TRUE(result.reason.empty());
 
-  // Try to access some parameters that have not been declared
-  int p1 = 0, p2 = 0;
-  EXPECT_THROW(getParameter(p1, "not_declared", 8, ParameterType::Dynamic),
-               rclcpp::exceptions::InvalidParameterValueException);
-  EXPECT_THROW(getParameter(p2, "not_declared2", 9, ParameterType::Static),
-               rclcpp::exceptions::InvalidParameterValueException);
-
   // Try to set some parameters that have not been declared via the service client
   result_future = rec_param->set_parameters_atomically({
     rclcpp::Parameter("static_int", 10),
@@ -292,7 +285,4 @@ TEST(ParameterHandlerTest, DynamicAndStaticParametersNotDeclaredTest)
   // The ParameterNotDeclaredException handler in rclcpp/parameter_service.cpp
   // overrides any other reasons and does not provide details to the service client.
   EXPECT_EQ(result.reason, std::string("One or more parameters were not declared before setting"));
-
-  EXPECT_EQ(p1, 0);
-  EXPECT_EQ(p2, 0);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Theres a bug when setting params from other plugins when using mppi|
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |

---

## Description of contribution in a few bullet points

Currently, the parameters handler library in the MPPI will return failure when trying to set a parameter in the controller server node that does not belong to the MPPI plugin. This is because rclcpp will stop processing dynamic params callbacks when one of them returns falure, see https://github.com/ros2/rclcpp/pull/2735 for details 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
