### PR TITLE
Fix flaky mppi test

### DIFF
--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -82,18 +82,17 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   // Request an update with no noise yet generated, should result in identical outputs
   generator.initialize(settings, false, "test_name", &handler);
   generator.reset(settings, false);  // sets initial sizing and zeros out noises
-  generator.setNoisedControls(state, control_sequence);
-  EXPECT_EQ(state.cvx(0), 0);
-  EXPECT_EQ(state.cvy(0), 0);
-  EXPECT_EQ(state.cwz(0), 0);
-  EXPECT_EQ(state.cvx(0, 9), 9);
-  EXPECT_EQ(state.cvy(0, 9), 9);
-  EXPECT_EQ(state.cwz(0, 9), 9);
-
-  // Request an update with noise requested
-  generator.generateNextNoises();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   generator.setNoisedControls(state, control_sequence);
+
+  //saved initial state
+  auto initial_cvx_0 = state.cvx(0);
+  auto initial_cvy_0 = state.cvy(0);
+  auto initial_cwz_0 = state.cwz(0);
+  auto initial_cvx_9 = state.cvx(0, 9);
+  auto initial_cvy_9 = state.cvy(0, 9);
+  auto initial_cwz_9 = state.cwz(0, 9);
+
   EXPECT_NE(state.cvx(0), 0);
   EXPECT_EQ(state.cvy(0), 0);  // Not populated in non-holonomic
   EXPECT_NE(state.cwz(0), 0);
@@ -102,11 +101,23 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   EXPECT_NE(state.cwz(0, 9), 9);
 
   EXPECT_NEAR(state.cvx(0), 0, 0.3);
-  EXPECT_NEAR(state.cvy(0), 0, 0.3);
   EXPECT_NEAR(state.cwz(0), 0, 0.3);
   EXPECT_NEAR(state.cvx(0, 9), 9, 0.3);
-  EXPECT_NEAR(state.cvy(0, 9), 9, 0.3);
   EXPECT_NEAR(state.cwz(0, 9), 9, 0.3);
+
+  // Request an update with noise requested
+  generator.generateNextNoises();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  generator.setNoisedControls(state, control_sequence);
+
+  // Ensure the state has changed after generating new noises
+  EXPECT_NE(state.cvx(0), initial_cvx_0);
+  EXPECT_EQ(state.cvy(0), initial_cvy_0);  // Not populated in non-holonomic
+  EXPECT_NE(state.cwz(0), initial_cwz_0);
+  EXPECT_NE(state.cvx(0, 9), initial_cvx_9);
+  EXPECT_EQ(state.cvy(0, 9), initial_cvy_9);  // Not populated in non-holonomic
+  EXPECT_NE(state.cwz(0, 9), initial_cwz_9);
+
 
   // Test holonomic setting
   generator.reset(settings, true);  // Now holonomically
@@ -129,3 +140,72 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
 
   generator.shutdown();
 }
+
+TEST(NoiseGeneratorTest, NoiseGeneratorMainNoRegenerate)
+{
+  // This time with no regeneration of noises
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  ParametersHandler handler(node);
+  NoiseGenerator generator;
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 100;
+  settings.time_steps = 25;
+  settings.sampling_std.vx = 0.1;
+  settings.sampling_std.vy = 0.1;
+  settings.sampling_std.wz = 0.1;
+
+  // Populate a potential control sequence
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(25);
+  for (unsigned int i = 0; i != control_sequence.vx.rows(); i++) {
+    control_sequence.vx(i) = i;
+    control_sequence.vy(i) = i;
+    control_sequence.wz(i) = i;
+  }
+
+  mppi::models::State state;
+  state.reset(settings.batch_size, settings.time_steps);
+
+  // Request an update with no noise yet generated, should result in identical outputs
+  generator.initialize(settings, false, "test_name", &handler);
+  generator.reset(settings, false);  // sets initial sizing and zeros out noises
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  generator.setNoisedControls(state, control_sequence);
+
+  //saved initial state
+  auto initial_cvx_0 = state.cvx(0);
+  auto initial_cvy_0 = state.cvy(0);
+  auto initial_cwz_0 = state.cwz(0);
+  auto initial_cvx_9 = state.cvx(0, 9);
+  auto initial_cvy_9 = state.cvy(0, 9);
+  auto initial_cwz_9 = state.cwz(0, 9);
+
+  EXPECT_NE(state.cvx(0), 0);
+  EXPECT_EQ(state.cvy(0), 0);  // Not populated in non-holonomic
+  EXPECT_NE(state.cwz(0), 0);
+  EXPECT_NE(state.cvx(0, 9), 9);
+  EXPECT_EQ(state.cvy(0, 9), 9);  // Not populated in non-holonomic
+  EXPECT_NE(state.cwz(0, 9), 9);
+
+  EXPECT_NEAR(state.cvx(0), 0, 0.3);
+  EXPECT_NEAR(state.cwz(0), 0, 0.3);
+  EXPECT_NEAR(state.cvx(0, 9), 9, 0.3);
+  EXPECT_NEAR(state.cwz(0, 9), 9, 0.3);
+
+  // this doesn't work if regenerate_noises is false
+  generator.generateNextNoises();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  generator.setNoisedControls(state, control_sequence);
+
+  // Ensure the state has changed after generating new noises
+  EXPECT_EQ(state.cvx(0), initial_cvx_0);
+  EXPECT_EQ(state.cvy(0), initial_cvy_0);  // Not populated in non-holonomic
+  EXPECT_EQ(state.cwz(0), initial_cwz_0);
+  EXPECT_EQ(state.cvx(0, 9), initial_cvx_9);
+  EXPECT_EQ(state.cvy(0, 9), initial_cvy_9);  // Not populated in non-holonomic
+  EXPECT_EQ(state.cwz(0, 9), initial_cwz_9);
+
+  generator.shutdown();
+}
+

--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -85,7 +85,7 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   generator.setNoisedControls(state, control_sequence);
 
-  //saved initial state
+  // save initial state
   auto initial_cvx_0 = state.cvx(0);
   auto initial_cvy_0 = state.cvy(0);
   auto initial_cwz_0 = state.cwz(0);
@@ -173,7 +173,7 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMainNoRegenerate)
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   generator.setNoisedControls(state, control_sequence);
 
-  //saved initial state
+  // save initial state
   auto initial_cvx_0 = state.cvx(0);
   auto initial_cvy_0 = state.cvy(0);
   auto initial_cwz_0 = state.cwz(0);
@@ -208,4 +208,3 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMainNoRegenerate)
 
   generator.shutdown();
 }
-


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4932  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo sim |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

- Fixed the flaky test as mentioned in the issue, added a new one for non-regenerate noise

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Unit test, run around 10000 rounds

---

## Future work that may be required in bullet points

Currently in noise generator we have 3 tests, the first test `NoiseGeneratorLifecycle` is actually covered by my new one, should we delete this test or keep it?

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
