### PR TITLE
nav2_rviz_plugins: Remove slots without implementation

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/costmap_cost_tool.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/costmap_cost_tool.hpp
@@ -46,7 +46,6 @@ public:
   void handleGlobalCostResponse(rclcpp::Client<nav2_msgs::srv::GetCosts>::SharedFuture);
 
 private Q_SLOTS:
-  void updateAutoDeactivate();
 
 private:
   rclcpp::Client<nav2_msgs::srv::GetCosts>::SharedPtr local_cost_client_;

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
@@ -57,7 +57,6 @@ public:
 
 private Q_SLOTS:
   void startThread();
-  void onStartup();
   void onDockingButtonPressed();
   void onUndockingButtonPressed();
   void onCancelDocking();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none so far |
| Primary OS tested on | Nix |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Without this change, when compiled for Jazzy with Nix using gcc14 and qt-5.15, loading the plugins to rviz fails with the following error:

    [rviz2]: PluginlibFactory: The plugin for class
    'nav2_rviz_plugins/Navigation 2' failed to load. Error: Failed to
    load library /nix/store/...-ros-env/lib/libnav2_rviz_plugins.so.
    Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in
    the library code, and that names are consistent between this macro
    and your XML. Error string: Could not load library dlopen error:
    /nix/store/...-ros-env/lib/libnav2_rviz_plugins.so: undefined
    symbol: _ZN17nav2_rviz_plugins12DockingPanel9onStartupEv, at
    /build/rcutils-release-release-jazzy-rcutils-6.7.2-1/src/shared_library.c:99

The dynamic linker complains about undefined symbol, which corresponds to a Qt slot, which is declared, but has no implementation. I'm not sure what is the root cause of this behavior, but removing the slot definitions fixes the problem and the plugins can be loaded.

This PR is related to https://github.com/lopsided98/nix-ros-overlay/pull/591#issuecomment-2708725318.

## Description of documentation updates required from your changes

None

## Description of how this change was tested

Running `rviz2` and manually adding Navigation 2 panel.
---

## Future work that may be required in bullet points

Testing with non-Nix builds. Hopefully, will be done by CI.
<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
