### PR TITLE
[nav2_behavior_tree] Add force_use_current_pose to ComputePathToPoseAction

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -80,6 +80,9 @@ public:
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>(
           "start", "Start pose of the path if overriding current robot pose"),
+        BT::InputPort<bool>(
+          "force_use_current_pose", "Use current robot pose, even if `start` is provided "
+          "(effectively ignoring it)"),
         BT::InputPort<std::string>(
           "planner_id", "",
           "Mapped name to the planner plugin type to use"),

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -77,6 +77,7 @@
     <Action ID="ComputePathToPose">
       <input_port name="goal">Destination to plan to</input_port>
       <input_port name="start">Start pose of the path if overriding current robot pose</input_port>
+      <input_port name="force_use_current_pose">Use current robot pose, even if `start` is provided (effectively ignoring it)</input_port>
       <input_port name="planner_id">Mapped name to the planner plugin type to use</input_port>
       <input_port name="server_name">Server name</input_port>
       <input_port name="server_timeout">Server timeout</input_port>

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -33,7 +33,13 @@ void ComputePathToPoseAction::on_tick()
   getInput("goal", goal_.goal);
   getInput("planner_id", goal_.planner_id);
   if (getInput("start", goal_.start)) {
-    goal_.use_start = true;
+    bool force_use_current_pose = false;
+    getInput("force_use_current_pose", force_use_current_pose);
+    if (force_use_current_pose) {
+      goal_.use_start = false;
+    } else {
+      goal_.use_start = true;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on |(Ubuntu|
| Robotic platform tested on | Dexory robot|
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Adds an optional input field `force_use_current_pose` to the `ComputePathToPoseAction` BT node.
When set to true, use the current robot pose, even if `start` is provided (effectively ignoring it).
This is useful when calling several time the `ComputePathToPoseAction` in a BT with different arguments and wanting to use the current pose of the robot after a call where `start` was used (and hence existing in the blackboard).

## Description of documentation updates required from your changes

If accepted in this state, then update this: https://docs.nav2.org/configuration/packages/bt-plugins/actions/ComputePathToPose.html#computepathtopose

## Description of how this change was tested

Extensively tested on my physical robot platform (but backported from Dexory jazzy branch)

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
