### PR TITLE
Use main function instead of global variable to setup the test environment.

### DIFF
--- a/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
@@ -63,10 +63,10 @@ public:
   }
 };
 
-class RemoveInCollisionGoalsTestFixture : public ::testing::Test
+class BTTestEnv
 {
 public:
-  static void SetUpTestCase()
+  BTTestEnv()
   {
     node_ = std::make_shared<rclcpp::Node>("in_collision_goals_test_fixture");
     factory_ = std::make_shared<BT::BehaviorTreeFactory>();
@@ -100,7 +100,7 @@ public:
       "RemoveInCollisionGoals", builder);
   }
 
-  static void TearDownTestCase()
+  ~BTTestEnv()
   {
     delete config_;
     config_ = nullptr;
@@ -109,31 +109,16 @@ public:
     factory_.reset();
   }
 
-  void TearDown() override
-  {
-    tree_.reset();
-  }
-  static std::shared_ptr<RemoveInCollisionGoalsSuccessService> success_server_;
-  static std::shared_ptr<RemoveInCollisionGoalsFailureService> failure_server_;
-
-protected:
-  static rclcpp::Node::SharedPtr node_;
-  static BT::NodeConfiguration * config_;
-  static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
-  static std::shared_ptr<BT::Tree> tree_;
+  std::shared_ptr<RemoveInCollisionGoalsSuccessService> success_server_;
+  std::shared_ptr<RemoveInCollisionGoalsFailureService> failure_server_;
+  rclcpp::Node::SharedPtr node_;
+  BT::NodeConfiguration * config_;
+  std::shared_ptr<BT::BehaviorTreeFactory> factory_;
 };
 
-rclcpp::Node::SharedPtr RemoveInCollisionGoalsTestFixture::node_ = nullptr;
+BTTestEnv * test_env = nullptr;
 
-BT::NodeConfiguration * RemoveInCollisionGoalsTestFixture::config_ = nullptr;
-std::shared_ptr<RemoveInCollisionGoalsSuccessService>
-RemoveInCollisionGoalsTestFixture::success_server_ = nullptr;
-std::shared_ptr<RemoveInCollisionGoalsFailureService>
-RemoveInCollisionGoalsTestFixture::failure_server_ = nullptr;
-std::shared_ptr<BT::BehaviorTreeFactory> RemoveInCollisionGoalsTestFixture::factory_ = nullptr;
-std::shared_ptr<BT::Tree> RemoveInCollisionGoalsTestFixture::tree_ = nullptr;
-
-TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_success)
+TEST(RemoveInCollisionGoalsTest, test_tick_remove_in_collision_goals_success)
 {
   // create tree
   std::string xml_txt =
@@ -144,7 +129,7 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_su
         </BehaviorTree>
       </root>)";
 
-  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+  BT::Tree tree_ = test_env->factory_->createTreeFromText(xml_txt, test_env->config_->blackboard);
 
   // create new goal and set it on blackboard
   geometry_msgs::msg::PoseStampedArray poses;
@@ -161,18 +146,18 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_su
   poses.poses[3].pose.position.x = 2.0;
   poses.poses[3].pose.position.y = 0.0;
 
-  config_->blackboard->set("goals", poses);
+  test_env->config_->blackboard->set("goals", poses);
 
   // tick until node is not running
-  tree_->rootNode()->executeTick();
-  while (tree_->rootNode()->status() == BT::NodeStatus::RUNNING) {
-    tree_->rootNode()->executeTick();
+  tree_.rootNode()->executeTick();
+  while (tree_.rootNode()->status() == BT::NodeStatus::RUNNING) {
+    tree_.rootNode()->executeTick();
   }
 
-  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree_.rootNode()->status(), BT::NodeStatus::SUCCESS);
   // check that it removed the point in range
   geometry_msgs::msg::PoseStampedArray output_poses;
-  EXPECT_TRUE(config_->blackboard->get("goals", output_poses));
+  EXPECT_TRUE(test_env->config_->blackboard->get("goals", output_poses));
 
   EXPECT_EQ(output_poses.poses.size(), 3u);
   EXPECT_EQ(output_poses.poses[0], poses.poses[0]);
@@ -180,7 +165,7 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_su
   EXPECT_EQ(output_poses.poses[2], poses.poses[2]);
 }
 
-TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fail)
+TEST(RemoveInCollisionGoalsTest, test_tick_remove_in_collision_goals_fail)
 {
   // create tree
   std::string xml_txt =
@@ -191,7 +176,7 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fa
         </BehaviorTree>
       </root>)";
 
-  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+  BT::Tree tree_ = test_env->factory_->createTreeFromText(xml_txt, test_env->config_->blackboard);
 
   // create new goal and set it on blackboard
   geometry_msgs::msg::PoseStampedArray poses;
@@ -208,18 +193,18 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fa
   poses.poses[3].pose.position.x = 2.0;
   poses.poses[3].pose.position.y = 0.0;
 
-  config_->blackboard->set("goals", poses);
+  test_env->config_->blackboard->set("goals", poses);
 
   // tick until node is not running
-  tree_->rootNode()->executeTick();
-  while (tree_->rootNode()->status() == BT::NodeStatus::RUNNING) {
-    tree_->rootNode()->executeTick();
+  tree_.rootNode()->executeTick();
+  while (tree_.rootNode()->status() == BT::NodeStatus::RUNNING) {
+    tree_.rootNode()->executeTick();
   }
 
   // check that it failed and returned the original goals
-  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree_.rootNode()->status(), BT::NodeStatus::FAILURE);
   geometry_msgs::msg::PoseStampedArray output_poses;
-  EXPECT_TRUE(config_->blackboard->get("goals", output_poses));
+  EXPECT_TRUE(test_env->config_->blackboard->get("goals", output_poses));
 
   EXPECT_EQ(output_poses.poses.size(), 4u);
   EXPECT_EQ(output_poses.poses[0], poses.poses[0]);
@@ -235,25 +220,41 @@ int main(int argc, char ** argv)
   // initialize ROS
   rclcpp::init(argc, argv);
 
+  // initialize test environment
+  test_env = new BTTestEnv();
+
+  // stop signal
+  std::atomic_bool stop_thread(false);
+
   // initialize service and spin on new thread
-  RemoveInCollisionGoalsTestFixture::success_server_ =
+  test_env->success_server_ =
     std::make_shared<RemoveInCollisionGoalsSuccessService>();
-  std::thread success_server_thread([]() {
-      rclcpp::spin(RemoveInCollisionGoalsTestFixture::success_server_);
+  std::thread success_server_thread([&stop_thread]() {
+      while (!stop_thread.load()) {
+        rclcpp::spin_some(test_env->success_server_);
+      }
     });
 
-  RemoveInCollisionGoalsTestFixture::failure_server_ =
+  test_env->failure_server_ =
     std::make_shared<RemoveInCollisionGoalsFailureService>();
-  std::thread failure_server_thread([]() {
-      rclcpp::spin(RemoveInCollisionGoalsTestFixture::failure_server_);
+  std::thread failure_server_thread([&stop_thread]() {
+      while (!stop_thread.load()) {
+        rclcpp::spin_some(test_env->failure_server_);
+      }
     });
 
   int all_successful = RUN_ALL_TESTS();
 
-  // shutdown ROS
-  rclcpp::shutdown();
+  // stop the threads
+  stop_thread.store(true);
   success_server_thread.join();
   failure_server_thread.join();
+
+  // clean the test environment
+  delete test_env;
+
+  // shutdown ROS
+  rclcpp::shutdown();
 
   return all_successful;
 }

--- a/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
@@ -106,6 +106,7 @@ public:
     config_ = nullptr;
     node_.reset();
     success_server_.reset();
+    failure_server_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/test_bt_utils.cpp
+++ b/nav2_behavior_tree/test/test_bt_utils.cpp
@@ -470,4 +470,6 @@ TEST(deconflictPortAndParamFrameTest, test_correct_syntax)
     node, "test", tree.rootNode());
 
   EXPECT_EQ(value, 1);
+
+  rclcpp::shutdown();
 }

--- a/nav2_collision_monitor/test/kinematics_test.cpp
+++ b/nav2_collision_monitor/test/kinematics_test.cpp
@@ -29,14 +29,6 @@ using namespace std::chrono_literals;
 
 static constexpr double EPSILON = std::numeric_limits<float>::epsilon();
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(KinematicsTest, testTransformPoints)
 {
   // Transform: move frame to (2.0, 1.0) coordinate and rotate it on 30 degrees
@@ -95,4 +87,17 @@ TEST(KinematicsTest, testProjectState)
   EXPECT_NEAR(vel.x, std::cos(rotated_vel_angle), EPSILON);
   EXPECT_NEAR(vel.y, std::sin(rotated_vel_angle), EPSILON);
   EXPECT_NEAR(vel.tw, M_PI / 4.0, EPSILON);  // should be the same
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_controller/plugins/test/goal_checker.cpp
+++ b/nav2_controller/plugins/test/goal_checker.cpp
@@ -239,7 +239,13 @@ TEST(StoppedGoalChecker, get_tol_and_dynamic_params)
 
 int main(int argc, char ** argv)
 {
+  ::testing::InitGoogleTest(&argc, argv);
+
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_controller/plugins/test/progress_checker.cpp
+++ b/nav2_controller/plugins/test/progress_checker.cpp
@@ -238,7 +238,13 @@ TEST(PoseProgressChecker, unit_tests)
 
 int main(int argc, char ** argv)
 {
+  ::testing::InitGoogleTest(&argc, argv);
+
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_controller/test/test_dynamic_parameters.cpp
+++ b/nav2_controller/test/test_dynamic_parameters.cpp
@@ -51,14 +51,6 @@ public:
   }
 };
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(WPTest, test_dynamic_parameters)
 {
   auto controller = std::make_shared<ControllerShim>();
@@ -85,4 +77,17 @@ TEST(WPTest, test_dynamic_parameters)
   EXPECT_EQ(controller->get_parameter("min_y_velocity_threshold").as_double(), 100.0);
   EXPECT_EQ(controller->get_parameter("min_theta_velocity_threshold").as_double(), 100.0);
   EXPECT_EQ(controller->get_parameter("failure_tolerance").as_double(), 5.0);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
+++ b/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
@@ -21,14 +21,6 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class DynParamTestNode
 {
 public:
@@ -104,4 +96,17 @@ TEST(DynParamTestNode, testDynParamsSet)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/footprint_tests.cpp
+++ b/nav2_costmap_2d/test/integration/footprint_tests.cpp
@@ -44,14 +44,6 @@
 #include "tf2_ros/transform_listener.h"
 #include "nav2_costmap_2d/footprint.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class FootprintTestNode
 {
 public:
@@ -201,4 +193,17 @@ TEST_F(TestNode, footprint_from_same_level_param)
   EXPECT_EQ(5.0f, footprint[2].x);
   EXPECT_EQ(6.0f, footprint[2].y);
   EXPECT_EQ(0.0f, footprint[2].z);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -51,14 +51,6 @@
 using geometry_msgs::msg::Point;
 using nav2_costmap_2d::CellData;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestNode : public ::testing::Test
 {
 public:
@@ -638,4 +630,17 @@ TEST_F(TestNode, testDynParamsSet)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -52,14 +52,6 @@ using std::none_of;
 using std::pair;
 using std::string;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestLifecycleNode : public nav2_util::LifecycleNode
 {
 public:
@@ -624,4 +616,17 @@ TEST_F(TestNodeWithoutUnknownOverwrite, testMaxWithoutUnknownOverwriteCombinatio
   int unknown_count = countValues(*(layers.getCostmap()), nav2_costmap_2d::NO_INFORMATION);
 
   ASSERT_EQ(unknown_count, 100);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
+++ b/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
@@ -33,14 +33,6 @@ using std::none_of;
 using std::pair;
 using std::string;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestLifecycleNode : public nav2_util::LifecycleNode
 {
 public:
@@ -685,4 +677,17 @@ TEST_F(TestNode, testDynParamsSetPluginContainerLayer)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/range_tests.cpp
+++ b/nav2_costmap_2d/test/integration/range_tests.cpp
@@ -53,22 +53,6 @@ using std::none_of;
 using std::pair;
 using std::string;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture()
-  {
-    rclcpp::init(0, nullptr);
-  }
-
-  ~RclCppFixture()
-  {
-    rclcpp::shutdown();
-  }
-};
-
-RclCppFixture g_rclcppfixture;
-
 class TestLifecycleNode : public nav2_util::LifecycleNode
 {
 public:
@@ -291,4 +275,17 @@ TEST_F(TestNode, testProbabilisticModelDownward) {
   ASSERT_EQ(layers.getCostmap()->getCost(3, 5), 254);
   ASSERT_EQ(layers.getCostmap()->getCost(3, 6), 0);
   ASSERT_EQ(layers.getCostmap()->getCost(3, 7), 254);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
@@ -22,14 +22,6 @@
 #include "tf2_ros/transform_listener.h"
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class CostmapRosLifecycleNode : public nav2_util::LifecycleNode
 {
 public:
@@ -177,4 +169,17 @@ TEST_F(CostmapRosTestFixture, costmap_pub_test)
   }
 
   SUCCEED();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
@@ -18,13 +18,6 @@
 #include "nav2_costmap_2d/costmap_2d_publisher.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 class TestCostmapSubscriberShould : public ::testing::Test
 {
 public:
@@ -195,4 +188,17 @@ TEST_F(
   throwExceptionIfGetCostmapMethodIsCalledBeforeAnyCostmapMsgReceived)
 {
   ASSERT_ANY_THROW(costmapSubscriber->getCostmap());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
@@ -43,14 +43,6 @@ using namespace std::chrono_literals;
 using namespace std::placeholders;
 using nav2_util::geometry_utils::orientationAroundZAxis;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class DummyCostmapSubscriber : public nav2_costmap_2d::CostmapSubscriber
 {
 public:
@@ -361,4 +353,17 @@ TEST_F(TestNode, CollisionSpace)
 
   // Partially in obstacle
   ASSERT_EQ(collision_checker_->testPose(4.5, 4.5, 0), false);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/regression/plugin_api_order.cpp
+++ b/nav2_costmap_2d/test/regression/plugin_api_order.cpp
@@ -47,7 +47,13 @@ TEST(CostmapPluginsTester, checkPluginAPIOrder)
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/unit/copy_window_test.cpp
+++ b/nav2_costmap_2d/test/unit/copy_window_test.cpp
@@ -17,14 +17,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(CopyWindow, copyValidWindow)
 {
   nav2_costmap_2d::Costmap2D src(10, 10, 0.1, 0.0, 0.0);
@@ -49,4 +41,17 @@ TEST(CopyWindow, copyInvalidWindow)
   // Case2: incorrect destination bounds
   ASSERT_FALSE(dst.copyWindow(src, 0, 0, 1, 1, 5, 5));
   ASSERT_FALSE(dst.copyWindow(src, 0, 0, 6, 6, 0, 0));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/unit/costmap_conversion_test.cpp
+++ b/nav2_costmap_2d/test/unit/costmap_conversion_test.cpp
@@ -25,14 +25,6 @@
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 static constexpr double EPSILON = std::numeric_limits<float>::epsilon();
 static constexpr double RESOLUTION = 0.05;
 static constexpr double ORIGIN_X = 0.1;
@@ -119,4 +111,17 @@ TEST_F(TestNode, convertOccGridToCostmap)
 {
   createMaps();
   verifyCostmap();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/unit/costmap_cost_service_test.cpp
+++ b/nav2_costmap_2d/test/unit/costmap_cost_service_test.cpp
@@ -21,14 +21,6 @@
 #include "nav2_msgs/srv/get_costs.hpp"
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 using namespace std::chrono_literals;
 
 class GetCostServiceTest : public ::testing::Test
@@ -92,4 +84,17 @@ TEST_F(GetCostServiceTest, TestWithFootprint)
   } else {
     FAIL() << "Failed to call service";
   }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
+++ b/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
@@ -20,14 +20,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/layer.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class LayerWrapper : public nav2_costmap_2d::Layer
 {
   void reset() {}
@@ -72,4 +64,17 @@ TEST(DeclareParameter, useInvalidParameter)
   } catch (rclcpp::exceptions::ParameterUninitializedException & ex) {
     SUCCEED();
   }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_costmap_2d/test/unit/denoise_layer_test.cpp
+++ b/nav2_costmap_2d/test/unit/denoise_layer_test.cpp
@@ -452,15 +452,6 @@ TEST_F(DenoiseLayerTester, updateCosts) {
   ASSERT_EQ(costmap.getCost(0), FREE_SPACE);
 }
 
-// Copy paste from declare_parameter_test.cpp
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture rcl_cpp_fixture;
-
 std::shared_ptr<nav2_costmap_2d::DenoiseLayer> constructLayer(
   std::shared_ptr<nav2_util::LifecycleNode> node =
   std::make_shared<nav2_util::LifecycleNode>("test_node"))
@@ -516,4 +507,17 @@ TEST_F(DenoiseLayerTester, initializeInvalid) {
   ASSERT_EQ(
     DenoiseLayerTester::getParameters(*layer),
     std::make_tuple(true, ConnectivityType::Way8, 1));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_docking/opennav_docking/test/test_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_controller.cpp
@@ -27,14 +27,6 @@
 // Testing the controller at high level; the nav2_graceful_controller
 // Where the control law derives has over 98% test coverage
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -547,3 +539,16 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
 
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_dock_database.cpp
+++ b/nav2_docking/opennav_docking/test/test_dock_database.cpp
@@ -22,14 +22,6 @@
 // Integration tests handle coverage more fully than the database lookups and population.
 // However, Utils unit tests already validate the key database population functions.
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace std::chrono_literals;
 
 namespace opennav_docking
@@ -137,3 +129,16 @@ TEST(DatabaseTests, reloadDbService)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -25,14 +25,6 @@
 
 using namespace std::chrono_literals;  // NOLINT
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -272,3 +264,16 @@ TEST(DockingServerTests, testDynamicParams)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_navigator.cpp
+++ b/nav2_docking/opennav_docking/test/test_navigator.cpp
@@ -22,14 +22,6 @@
 
 // Test navigator
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -137,3 +129,16 @@ TEST(NavigatorTests, TestNavigator)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
@@ -24,14 +24,6 @@
 
 // Testing the simple charging dock plugin
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -243,3 +235,16 @@ TEST(SimpleChargingDockTests, RefinedPoseTest)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
@@ -24,14 +24,6 @@
 
 // Testing the simple non-charging dock plugin
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -203,3 +195,16 @@ TEST(SimpleNonChargingDockTests, RefinedPoseTest)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_docking/opennav_docking/test/test_utils.cpp
+++ b/nav2_docking/opennav_docking/test/test_utils.cpp
@@ -19,14 +19,6 @@
 
 // Test parsing dock plugins and database files (see test_dock_file.yaml).
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_docking
 {
 
@@ -144,3 +136,16 @@ TEST(UtilsTests, testl2Norm)
 }
 
 }  // namespace opennav_docking
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_dwb_controller/dwb_core/test/utils_test.cpp
+++ b/nav2_dwb_controller/dwb_core/test/utils_test.cpp
@@ -108,7 +108,13 @@ TEST(Utils, ProjectPose)
 
 int main(int argc, char ** argv)
 {
+  ::testing::InitGoogleTest(&argc, argv);
+
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_map_server/test/component/test_map_saver_node.cpp
+++ b/nav2_map_server/test/component/test_map_saver_node.cpp
@@ -33,15 +33,6 @@ using std::filesystem::path;
 using lifecycle_msgs::msg::Transition;
 using namespace nav2_map_server;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-
-RclCppFixture g_rclcppfixture;
-
 class MapSaverTestFixture : public ::testing::Test
 {
 public:
@@ -219,4 +210,17 @@ TEST_F(MapSaverTestFixture, SaveMapInvalidParameters)
   req->occupied_thresh = 0.2;
   resp = send_request<nav2_msgs::srv::SaveMap>(node_, client, req);
   ASSERT_EQ(resp->result, false);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_map_server/test/component/test_map_server_node.cpp
+++ b/nav2_map_server/test/component/test_map_server_node.cpp
@@ -33,15 +33,6 @@ using std::filesystem::path;
 
 using lifecycle_msgs::msg::Transition;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-
-RclCppFixture g_rclcppfixture;
-
 class MapServerTestFixture : public ::testing::Test
 {
 public:
@@ -234,4 +225,17 @@ TEST_F(MapServerTestFixture, NoInitialMap)
 
   ASSERT_EQ(load_res->result, nav2_msgs::srv::LoadMap::Response::RESULT_SUCCESS);
   verifyMapMsg(load_res->map);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_map_server/test/map_saver_cli/test_map_saver_cli.cpp
+++ b/nav2_map_server/test/map_saver_cli/test_map_saver_cli.cpp
@@ -143,4 +143,6 @@ TEST(MapSaverCLI, CLITest)
     "ros2 run nav2_map_server map_saver_cli --ros-args --remap __node:=map_saver_test_node");
   return_code = system(command.c_str());
   EXPECT_EQ(return_code, 0);
+
+  rclcpp::shutdown();
 }

--- a/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
+++ b/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
@@ -36,14 +36,6 @@ static const double MULTIPLIER = 0.2;
 
 static const double EPSILON = std::numeric_limits<float>::epsilon();
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class InfoServerWrapper : public nav2_map_server::CostmapFilterInfoServer
 {
 public:
@@ -174,4 +166,17 @@ TEST_F(InfoServerTester, testCostmapFilterInfoDeactivateActivate)
   EXPECT_EQ(info_->filter_mask_topic, MASK_TOPIC);
   EXPECT_NEAR(info_->base, BASE, EPSILON);
   EXPECT_NEAR(info_->multiplier, MULTIPLIER, EPSILON);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_map_server/test/unit/test_map_io.cpp
+++ b/nav2_map_server/test/unit/test_map_io.cpp
@@ -52,15 +52,6 @@ using namespace std;  // NOLINT
 using namespace nav2_map_server;  // NOLINT
 using std::filesystem::path;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-
-RclCppFixture g_rclcppfixture;
-
 class MapIOTester : public ::testing::Test
 {
 protected:
@@ -337,4 +328,17 @@ TEST(HomeUserExpanderTestSuite, homeUserExpanderShouldExpandHomeSequenceWhenHome
   const std::string fileName{"~/valid_file.yaml"};
   const std::string expectedOutputFileName{"/home/user/valid_file.yaml"};
   ASSERT_EQ(expectedOutputFileName, expand_user_home_dir_if_needed(fileName, "/home/user"));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/controller_state_transition_test.cpp
+++ b/nav2_mppi_controller/test/controller_state_transition_test.cpp
@@ -24,14 +24,6 @@
 
 #include "utils/utils.hpp"
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 // Tests basic transition from configure->active->process->deactivate->cleanup
 
 TEST(ControllerStateTransitionTest, ControllerNotFail)
@@ -72,4 +64,17 @@ TEST(ControllerStateTransitionTest, ControllerNotFail)
   controller->setSpeedLimit(1.0, true);
   controller->deactivate();
   controller->cleanup();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -21,14 +21,6 @@
 
 // Tests critic manager
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 using namespace mppi::critics;  // NOLINT
 
@@ -150,4 +142,17 @@ TEST(CriticManagerTests, CriticLoadingTest)
   CriticManagerWrapperEnum critic_manager;
   critic_manager.on_configure(node, "critic_manager", costmap_ros, &param_handler);
   EXPECT_EQ(critic_manager.getCriticNum(), 2u);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/models_test.cpp
+++ b/nav2_mppi_controller/test/models_test.cpp
@@ -21,14 +21,6 @@
 
 // Tests model classes with methods
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi::models;  // NOLINT
 
 TEST(ModelsTest, ControlSequenceTest)
@@ -146,4 +138,17 @@ TEST(ModelsTest, TrajectoriesTest)
   EXPECT_EQ(trajectories.x.cols(), 40);
   EXPECT_EQ(trajectories.y.cols(), 40);
   EXPECT_EQ(trajectories.yaws.cols(), 40);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -24,14 +24,6 @@
 
 // Tests motion models
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 
 TEST(MotionModelTests, DiffDriveTest)
@@ -255,4 +247,17 @@ TEST(MotionModelTests, AckermannReversingTest)
 
   // Check it cleanly destructs
   model.reset();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -26,14 +26,6 @@
 
 // Tests noise generator object
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 
 TEST(NoiseGeneratorTest, NoiseGeneratorLifecycle)
@@ -128,4 +120,17 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   EXPECT_NEAR(state.cwz(0, 9), 9, 0.3);
 
   generator.shutdown();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/optimizer_smoke_test.cpp
+++ b/nav2_mppi_controller/test/optimizer_smoke_test.cpp
@@ -28,14 +28,6 @@
 
 #include "utils/utils.hpp"
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 // Smoke tests the optimizer
 
 class OptimizerSuite : public ::testing::TestWithParam<std::tuple<std::string,
@@ -110,3 +102,16 @@ INSTANTIATE_TEST_SUITE_P(
           {"PathAngleCritic"}, {"PathFollowCritic"}, {"PreferForwardCritic"}}),
       true))
 );
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -21,14 +21,6 @@
 
 // Tests main optimizer functions
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 using namespace mppi::critics;  // NOLINT
 using namespace mppi::utils;  // NOLINT
@@ -652,4 +644,17 @@ TEST(OptimizerTests, integrateStateVelocitiesTests)
     EXPECT_NEAR(traj.x(1, i), x, 1e-6);
     EXPECT_NEAR(traj.y(1, i), y, 1e-6);
   }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/parameter_handler_test.cpp
+++ b/nav2_mppi_controller/test/parameter_handler_test.cpp
@@ -21,15 +21,6 @@
 
 // Tests parameter handler object
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 
 class ParametersHandlerWrapper : public ParametersHandler
@@ -285,4 +276,17 @@ TEST(ParameterHandlerTest, DynamicAndStaticParametersNotDeclaredTest)
   // The ParameterNotDeclaredException handler in rclcpp/parameter_service.cpp
   // overrides any other reasons and does not provide details to the service client.
   EXPECT_EQ(result.reason, std::string("One or more parameters were not declared before setting"));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/path_handler_test.cpp
+++ b/nav2_mppi_controller/test/path_handler_test.cpp
@@ -22,14 +22,6 @@
 
 // Tests path handling
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 
 class PathHandlerWrapper : public PathHandler
@@ -246,4 +238,17 @@ TEST(PathHandlerTests, TestInversionToleranceChecks)
   // Offset spatially + off angled but both within tolerances
   robot_pose.pose.position.x = 9.10;
   EXPECT_TRUE(handler.isWithinInversionTolerancesWrapper(robot_pose));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
+++ b/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
@@ -21,14 +21,6 @@
 
 // Tests trajectory visualization
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi;  // NOLINT
 
 TEST(TrajectoryVisualizerTests, StateTransition)
@@ -215,4 +207,17 @@ TEST(TrajectoryVisualizerTests, VisOptimalPath)
     EXPECT_EQ(received_path.poses[i].pose.orientation.z, expected_orientation.z);
     EXPECT_EQ(received_path.poses[i].pose.orientation.w, expected_orientation.w);
   }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -23,14 +23,6 @@
 
 // Tests noise generator object
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 using namespace mppi::utils;  // NOLINT
 using namespace mppi;  // NOLINT
 
@@ -575,4 +567,17 @@ TEST(UtilsTests, NormalizeYawsBetweenPointsTest)
   yaws_between_points_corrected = utils::normalize_yaws_between_points(goal_angle,
     yaw_between_points);
   EXPECT_NEAR(yaws_between_points_corrected[1], -0.8 * M_PIF_2, 1e-3);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_navfn_planner/test/test_dynamic_parameters.cpp
+++ b/nav2_navfn_planner/test/test_dynamic_parameters.cpp
@@ -23,14 +23,6 @@
 #include "nav2_navfn_planner/navfn_planner.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(NavfnTest, testDynamicParameter)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("Navfntest");
@@ -61,4 +53,17 @@ TEST(NavfnTest, testDynamicParameter)
   EXPECT_EQ(node->get_parameter("test.use_astar").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.allow_unknown").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.use_final_approach_orientation").as_bool(), true);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_planner/test/test_dynamic_parameters.cpp
+++ b/nav2_planner/test/test_dynamic_parameters.cpp
@@ -51,14 +51,6 @@ public:
   }
 };
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(WPTest, test_dynamic_parameters)
 {
   auto planner = std::make_shared<PlannerShim>();
@@ -87,4 +79,17 @@ TEST(WPTest, test_dynamic_parameters)
     results);
 
   EXPECT_EQ(planner->get_parameter("expected_planner_frequency").as_double(), -1.0);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -27,14 +27,6 @@
 #include "nav2_costmap_2d/costmap_filters/filter_values.hpp"
 #include "nav2_core/controller_exceptions.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class BasicAPIRPP : public nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
 {
 public:
@@ -1122,4 +1114,17 @@ TEST_F(TransformGlobalPlanTest, prune_after_leaving_costmap)
   EXPECT_NEAR(transformed_plan.poses.size(), 10u, 1);
   EXPECT_NEAR(transformed_plan.poses[0].pose.position.x, 0.0, 0.5);
   EXPECT_NEAR(transformed_plan.poses[0].pose.position.y, 0.0, 0.5);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_rotation_shim_controller/test/test_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/test/test_shim_controller.cpp
@@ -26,14 +26,6 @@
 #include "nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class RotationShimShim : public nav2_rotation_shim_controller::RotationShimController
 {
 public:
@@ -643,4 +635,17 @@ TEST(RotationShimControllerTest, testDynamicParameter)
   EXPECT_EQ(node->get_parameter("test.rotate_to_goal_heading").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.rotate_to_heading_once").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.closed_loop").as_bool(), false);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -29,14 +29,6 @@
 #include "nav2_smac_planner/collision_checker.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(AStarTest, test_a_star_2d)
 {
   auto lnode = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
@@ -433,4 +425,17 @@ TEST(AStarTest, test_constants)
     nav2_smac_planner::fromString(
       "REEDS_SHEPP"), nav2_smac_planner::MotionModel::REEDS_SHEPP);
   EXPECT_EQ(nav2_smac_planner::fromString("NONE"), nav2_smac_planner::MotionModel::UNKNOWN);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_collision_checker.cpp
+++ b/nav2_smac_planner/test/test_collision_checker.cpp
@@ -22,14 +22,6 @@
 
 using namespace nav2_costmap_2d;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(collision_footprint, test_basic)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("testA");
@@ -221,4 +213,17 @@ TEST(collision_footprint, test_point_and_line_cost)
   EXPECT_NEAR(other_value, 254.0, 0.001);  // center cost
 
   delete costmap_;
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_costmap_downsampler.cpp
+++ b/nav2_smac_planner/test/test_costmap_downsampler.cpp
@@ -21,14 +21,6 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_smac_planner/costmap_downsampler.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(CostmapDownsampler, costmap_downsample_test)
 {
   nav2_util::LifecycleNode::SharedPtr node = std::make_shared<nav2_util::LifecycleNode>(
@@ -64,4 +56,17 @@ TEST(CostmapDownsampler, costmap_downsample_test)
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsY(), 1u);
 
   downsampler.resizeCostmap();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_node2d.cpp
+++ b/nav2_smac_planner/test/test_node2d.cpp
@@ -24,14 +24,6 @@
 #include "nav2_smac_planner/node_2d.hpp"
 #include "nav2_smac_planner/collision_checker.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(Node2DTest, test_node_2d)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
@@ -154,4 +146,17 @@ TEST(Node2DTest, test_node_2d_neighbors)
 
   // should be empty since totally invalid
   EXPECT_EQ(neighbors.size(), 0u);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_nodebasic.cpp
+++ b/nav2_smac_planner/test/test_nodebasic.cpp
@@ -25,14 +25,6 @@
 #include "nav2_smac_planner/node_lattice.hpp"
 #include "nav2_smac_planner/collision_checker.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(NodeBasicTest, test_node_basic)
 {
   nav2_smac_planner::NodeBasic<nav2_smac_planner::NodeHybrid> node(50);
@@ -49,4 +41,17 @@ TEST(NodeBasicTest, test_node_basic)
 
   EXPECT_EQ(node3.index, 200u);
   EXPECT_EQ(node3.graph_node_ptr, nullptr);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -27,14 +27,6 @@
 #include "nav2_smac_planner/collision_checker.hpp"
 #include "nav2_smac_planner/types.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(NodeHybridTest, test_node_hybrid)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
@@ -417,4 +409,17 @@ TEST(NodeHybridTest, basic_get_closest_angular_bin_test)
     unsigned int calculated_angular_bin = motion_table.getClosestAngularBin(test_theta);
     EXPECT_EQ(expected_angular_bin, calculated_angular_bin);
   }
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_nodelattice.cpp
+++ b/nav2_smac_planner/test/test_nodelattice.cpp
@@ -26,14 +26,6 @@
 
 using json = nlohmann::json;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(NodeLatticeTest, parser_test)
 {
   std::string pkg_share_dir = ament_index_cpp::get_package_share_directory("nav2_smac_planner");
@@ -394,4 +386,17 @@ TEST(NodeLatticeTest, test_node_lattice_custom_footprint)
   }
 
   delete costmap;
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_smac_2d.cpp
+++ b/nav2_smac_planner/test/test_smac_2d.cpp
@@ -30,14 +30,6 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 // SMAC smoke tests for plugin-level issues rather than algorithms
 // (covered by more extensively testing in other files)
 // System tests in nav2_system_tests will actually plan with this work
@@ -149,4 +141,17 @@ TEST(SmacTest, test_smac_2d_reconfigure) {
   rclcpp::spin_until_future_complete(
     node2D->get_node_base_interface(),
     results);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -29,14 +29,6 @@
 #include "nav2_smac_planner/smac_planner_hybrid.hpp"
 #include "nav2_smac_planner/smac_planner_2d.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 // SMAC smoke tests for plugin-level issues rather than algorithms
 // (covered by more extensively testing in other files)
 // System tests in nav2_system_tests will actually plan with this work
@@ -169,4 +161,17 @@ TEST(SmacTest, test_smac_se2_reconfigure)
     nodeSE2->get_node_base_interface(),
     results2);
   EXPECT_EQ(nodeSE2->get_parameter("resolution").as_double(), 0.2);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -28,14 +28,6 @@
 #include "nav2_smac_planner/collision_checker.hpp"
 #include "nav2_smac_planner/smac_planner_lattice.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 // Simple wrapper to be able to call a private member
 class LatticeWrap : public nav2_smac_planner::SmacPlannerLattice
 {
@@ -156,4 +148,17 @@ TEST(SmacTest, test_smac_lattice_reconfigure)
   std::vector<rclcpp::Parameter> parameters;
   parameters.push_back(rclcpp::Parameter("test.lattice_filepath", std::string("HI")));
   EXPECT_THROW(planner->callDynamicParams(parameters), std::runtime_error);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -31,14 +31,6 @@
 
 using namespace nav2_smac_planner;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class SmootherWrapper : public nav2_smac_planner::Smoother
 {
 public:
@@ -190,4 +182,17 @@ TEST(SmootherTest, test_full_smoother)
 
   delete costmap;
   nav2_smac_planner::NodeHybrid::destroyStaticAssets();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smoother/test/test_savitzky_golay_smoother.cpp
+++ b/nav2_smoother/test/test_savitzky_golay_smoother.cpp
@@ -34,14 +34,6 @@ using namespace smoother_utils;  // NOLINT
 using namespace nav2_smoother;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(SmootherTest, test_sg_smoother_basics)
 {
   rclcpp_lifecycle::LifecycleNode::SharedPtr node =
@@ -326,4 +318,17 @@ TEST(SmootherTest, test_sg_smoother_reversing)
   }
 
   EXPECT_LT(length, base_length);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_smoother/test/test_simple_smoother.cpp
+++ b/nav2_smoother/test/test_simple_smoother.cpp
@@ -28,14 +28,6 @@ using namespace smoother_utils;  // NOLINT
 using namespace nav2_smoother;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class SmootherWrapper : public nav2_smoother::SimpleSmoother
 {
 public:
@@ -284,4 +276,17 @@ TEST(SmootherTest, test_simple_smoother)
   max_its_path.poses[10].pose.position.x = 0.5;
   max_its_path.poses[10].pose.position.y = 1.0;
   EXPECT_TRUE(smoother->smooth(max_its_path, max_time));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -19,13 +19,6 @@
 #include "nav2_theta_star_planner/theta_star.hpp"
 #include "nav2_theta_star_planner/theta_star_planner.hpp"
 
-class init_rclcpp
-{
-public:
-  init_rclcpp() {rclcpp::init(0, nullptr);}
-  ~init_rclcpp() {rclcpp::shutdown();}
-};
-
 /// class created to access the protected members of the ThetaStar class
 /// u is used as shorthand for use
 class test_theta_star : public theta_star::ThetaStar
@@ -70,8 +63,6 @@ public:
     return false;
   }
 };
-
-init_rclcpp node;
 
 // Tests meant to test the algorithm itself and its helper functions
 TEST(ThetaStarTest, test_theta_star) {
@@ -237,4 +228,17 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
   rclcpp::spin_until_future_complete(
     life_node->get_node_base_interface(),
     results);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_util/test/test_base_footprint_publisher.cpp
+++ b/nav2_util/test/test_base_footprint_publisher.cpp
@@ -19,14 +19,6 @@
 #include "gtest/gtest.h"
 #include "tf2/exceptions.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
 {
   auto node = std::make_shared<nav2_util::BaseFootprintPublisher>();
@@ -69,4 +61,17 @@ TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
   EXPECT_EQ(t.transform.translation.x, 1.0);
   EXPECT_EQ(t.transform.translation.y, 1.0);
   EXPECT_EQ(t.transform.translation.z, 0.0);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_util/test/test_lifecycle_cli_node.cpp
+++ b/nav2_util/test/test_lifecycle_cli_node.cpp
@@ -63,22 +63,6 @@ public:
   std::shared_ptr<DummyNode> node;
 };
 
-class RclCppFixture
-{
-public:
-  RclCppFixture()
-  {
-    rclcpp::init(0, nullptr);
-  }
-
-  ~RclCppFixture()
-  {
-    rclcpp::shutdown();
-  }
-};
-
-RclCppFixture g_rclcppfixture;
-
 TEST(LifecycleCLI, fails_no_node_name)
 {
   Handle handle;
@@ -107,6 +91,19 @@ TEST(LifecycleCLI, succeeds_node_name)
   (void)rc;
   EXPECT_EQ(handle.node->activated, true);
   SUCCEED();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }
 
 #endif  // NAV2_UTIL__TEST__TEST_LIFECYCLE_CLI_NODE_HPP_

--- a/nav2_util/test/test_lifecycle_utils.cpp
+++ b/nav2_util/test/test_lifecycle_utils.cpp
@@ -23,14 +23,6 @@
 using nav2_util::startup_lifecycle_nodes;
 using nav2_util::reset_lifecycle_nodes;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 void SpinNodesUntilDone(
   std::vector<rclcpp_lifecycle::LifecycleNode::SharedPtr> nodes,
   std::atomic<bool> * test_done)
@@ -57,4 +49,17 @@ TEST(Lifecycle, interface)
   done = true;
   node_thread.join();
   SUCCEED();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -27,14 +27,6 @@ using nav2_util::time_to_string;
 using nav2_util::declare_parameter_if_not_declared;
 using nav2_util::get_plugin_type_param;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(SanitizeNodeName, SanitizeNodeName)
 {
   ASSERT_EQ(sanitize_node_name("bar"), "bar");
@@ -93,4 +85,17 @@ TEST(GetPluginTypeParam, GetPluginTypeParam)
   node->declare_parameter("Foo.plugin", "bar");
   ASSERT_EQ(get_plugin_type_param(node, "Foo"), "bar");
   EXPECT_THROW(get_plugin_type_param(node, "Waldo"), std::runtime_error);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_util/test/test_odometry_utils.cpp
+++ b/nav2_util/test/test_odometry_utils.cpp
@@ -24,14 +24,6 @@
 using namespace std::chrono;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(OdometryUtils, test_uninitialized)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
@@ -157,4 +149,17 @@ TEST(OdometryUtils, test_smoothed_velocity)
   EXPECT_EQ(twist_raw_msg.linear.x, 5.0);
   EXPECT_EQ(twist_raw_msg.linear.y, 5.0);
   EXPECT_EQ(twist_raw_msg.angular.z, 5.0);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -32,6 +32,7 @@ TEST(RobotUtils, LookupExceptionError)
   ASSERT_FALSE(nav2_util::getCurrentPose(global_pose, tf, "map", "base_link", 0.1));
   global_pose.header.frame_id = "base_link";
   ASSERT_FALSE(nav2_util::transformPoseInTargetFrame(global_pose, global_pose, tf, "map", 0.1));
+  rclcpp::shutdown();
 }
 
 TEST(RobotUtils, validateTwist)

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -27,14 +27,6 @@
 
 using namespace std::chrono_literals;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class VelSmootherShim : public nav2_velocity_smoother::VelocitySmoother
 {
 public:
@@ -714,4 +706,17 @@ TEST(VelocitySmootherTest, testDynamicParameter)
   smoother->cleanup(state);
   smoother->shutdown(state);
   smoother.reset();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_waypoint_follower/test/test_dynamic_parameters.cpp
+++ b/nav2_waypoint_follower/test/test_dynamic_parameters.cpp
@@ -56,14 +56,6 @@ public:
   }
 };
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(WPTest, test_dynamic_parameters)
 {
   auto follower = std::make_shared<WPShim>();
@@ -88,4 +80,17 @@ TEST(WPTest, test_dynamic_parameters)
   follower->deactivate();
   follower->cleanup();
   follower.reset();
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }

--- a/nav2_waypoint_follower/test/test_task_executors.cpp
+++ b/nav2_waypoint_follower/test/test_task_executors.cpp
@@ -27,15 +27,6 @@
 #include "nav2_waypoint_follower/plugins/wait_at_waypoint.hpp"
 #include "nav2_waypoint_follower/plugins/input_at_waypoint.hpp"
 
-
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(WaypointFollowerTest, WaitAtWaypoint)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("testWaypointNode");
@@ -161,4 +152,17 @@ TEST(WaypointFollowerTest, PhotoAtWaypoint)
 
   // plugin is not enabled, should exit
   EXPECT_TRUE(paw->processAtWaypoint(pose, 0));
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Now the unit test relies on using global variables to setup the environment.
For example, https://github.com/ros-navigation/navigation2/blob/4694386872365851c840737515f89e3d409c1d9f/nav2_planner/test/test_dynamic_parameters.cpp#L60
I think it would be better to use the main function instead.

We discovered that while testing `rmw_zenoh`.
Due to [the issue](https://github.com/ros2/rmw_zenoh?tab=readme-ov-file#crash-when-program-terminates), rmw_zenoh couldn't shutdown in atexit stage. That means calling shutdown in the destructor of a global variable will cause panic.
We believe it would be better to avoid using global variables.

Here is the list of affected tests: https://github.com/ZettaScaleLabs/rmw_zenoh/issues/54

## Description of documentation updates required from your changes

Not required

## Description of how this change was tested

Run the CI test.


---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
