### PR TITLE
[CostmapTopicCollisionChecker] Alternative constructor with footprint string

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_topic_collision_checker.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_topic_collision_checker.hpp
@@ -49,6 +49,15 @@ public:
     std::string name = "collision_checker");
 
   /**
+   * @brief Alternative constructor with a footprint string instead of a subscriber. It needs to be
+   * defined relative to the robot frame
+   */
+  CostmapTopicCollisionChecker(
+    CostmapSubscriber & costmap_sub,
+    std::string footprint_string,
+    std::string name = "collision_checker");
+
+  /**
    * @brief A destructor
    */
   ~CostmapTopicCollisionChecker() = default;
@@ -90,10 +99,11 @@ protected:
   // Name used for logging
   std::string name_;
   CostmapSubscriber & costmap_sub_;
-  FootprintSubscriber & footprint_sub_;
+  std::shared_ptr<FootprintSubscriber> footprint_sub_;
   FootprintCollisionChecker<std::shared_ptr<Costmap2D>> collision_checker_;
   rclcpp::Clock::SharedPtr clock_;
   Footprint footprint_;
+  std::string footprint_string_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
@@ -38,9 +38,20 @@ CostmapTopicCollisionChecker::CostmapTopicCollisionChecker(
   std::string name)
 : name_(name),
   costmap_sub_(costmap_sub),
-  footprint_sub_(footprint_sub),
+  footprint_sub_(&footprint_sub),
   collision_checker_(nullptr)
 {}
+
+CostmapTopicCollisionChecker::CostmapTopicCollisionChecker(
+  CostmapSubscriber & costmap_sub,
+  std::string footprint_string,
+  std::string name)
+: name_(name),
+  costmap_sub_(costmap_sub),
+  collision_checker_(nullptr)
+{
+  makeFootprintFromString(footprint_string, footprint_);
+}
 
 bool CostmapTopicCollisionChecker::isCollisionFree(
   const geometry_msgs::msg::Pose2D & pose,
@@ -90,8 +101,13 @@ Footprint CostmapTopicCollisionChecker::getFootprint(
 {
   if (fetch_latest_footprint) {
     std_msgs::msg::Header header;
-    if (!footprint_sub_.getFootprintInRobotFrame(footprint_, header)) {
-      throw CollisionCheckerException("Current footprint not available.");
+
+    // if footprint_sub_ was not initialized (alternative constructor), we are using the
+    // footprint built from the footprint_string alternative constructor argument.
+    if (footprint_sub_) {
+      if (!footprint_sub_->getFootprintInRobotFrame(footprint_, header)) {
+        throw CollisionCheckerException("Current footprint not available.");
+      }
     }
   }
   Footprint footprint;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   ||
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory Robot |
| Does this PR contain AI generated software? ||

---

## Description of contribution in a few bullet points

I needed to use the `CostmapTopicCollisionChecker` but with a custom footprint, NOT one served from a topic with `FootprintSubscriber`. So I added a constructor building a footpring from a string (same format as everywhere else).


## Description of documentation updates required from your changes

Don't see any.

## Description of how this change was tested

Dexory robot for a few days.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
