### PR TITLE
Throttle collision monitor's polygon ingestion update log message

### DIFF
--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -588,9 +588,16 @@ Polygon::dynamicParametersCallback(
 
 void Polygon::polygonCallback(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg)
 {
-  RCLCPP_INFO(
+  auto node = node_.lock();
+  if (!node) {
+    throw std::runtime_error{"Failed to lock node"};
+  }
+  auto& clock = *node->get_clock();
+  RCLCPP_INFO_THROTTLE(
     logger_,
-    "[%s]: Polygon shape update has been arrived",
+    clock,
+    2000,
+    "[%s]: Polygon shape update has arrived",
     polygon_name_.c_str());
   updatePolygon(msg);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu 24 |
| Robotic platform tested on | gazebo sim and on-machine |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Throttle the RCLCPP_INFO log message in the `polygonCallback` of collision monitor. When a polygon update is sent to collision monitor the log message "Polygon shape update has been arrived". If you are providing polygon updates often this will fill logs. Would consider making debug message as well. It is nice to have in logs though. Also fixed the grammar of the log message while I was modifying the line.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

+ In simulation and on-machine

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
