### PR TITLE
Fix the message header timestamp of the velocity_smoother, when the input timed out

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -314,11 +314,12 @@ void VelocitySmoother::smootherTimer()
 
   // Check for velocity timeout. If nothing received, publish zeros to apply deceleration
   if (now() - last_command_time_ > velocity_timeout_) {
-    if (last_cmd_ == geometry_msgs::msg::TwistStamped() || stopped_) {
+    if (last_cmd_.twist == geometry_msgs::msg::Twist() || stopped_) {
       stopped_ = true;
       return;
     }
     *command_ = geometry_msgs::msg::TwistStamped();
+    command_->header.stamp = now();
   }
 
   stopped_ = false;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Populate the header stamp of the TwistStamped message with the actual time, in the case that the velocity command times out and sends zero velocities to stop the robot.

## Description of documentation updates required from your changes

* Not needed

## Description of how this change was tested

* Checked in simulation using `ros2 topic echo /cmd_vel_smoothed` , that the `header.stamp` is always populated by a timestamp and not zero at the end of a path or after cancelling a path

---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
