### PR TITLE
Fix Misplaced Footprint on Static Layer

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -49,6 +49,8 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/footprint.hpp"
+#include "nav2_util/robot_utils.hpp"
+#include "tf2/utils.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -197,7 +199,8 @@ protected:
   bool trinary_costmap_;
   bool map_received_{false};
   bool map_received_in_update_bounds_{false};
-  tf2::Duration transform_tolerance_;
+  double transform_tolerance_;
+  std::string robot_base_frame_;
   nav_msgs::msg::OccupancyGrid::SharedPtr map_buffer_;
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -386,7 +386,7 @@ StaticLayer::updateFootprint(
   if (!footprint_clearing_enabled_) {return;}
 
   if (map_frame_.empty()) {return;}
-  if (map_frame != global_frame_) {
+  if (map_frame_ != global_frame_) {
     geometry_msgs::msg::PoseStamped robot_pose;
     nav2_util::getCurrentPose(
       robot_pose, *tf_,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

I noticed that the robot footprint clearing is clearing the wrong spot on the local costmap. The offset is exactly odom->map TF
My static_layer on local costmap (rolling_window=True) subscribes to occupancy grid in 'map' frame
![Screenshot from 2025-02-10 02-38-32](https://github.com/user-attachments/assets/c5b871c9-87c0-47c7-922e-a3094e73d97e)

The robot pose received by the static layer is in the costmap's global frame, but it should be in the frame of the map it subscribes to, because otherwise the static layer is transformed by odom->map TF and the footprint ends up in the wrong place:
https://github.com/ros-navigation/navigation2/blob/088c423deb97a76f5a5f4ca133cb122338576fe1/nav2_costmap_2d/plugins/static_layer.cpp#L454

## Description of how this change was tested

* Drive into static_layer's lethal space, see if the footprint is cleared in the correct place, and it is
 
![Screenshot from 2025-02-10 02-35-13](https://github.com/user-attachments/assets/5d29f160-29b7-453e-b092-feebdbae3af8)


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
