### PR TITLE
Fix uninitialized element used in mppi trajectory test

### DIFF
--- a/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
+++ b/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
@@ -181,10 +181,11 @@ TEST(TrajectoryVisualizerTests, VisOptimalPath)
   EXPECT_EQ(received_path.poses.size(), 0u);
 
   // Now populated with content, should publish
-  optimal_trajectory.resize(20, 2);
+  optimal_trajectory.resize(20, 3);
   for (unsigned int i = 0; i != optimal_trajectory.rows() - 1; i++) {
     optimal_trajectory(i, 0) = static_cast<float>(i);
     optimal_trajectory(i, 1) = static_cast<float>(i);
+    optimal_trajectory(i, 2) = static_cast<float>(i);
   }
   vis.add(optimal_trajectory, "Optimal Trajectory", cmd_stamp);
   vis.visualize(bogus_path);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4934 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

- Fix bug as described in the issue

## Description of documentation updates required from your changes


## Description of how this change was tested

Unit test run around 10000 rounds, no error occured

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
