### PR TITLE
Clean up the planner in test_planner_plugins

### DIFF
--- a/nav2_system_tests/src/planning/test_planner_plugins.cpp
+++ b/nav2_system_tests/src/planning/test_planner_plugins.cpp
@@ -66,7 +66,7 @@ void testSmallPathValidityAndOrientation(std::string plugin, double length)
   auto path = obj->getPlan(start, goal, "GridBased", dummy_cancel_checker);
   EXPECT_GT((int)path.poses.size(), 0);
   EXPECT_NEAR(tf2::getYaw(path.poses.back().pose.orientation), -M_PI, 0.01);
-  // obj->onCleanup(state);
+  obj->onCleanup(state);
   obj.reset();
 }
 
@@ -116,7 +116,7 @@ void testSmallPathValidityAndNoOrientation(std::string plugin, double length)
       atan2(dy, dx),
       0.01);
   }
-  // obj->onCleanup(state);
+  obj->onCleanup(state);
   obj.reset();
 }
 
@@ -146,7 +146,7 @@ void testCancel(std::string plugin)
   EXPECT_THROW(
     obj->getPlan(start, goal, "GridBased", always_cancelled),
     nav2_core::PlannerCancelled);
-  // obj->onCleanup(state);
+  obj->onCleanup(state);
   obj.reset();
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

[Costmap node](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/include/nav2_smac_planner/smac_planner_lattice.hpp#L105) should be released after the test.
However, it's held by the [static variable costmap_ros](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp#L482) in `class NodeHybrid` after calling [resetObstacleHeuristic](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/src/node_hybrid.cpp#L496) in [_a_star->setGoal](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/src/a_star.cpp#L229).

To release the node, we need to call [nav2_smac_planner::NodeHybrid::destroyStaticAssets();](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp#L467), which is part of the [SmacPlannerLattice::cleanup()](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_smac_planner/src/smac_planner_lattice.cpp#L265).

I saw there were some commented cleanup, so I just uncommented them. Please let me know if those comment are intentional.

Note: this issue only affects these [two tests](https://github.com/ros-navigation/navigation2/blob/353319f02e86205346a0352cb00e9c2a71638b40/nav2_system_tests/src/planning/test_planner_plugins.cpp#L348-L356) while they are using `class NodeHybrid`.

## Description of documentation updates required from your changes

No

## Description of how this change was tested

Yes, running the system test.

---

## Future work that may be required in bullet points

No

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
