### PR TITLE
Optimize costmap2d publisher performance

### DIFF
--- a/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
@@ -167,9 +167,11 @@ TEST_F(TestCostmapSubscriberShould, handleFullCostmapMsgs)
   bool always_send_full_costmap = true;
 
   std::vector<std::vector<std::uint8_t>> expectedCostmaps;
-  std::unique_ptr<nav_msgs::msg::OccupancyGrid> expectedGrids = std::make_unique<nav_msgs::msg::OccupancyGrid>();
+  std::unique_ptr<nav_msgs::msg::OccupancyGrid> expectedGrids =
+    std::make_unique<nav_msgs::msg::OccupancyGrid>();
   std::vector<std::vector<std::uint8_t>> receivedCostmaps;
-  std::unique_ptr<nav_msgs::msg::OccupancyGrid> receivedGrids = std::make_unique<nav_msgs::msg::OccupancyGrid>();
+  std::unique_ptr<nav_msgs::msg::OccupancyGrid> receivedGrids =
+    std::make_unique<nav_msgs::msg::OccupancyGrid>();
 
   auto costmapPublisher = std::make_shared<nav2_costmap_2d::Costmap2DPublisher>(
     node, costmapToSend.get(), "", topicName, always_send_full_costmap);
@@ -213,9 +215,11 @@ TEST_F(TestCostmapSubscriberShould, handleCostmapUpdateMsgs)
   bool always_send_full_costmap = false;
 
   std::vector<std::vector<std::uint8_t>> expectedCostmaps;
-  std::unique_ptr<map_msgs::msg::OccupancyGridUpdate> expectedGrids = std::make_unique<map_msgs::msg::OccupancyGridUpdate>();
+  std::unique_ptr<map_msgs::msg::OccupancyGridUpdate> expectedGrids =
+    std::make_unique<map_msgs::msg::OccupancyGridUpdate>();
   std::vector<std::vector<std::uint8_t>> receivedCostmaps;
-  std::unique_ptr<map_msgs::msg::OccupancyGridUpdate> receivedGrids = std::make_unique<map_msgs::msg::OccupancyGridUpdate>();
+  std::unique_ptr<map_msgs::msg::OccupancyGridUpdate> receivedGrids =
+    std::make_unique<map_msgs::msg::OccupancyGridUpdate>();
 
   auto costmapPublisher = std::make_shared<nav2_costmap_2d::Costmap2DPublisher>(
     node, costmapToSend.get(), "", topicName, always_send_full_costmap);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Related ticket is #4914  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo sim |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Motivated by the ticket, I did a quick profiling and tried to optimize the performance, for those loops using translation maps, I suggest to use std::transform, it is a 2-5x speed up, for the update ones, I suggest to get the costmap pointer instead of calling `getcost(x,y)`, also a `copy_n` is used in the inner loop, which is around 10x speed up

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Run on the unit test and my simulation

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
