### PR TITLE
nav2_smac_planner: Fix incorrect conversion between costmap and worlrd coordinates

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -45,9 +45,9 @@ inline geometry_msgs::msg::Pose getWorldCoords(
 {
   geometry_msgs::msg::Pose msg;
   msg.position.x =
-    static_cast<float>(costmap->getOriginX()) + (mx - 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginX()) + (mx + 0.5) * costmap->getResolution();
   msg.position.y =
-    static_cast<float>(costmap->getOriginY()) + (my - 0.5) * costmap->getResolution();
+    static_cast<float>(costmap->getOriginY()) + (my + 0.5) * costmap->getResolution();
   return msg;
 }
 


### PR DESCRIPTION
The Smac planner computes paths using costmap coordinates (cell indexes).
Therefore, conversions between world coordinates and costmap coordinates are required.
The issue was that the world-to-costmap conversion used a floor approximation, while the costmap-to-world conversion behaved as if a ceil approximation had been used.
As a result, the planner's output was often shifted in the negative direction.
This commit corrects the inconsistency to ensure proper alignment between costmap and world coordinates.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/4735 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | / |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* I fix the bad conversion cotsmap_cell_index->Worlds in SmacPlanner
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
