### PR TITLE
Migrate `geometry_msgs/PoseStampedArray` to `nav_msgs/Goals`

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp
@@ -24,9 +24,9 @@
 #include "behaviortree_cpp/behavior_tree.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "nav_msgs/msg/path.hpp"
+#include "nav_msgs/msg/goals.hpp"
 
 namespace BT
 {
@@ -136,20 +136,20 @@ inline std::vector<geometry_msgs::msg::PoseStamped> convertFromString(const Stri
 }
 
 /**
- * @brief Parse XML string to geometry_msgs::msg::PoseStampedArray
+ * @brief Parse XML string to nav_msgs::msg::Goals
  * @param key XML string
- * @return geometry_msgs::msg::PoseStampedArray
+ * @return nav_msgs::msg::Goals
  */
 template<>
-inline geometry_msgs::msg::PoseStampedArray convertFromString(const StringView key)
+inline nav_msgs::msg::Goals convertFromString(const StringView key)
 {
   auto parts = BT::splitString(key, ';');
   if ((parts.size() - 2) % 9 != 0) {
-    throw std::runtime_error("invalid number of fields for PoseStampedArray attribute)");
+    throw std::runtime_error("invalid number of fields for Goals attribute)");
   } else {
-    geometry_msgs::msg::PoseStampedArray pose_stamped_array;
-    pose_stamped_array.header.stamp = rclcpp::Time(BT::convertFromString<int64_t>(parts[0]));
-    pose_stamped_array.header.frame_id = BT::convertFromString<std::string>(parts[1]);
+    nav_msgs::msg::Goals goals_array;
+    goals_array.header.stamp = rclcpp::Time(BT::convertFromString<int64_t>(parts[0]));
+    goals_array.header.frame_id = BT::convertFromString<std::string>(parts[1]);
     for (size_t i = 2; i < parts.size(); i += 9) {
       geometry_msgs::msg::PoseStamped pose_stamped;
       pose_stamped.header.stamp = rclcpp::Time(BT::convertFromString<int64_t>(parts[i]));
@@ -161,9 +161,9 @@ inline geometry_msgs::msg::PoseStampedArray convertFromString(const StringView k
       pose_stamped.pose.orientation.y = BT::convertFromString<double>(parts[i + 6]);
       pose_stamped.pose.orientation.z = BT::convertFromString<double>(parts[i + 7]);
       pose_stamped.pose.orientation.w = BT::convertFromString<double>(parts[i + 8]);
-      pose_stamped_array.poses.push_back(pose_stamped);
+      goals_array.goals.push_back(pose_stamped);
     }
-    return pose_stamped_array;
+    return goals_array;
   }
 }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -80,7 +80,7 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+        BT::InputPort<nav_msgs::msg::Goals>(
           "goals",
           "Destinations to plan through"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "nav2_msgs/action/navigate_through_poses.hpp"
 #include "nav2_behavior_tree/bt_action_node.hpp"
 
@@ -73,7 +73,7 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+        BT::InputPort<nav_msgs::msg::Goals>(
           "goals", "Destinations to plan through"),
         BT::InputPort<std::string>("behavior_tree", "Behavior tree to run"),
         BT::OutputPort<ActionResult::_error_code_type>(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.hpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "nav2_behavior_tree/bt_service_node.hpp"
 #include "nav2_msgs/srv/get_costs.hpp"
 
@@ -52,7 +52,7 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<geometry_msgs::msg::PoseStampedArray>("input_goals",
+        BT::InputPort<nav_msgs::msg::Goals>("input_goals",
           "Original goals to remove from"),
         BT::InputPort<double>(
           "cost_threshold", 254.0,
@@ -61,7 +61,7 @@ public:
         BT::InputPort<bool>(
           "consider_unknown_as_obstacle", false,
           "Whether to consider unknown cost as obstacle"),
-        BT::OutputPort<geometry_msgs::msg::PoseStampedArray>("output_goals",
+        BT::OutputPort<nav_msgs::msg::Goals>("output_goals",
           "Goals with in-collision goals removed"),
       });
   }
@@ -70,7 +70,7 @@ private:
   bool use_footprint_;
   bool consider_unknown_as_obstacle_;
   double cost_threshold_;
-  geometry_msgs::msg::PoseStampedArray input_goals_;
+  nav_msgs::msg::Goals input_goals_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 #include "behaviortree_cpp/action_node.h"
@@ -43,9 +43,9 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>("input_goals",
+      BT::InputPort<nav_msgs::msg::Goals>("input_goals",
           "Original goals to remove viapoints from"),
-      BT::OutputPort<geometry_msgs::msg::PoseStampedArray>("output_goals",
+      BT::OutputPort<nav_msgs::msg::Goals>("output_goals",
           "Goals with passed viapoints removed"),
       BT::InputPort<double>("radius", 0.5, "radius to goal for it to be considered for removal"),
       BT::InputPort<std::string>("robot_base_frame", "Robot base frame"),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
@@ -21,7 +21,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "behaviortree_cpp/condition_node.h"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
 
 
@@ -59,7 +59,7 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+      BT::InputPort<nav_msgs::msg::Goals>(
         "goals", "Vector of navigation goals"),
       BT::InputPort<geometry_msgs::msg::PoseStamped>(
         "goal", "Navigation goal"),
@@ -70,7 +70,7 @@ private:
   bool first_time;
   rclcpp::Node::SharedPtr node_;
   geometry_msgs::msg::PoseStamped goal_;
-  geometry_msgs::msg::PoseStampedArray goals_;
+  nav_msgs::msg::Goals goals_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "behaviortree_cpp/condition_node.h"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
 
 namespace nav2_behavior_tree
@@ -56,7 +56,7 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+      BT::InputPort<nav_msgs::msg::Goals>(
         "goals", "Vector of navigation goals"),
       BT::InputPort<geometry_msgs::msg::PoseStamped>(
         "goal", "Navigation goal"),
@@ -65,7 +65,7 @@ public:
 
 private:
   geometry_msgs::msg::PoseStamped goal_;
-  geometry_msgs::msg::PoseStampedArray goals_;
+  nav_msgs::msg::Goals goals_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
@@ -50,7 +50,7 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+      BT::InputPort<nav_msgs::msg::Goals>(
         "goals", "Vector of navigation goals"),
       BT::InputPort<geometry_msgs::msg::PoseStamped>(
         "goal", "Navigation goal"),
@@ -66,7 +66,7 @@ private:
 
   bool goal_was_updated_;
   geometry_msgs::msg::PoseStamped goal_;
-  geometry_msgs::msg::PoseStampedArray goals_;
+  nav_msgs::msg::Goals goals_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
@@ -21,7 +21,7 @@
 #include <string>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 
 #include "behaviortree_cpp/decorator_node.h"
 
@@ -54,10 +54,10 @@ public:
   {
     return {
       BT::InputPort<geometry_msgs::msg::PoseStamped>("input_goal", "Original Goal"),
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>("input_goals", "Original Goals"),
+      BT::InputPort<nav_msgs::msg::Goals>("input_goals", "Original Goals"),
       BT::OutputPort<geometry_msgs::msg::PoseStamped>("output_goal",
           "Received Goal by subscription"),
-      BT::OutputPort<geometry_msgs::msg::PoseStampedArray>("output_goals",
+      BT::OutputPort<nav_msgs::msg::Goals>("output_goals",
           "Received Goals by subscription")
     };
   }
@@ -85,16 +85,16 @@ private:
 
   /**
    * @brief Callback function for goals update topic
-   * @param msg Shared pointer to geometry_msgs::msg::PoseStampedArray message
+   * @param msg Shared pointer to nav_msgs::msg::Goals message
    */
-  void callback_updated_goals(const geometry_msgs::msg::PoseStampedArray::SharedPtr msg);
+  void callback_updated_goals(const nav_msgs::msg::Goals::SharedPtr msg);
 
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_sub_;
-  rclcpp::Subscription<geometry_msgs::msg::PoseStampedArray>::SharedPtr goals_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Goals>::SharedPtr goals_sub_;
 
   geometry_msgs::msg::PoseStamped last_goal_received_;
   bool last_goal_received_set_{false};
-  geometry_msgs::msg::PoseStampedArray last_goals_received_;
+  nav_msgs::msg::Goals last_goals_received_;
   bool last_goals_received_set_{false};
 
   rclcpp::Node::SharedPtr node_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
@@ -58,7 +58,7 @@ public:
       BT::InputPort<double>("max_rate", 1.0, "Maximum rate"),
       BT::InputPort<double>("min_speed", 0.0, "Minimum speed"),
       BT::InputPort<double>("max_speed", 0.5, "Maximum speed"),
-      BT::InputPort<geometry_msgs::msg::PoseStampedArray>(
+      BT::InputPort<nav_msgs::msg::Goals>(
         "goals", "Vector of navigation goals"),
       BT::InputPort<geometry_msgs::msg::PoseStamped>(
         "goal", "Navigation goal"),
@@ -120,7 +120,7 @@ private:
 
   // current goal
   geometry_msgs::msg::PoseStamped goal_;
-  geometry_msgs::msg::PoseStampedArray goals_;
+  nav_msgs::msg::Goals goals_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_in_collision_goals_action.cpp
@@ -39,7 +39,7 @@ void RemoveInCollisionGoals::on_tick()
   getInput("input_goals", input_goals_);
   getInput("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
 
-  if (input_goals_.poses.empty()) {
+  if (input_goals_.goals.empty()) {
     setOutput("output_goals", input_goals_);
     should_send_request_ = false;
     return;
@@ -47,7 +47,7 @@ void RemoveInCollisionGoals::on_tick()
   request_ = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
   request_->use_footprint = use_footprint_;
 
-  for (const auto & goal : input_goals_.poses) {
+  for (const auto & goal : input_goals_.goals) {
     request_->poses.push_back(goal);
   }
 }
@@ -63,16 +63,16 @@ BT::NodeStatus RemoveInCollisionGoals::on_completion(
     return BT::NodeStatus::FAILURE;
   }
 
-  geometry_msgs::msg::PoseStampedArray valid_goal_poses;
+  nav_msgs::msg::Goals valid_goal_poses;
   for (size_t i = 0; i < response->costs.size(); ++i) {
     if ((response->costs[i] == 255 && !consider_unknown_as_obstacle_) ||
       response->costs[i] < cost_threshold_)
     {
-      valid_goal_poses.poses.push_back(input_goals_.poses[i]);
+      valid_goal_poses.goals.push_back(input_goals_.goals[i]);
     }
   }
   // Inform if all goals have been removed
-  if (valid_goal_poses.poses.empty()) {
+  if (valid_goal_poses.goals.empty()) {
     RCLCPP_INFO(
       node_->get_logger(),
       "All goals are in collision and have been removed from the list");

--- a/nav2_behavior_tree/plugins/action/remove_passed_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_passed_goals_action.cpp
@@ -49,10 +49,10 @@ inline BT::NodeStatus RemovePassedGoals::tick()
     initialize();
   }
 
-  geometry_msgs::msg::PoseStampedArray goal_poses;
+  nav_msgs::msg::Goals goal_poses;
   getInput("input_goals", goal_poses);
 
-  if (goal_poses.poses.empty()) {
+  if (goal_poses.goals.empty()) {
     setOutput("output_goals", goal_poses);
     return BT::NodeStatus::SUCCESS;
   }
@@ -61,21 +61,21 @@ inline BT::NodeStatus RemovePassedGoals::tick()
 
   geometry_msgs::msg::PoseStamped current_pose;
   if (!nav2_util::getCurrentPose(
-      current_pose, *tf_, goal_poses.poses[0].header.frame_id, robot_base_frame_,
+      current_pose, *tf_, goal_poses.goals[0].header.frame_id, robot_base_frame_,
       transform_tolerance_))
   {
     return BT::NodeStatus::FAILURE;
   }
 
   double dist_to_goal;
-  while (goal_poses.poses.size() > 1) {
-    dist_to_goal = euclidean_distance(goal_poses.poses[0].pose, current_pose.pose);
+  while (goal_poses.goals.size() > 1) {
+    dist_to_goal = euclidean_distance(goal_poses.goals[0].pose, current_pose.pose);
 
     if (dist_to_goal > viapoint_achieved_radius_) {
       break;
     }
 
-    goal_poses.poses.erase(goal_poses.poses.begin());
+    goal_poses.goals.erase(goal_poses.goals.begin());
   }
 
   setOutput("output_goals", goal_poses);

--- a/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.cpp
@@ -38,7 +38,7 @@ BT::NodeStatus GloballyUpdatedGoalCondition::tick()
     return BT::NodeStatus::SUCCESS;
   }
 
-  geometry_msgs::msg::PoseStampedArray current_goals;
+  nav_msgs::msg::Goals current_goals;
   BT::getInputOrBlackboard("goals", current_goals);
   geometry_msgs::msg::PoseStamped current_goal;
   BT::getInputOrBlackboard("goal", current_goal);

--- a/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
@@ -33,7 +33,7 @@ BT::NodeStatus GoalUpdatedCondition::tick()
     return BT::NodeStatus::FAILURE;
   }
 
-  geometry_msgs::msg::PoseStampedArray current_goals;
+  nav_msgs::msg::Goals current_goals;
   geometry_msgs::msg::PoseStamped current_goal;
   BT::getInputOrBlackboard("goals", current_goals);
   BT::getInputOrBlackboard("goal", current_goal);

--- a/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
@@ -44,7 +44,7 @@ BT::NodeStatus GoalUpdatedController::tick()
 
   setStatus(BT::NodeStatus::RUNNING);
 
-  geometry_msgs::msg::PoseStampedArray current_goals;
+  nav_msgs::msg::Goals current_goals;
   BT::getInputOrBlackboard("goals", current_goals);
   geometry_msgs::msg::PoseStamped current_goal;
   BT::getInputOrBlackboard("goal", current_goal);

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -72,7 +72,7 @@ void GoalUpdater::createROSInterfaces()
     goals_updater_topic_ = goals_updater_topic_new;
     rclcpp::SubscriptionOptions sub_option;
     sub_option.callback_group = callback_group_;
-    goals_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStampedArray>(
+    goals_sub_ = node_->create_subscription<nav_msgs::msg::Goals>(
       goals_updater_topic_,
       rclcpp::SystemDefaultsQoS(),
       std::bind(&GoalUpdater::callback_updated_goals, this, _1),
@@ -87,7 +87,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   }
 
   geometry_msgs::msg::PoseStamped goal;
-  geometry_msgs::msg::PoseStampedArray goals;
+  nav_msgs::msg::Goals goals;
 
   getInput("input_goal", goal);
   getInput("input_goals", goals);
@@ -120,7 +120,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   }
 
   if (last_goals_received_set_) {
-    if (last_goals_received_.poses.empty()) {
+    if (last_goals_received_.goals.empty()) {
       setOutput("output_goals", goals);
     } else if (last_goals_received_.header.stamp == rclcpp::Time(0)) {
       RCLCPP_WARN(
@@ -154,7 +154,7 @@ GoalUpdater::callback_updated_goal(const geometry_msgs::msg::PoseStamped::Shared
 }
 
 void
-GoalUpdater::callback_updated_goals(const geometry_msgs::msg::PoseStampedArray::SharedPtr msg)
+GoalUpdater::callback_updated_goals(const nav_msgs::msg::Goals::SharedPtr msg)
 {
   last_goals_received_ = *msg;
   last_goals_received_set_ = true;

--- a/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
@@ -66,7 +66,7 @@ inline BT::NodeStatus SpeedController::tick()
     first_tick_ = true;
   }
 
-  geometry_msgs::msg::PoseStampedArray current_goals;
+  nav_msgs::msg::Goals current_goals;
   BT::getInputOrBlackboard("goals", current_goals);
   geometry_msgs::msg::PoseStamped current_goal;
   BT::getInputOrBlackboard("goal", current_goal);

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -44,7 +44,7 @@ protected:
     const auto goal = goal_handle->get_goal();
     auto result = std::make_shared<nav2_msgs::action::ComputePathThroughPoses::Result>();
     result->path.poses.resize(2);
-    result->path.poses[1].pose.position.x = goal->goals.poses[0].pose.position.x;
+    result->path.poses[1].pose.position.x = goal->goals.goals[0].pose.position.x;
     if (goal->use_start) {
       result->path.poses[0].pose.position.x = goal->start.pose.position.x;
     } else {
@@ -137,9 +137,9 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick)
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
   // create new goal and set it on blackboard
-  geometry_msgs::msg::PoseStampedArray goals;
-  goals.poses.resize(1);
-  goals.poses[0].pose.position.x = 1.0;
+  nav_msgs::msg::Goals goals;
+  goals.goals.resize(1);
+  goals.goals[0].pose.position.x = 1.0;
   config_->blackboard->set("goals", goals);
 
   // tick until node succeeds
@@ -150,7 +150,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick)
   // the goal should have reached our server
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(tree_->rootNode()->getInput<std::string>("planner_id"), std::string("GridBased"));
-  EXPECT_EQ(action_server_->getCurrentGoal()->goals.poses[0].pose.position.x, 1.0);
+  EXPECT_EQ(action_server_->getCurrentGoal()->goals.goals[0].pose.position.x, 1.0);
   EXPECT_FALSE(action_server_->getCurrentGoal()->use_start);
   EXPECT_EQ(action_server_->getCurrentGoal()->planner_id, std::string("GridBased"));
 
@@ -166,7 +166,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::IDLE);
 
   // set new goal
-  goals.poses[0].pose.position.x = -2.5;
+  goals.goals[0].pose.position.x = -2.5;
   config_->blackboard->set("goals", goals);
 
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
@@ -174,7 +174,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick)
   }
 
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
-  EXPECT_EQ(action_server_->getCurrentGoal()->goals.poses[0].pose.position.x, -2.5);
+  EXPECT_EQ(action_server_->getCurrentGoal()->goals.goals[0].pose.position.x, -2.5);
 
   EXPECT_TRUE(config_->blackboard->get<nav_msgs::msg::Path>("path", path));
   EXPECT_EQ(path.poses.size(), 2u);
@@ -202,9 +202,9 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick_use_start)
   config_->blackboard->set("start", start);
 
   // create new goal and set it on blackboard
-  geometry_msgs::msg::PoseStampedArray goals;
-  goals.poses.resize(1);
-  goals.poses[0].pose.position.x = 1.0;
+  nav_msgs::msg::Goals goals;
+  goals.goals.resize(1);
+  goals.goals[0].pose.position.x = 1.0;
   config_->blackboard->set("goals", goals);
 
   // tick until node succeeds
@@ -215,7 +215,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick_use_start)
   // the goal should have reached our server
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(tree_->rootNode()->getInput<std::string>("planner_id"), std::string("GridBased"));
-  EXPECT_EQ(action_server_->getCurrentGoal()->goals.poses[0].pose.position.x, 1.0);
+  EXPECT_EQ(action_server_->getCurrentGoal()->goals.goals[0].pose.position.x, 1.0);
   EXPECT_EQ(action_server_->getCurrentGoal()->start.pose.position.x, 2.0);
   EXPECT_TRUE(action_server_->getCurrentGoal()->use_start);
   EXPECT_EQ(action_server_->getCurrentGoal()->planner_id, std::string("GridBased"));
@@ -232,7 +232,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick_use_start)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::IDLE);
 
   // set new goal and new start
-  goals.poses[0].pose.position.x = -2.5;
+  goals.goals[0].pose.position.x = -2.5;
   start.pose.position.x = -1.5;
   config_->blackboard->set("goals", goals);
   config_->blackboard->set("start", start);
@@ -242,7 +242,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick_use_start)
   }
 
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
-  EXPECT_EQ(action_server_->getCurrentGoal()->goals.poses[0].pose.position.x, -2.5);
+  EXPECT_EQ(action_server_->getCurrentGoal()->goals.goals[0].pose.position.x, -2.5);
 
   EXPECT_TRUE(config_->blackboard->get<nav_msgs::msg::Path>("path", path));
   EXPECT_EQ(path.poses.size(), 2u);

--- a/nav2_behavior_tree/test/plugins/action/test_get_pose_from_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_get_pose_from_path_action.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "nav_msgs/msg/path.hpp"
-#include "geometry_msgs/msg/pose_stamped_array.hpp"
+#include "nav_msgs/msg/goals.hpp"
 
 #include "behaviortree_cpp/bt_factory.h"
 
@@ -97,11 +97,11 @@ TEST_F(GetPoseFromPathTestFixture, test_tick)
 
   // create new path and set it on blackboard
   nav_msgs::msg::Path path;
-  geometry_msgs::msg::PoseStampedArray goals;
-  goals.poses.resize(2);
-  goals.poses[0].pose.position.x = 1.0;
-  goals.poses[1].pose.position.x = 2.0;
-  path.poses = goals.poses;
+  nav_msgs::msg::Goals goals;
+  goals.goals.resize(2);
+  goals.goals[0].pose.position.x = 1.0;
+  goals.goals[1].pose.position.x = 2.0;
+  path.poses = goals.goals;
   path.header.frame_id = "test_frame_1";
   config_->blackboard->set("path", path);
 

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -74,7 +74,7 @@ public:
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
     config_->blackboard->set("initial_pose_received", false);
-    geometry_msgs::msg::PoseStampedArray poses;
+    nav_msgs::msg::Goals poses;
     config_->blackboard->set(
       "goals", poses);
 
@@ -132,10 +132,10 @@ TEST_F(NavigateThroughPosesActionTestFixture, test_tick)
 
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
-  geometry_msgs::msg::PoseStampedArray poses;
-  poses.poses.resize(1);
-  poses.poses[0].pose.position.x = -2.5;
-  poses.poses[0].pose.orientation.x = 1.0;
+  nav_msgs::msg::Goals poses;
+  poses.goals.resize(1);
+  poses.goals[0].pose.position.x = -2.5;
+  poses.goals[0].pose.orientation.x = 1.0;
   config_->blackboard->set("goals", poses);
 
   // tick until node succeeds

--- a/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_in_collision_goals_action.cpp
@@ -148,19 +148,19 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_su
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
   // create new goal and set it on blackboard
-  geometry_msgs::msg::PoseStampedArray poses;
-  poses.poses.resize(4);
-  poses.poses[0].pose.position.x = 0.0;
-  poses.poses[0].pose.position.y = 0.0;
+  nav_msgs::msg::Goals poses;
+  poses.goals.resize(4);
+  poses.goals[0].pose.position.x = 0.0;
+  poses.goals[0].pose.position.y = 0.0;
 
-  poses.poses[1].pose.position.x = 0.5;
-  poses.poses[1].pose.position.y = 0.0;
+  poses.goals[1].pose.position.x = 0.5;
+  poses.goals[1].pose.position.y = 0.0;
 
-  poses.poses[2].pose.position.x = 1.0;
-  poses.poses[2].pose.position.y = 0.0;
+  poses.goals[2].pose.position.x = 1.0;
+  poses.goals[2].pose.position.y = 0.0;
 
-  poses.poses[3].pose.position.x = 2.0;
-  poses.poses[3].pose.position.y = 0.0;
+  poses.goals[3].pose.position.x = 2.0;
+  poses.goals[3].pose.position.y = 0.0;
 
   config_->blackboard->set("goals", poses);
 
@@ -172,13 +172,13 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_su
 
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   // check that it removed the point in range
-  geometry_msgs::msg::PoseStampedArray output_poses;
+  nav_msgs::msg::Goals output_poses;
   EXPECT_TRUE(config_->blackboard->get("goals", output_poses));
 
-  EXPECT_EQ(output_poses.poses.size(), 3u);
-  EXPECT_EQ(output_poses.poses[0], poses.poses[0]);
-  EXPECT_EQ(output_poses.poses[1], poses.poses[1]);
-  EXPECT_EQ(output_poses.poses[2], poses.poses[2]);
+  EXPECT_EQ(output_poses.goals.size(), 3u);
+  EXPECT_EQ(output_poses.goals[0], poses.goals[0]);
+  EXPECT_EQ(output_poses.goals[1], poses.goals[1]);
+  EXPECT_EQ(output_poses.goals[2], poses.goals[2]);
 }
 
 TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fail)
@@ -195,19 +195,19 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fa
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
   // create new goal and set it on blackboard
-  geometry_msgs::msg::PoseStampedArray poses;
-  poses.poses.resize(4);
-  poses.poses[0].pose.position.x = 0.0;
-  poses.poses[0].pose.position.y = 0.0;
+  nav_msgs::msg::Goals poses;
+  poses.goals.resize(4);
+  poses.goals[0].pose.position.x = 0.0;
+  poses.goals[0].pose.position.y = 0.0;
 
-  poses.poses[1].pose.position.x = 0.5;
-  poses.poses[1].pose.position.y = 0.0;
+  poses.goals[1].pose.position.x = 0.5;
+  poses.goals[1].pose.position.y = 0.0;
 
-  poses.poses[2].pose.position.x = 1.0;
-  poses.poses[2].pose.position.y = 0.0;
+  poses.goals[2].pose.position.x = 1.0;
+  poses.goals[2].pose.position.y = 0.0;
 
-  poses.poses[3].pose.position.x = 2.0;
-  poses.poses[3].pose.position.y = 0.0;
+  poses.goals[3].pose.position.x = 2.0;
+  poses.goals[3].pose.position.y = 0.0;
 
   config_->blackboard->set("goals", poses);
 
@@ -219,14 +219,14 @@ TEST_F(RemoveInCollisionGoalsTestFixture, test_tick_remove_in_collision_goals_fa
 
   // check that it failed and returned the original goals
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);
-  geometry_msgs::msg::PoseStampedArray output_poses;
+  nav_msgs::msg::Goals output_poses;
   EXPECT_TRUE(config_->blackboard->get("goals", output_poses));
 
-  EXPECT_EQ(output_poses.poses.size(), 4u);
-  EXPECT_EQ(output_poses.poses[0], poses.poses[0]);
-  EXPECT_EQ(output_poses.poses[1], poses.poses[1]);
-  EXPECT_EQ(output_poses.poses[2], poses.poses[2]);
-  EXPECT_EQ(output_poses.poses[3], poses.poses[3]);
+  EXPECT_EQ(output_poses.goals.size(), 4u);
+  EXPECT_EQ(output_poses.goals[0], poses.goals[0]);
+  EXPECT_EQ(output_poses.goals[1], poses.goals[1]);
+  EXPECT_EQ(output_poses.goals[2], poses.goals[2]);
+  EXPECT_EQ(output_poses.goals[3], poses.goals[3]);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
@@ -114,19 +114,19 @@ TEST_F(RemovePassedGoalsTestFixture, test_tick)
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
   // create new goal and set it on blackboard
-  geometry_msgs::msg::PoseStampedArray poses;
-  poses.poses.resize(4);
-  poses.poses[0].pose.position.x = 0.0;
-  poses.poses[0].pose.position.y = 0.0;
+  nav_msgs::msg::Goals poses;
+  poses.goals.resize(4);
+  poses.goals[0].pose.position.x = 0.0;
+  poses.goals[0].pose.position.y = 0.0;
 
-  poses.poses[1].pose.position.x = 0.5;
-  poses.poses[1].pose.position.y = 0.0;
+  poses.goals[1].pose.position.x = 0.5;
+  poses.goals[1].pose.position.y = 0.0;
 
-  poses.poses[2].pose.position.x = 1.0;
-  poses.poses[2].pose.position.y = 0.0;
+  poses.goals[2].pose.position.x = 1.0;
+  poses.goals[2].pose.position.y = 0.0;
 
-  poses.poses[3].pose.position.x = 2.0;
-  poses.poses[3].pose.position.y = 0.0;
+  poses.goals[3].pose.position.x = 2.0;
+  poses.goals[3].pose.position.y = 0.0;
 
   config_->blackboard->set("goals", poses);
 
@@ -136,12 +136,12 @@ TEST_F(RemovePassedGoalsTestFixture, test_tick)
   }
 
   // check that it removed the point in range
-  geometry_msgs::msg::PoseStampedArray output_poses;
+  nav_msgs::msg::Goals output_poses;
   EXPECT_TRUE(config_->blackboard->get("goals", output_poses));
 
-  EXPECT_EQ(output_poses.poses.size(), 2u);
-  EXPECT_EQ(output_poses.poses[0], poses.poses[2]);
-  EXPECT_EQ(output_poses.poses[1], poses.poses[3]);
+  EXPECT_EQ(output_poses.goals.size(), 2u);
+  EXPECT_EQ(output_poses.goals[0], poses.goals[2]);
+  EXPECT_EQ(output_poses.goals[1], poses.goals[3]);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updated_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updated_controller.cpp
@@ -32,8 +32,8 @@ public:
     // Setting fake goals on blackboard
     geometry_msgs::msg::PoseStamped goal1;
     goal1.header.stamp = node_->now();
-    geometry_msgs::msg::PoseStampedArray poses1;
-    poses1.poses.push_back(goal1);
+    nav_msgs::msg::Goals poses1;
+    poses1.goals.push_back(goal1);
     config_->blackboard->set("goal", goal1);
     config_->blackboard->set("goals", poses1);
     bt_node_ = std::make_shared<nav2_behavior_tree::GoalUpdatedController>(
@@ -63,8 +63,8 @@ TEST_F(GoalUpdatedControllerTestFixture, test_behavior)
   // Creating updated fake-goals
   geometry_msgs::msg::PoseStamped goal2;
   goal2.header.stamp = node_->now();
-  geometry_msgs::msg::PoseStampedArray poses2;
-  poses2.poses.push_back(goal2);
+  nav_msgs::msg::Goals poses2;
+  poses2.goals.push_back(goal2);
 
   // starting in idle
   EXPECT_EQ(bt_node_->status(), BT::NodeStatus::IDLE);

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
@@ -98,17 +98,17 @@ TEST_F(GoalUpdaterTestFixture, test_tick)
 
   // create new goal and set it on blackboard
   geometry_msgs::msg::PoseStamped goal;
-  geometry_msgs::msg::PoseStampedArray goals;
+  nav_msgs::msg::Goals goals;
   goal.header.stamp = node_->now();
   goal.pose.position.x = 1.0;
-  goals.poses.push_back(goal);
+  goals.goals.push_back(goal);
   config_->blackboard->set("goal", goal);
   config_->blackboard->set("goals", goals);
 
   // tick tree without publishing updated goal and get updated_goal
   tree_->rootNode()->executeTick();
   geometry_msgs::msg::PoseStamped updated_goal;
-  geometry_msgs::msg::PoseStampedArray updated_goals;
+  nav_msgs::msg::Goals updated_goals;
   EXPECT_TRUE(config_->blackboard->get("updated_goal", updated_goal));
   EXPECT_TRUE(config_->blackboard->get("updated_goals", updated_goals));
 }
@@ -130,31 +130,31 @@ TEST_F(GoalUpdaterTestFixture, test_older_goal_update)
   auto goal_updater_pub =
     node_->create_publisher<geometry_msgs::msg::PoseStamped>("goal_update", 10);
   auto goals_updater_pub =
-    node_->create_publisher<geometry_msgs::msg::PoseStampedArray>("goals_update", 10);
+    node_->create_publisher<nav_msgs::msg::Goals>("goals_update", 10);
 
   // create new goal and set it on blackboard
   geometry_msgs::msg::PoseStamped goal;
-  geometry_msgs::msg::PoseStampedArray goals;
+  nav_msgs::msg::Goals goals;
   goal.header.stamp = node_->now();
   goal.pose.position.x = 1.0;
   goals.header.stamp = goal.header.stamp;
-  goals.poses.push_back(goal);
+  goals.goals.push_back(goal);
   config_->blackboard->set("goal", goal);
   config_->blackboard->set("goals", goals);
 
   // publish updated_goal older than goal
   geometry_msgs::msg::PoseStamped goal_to_update;
-  geometry_msgs::msg::PoseStampedArray goals_to_update;
+  nav_msgs::msg::Goals goals_to_update;
   goal_to_update.header.stamp = rclcpp::Time(goal.header.stamp) - rclcpp::Duration(1, 0);
   goal_to_update.pose.position.x = 2.0;
   goals_to_update.header.stamp = goal_to_update.header.stamp;
-  goals_to_update.poses.push_back(goal_to_update);
+  goals_to_update.goals.push_back(goal_to_update);
 
   goal_updater_pub->publish(goal_to_update);
   goals_updater_pub->publish(goals_to_update);
   tree_->rootNode()->executeTick();
   geometry_msgs::msg::PoseStamped updated_goal;
-  geometry_msgs::msg::PoseStampedArray updated_goals;
+  nav_msgs::msg::Goals updated_goals;
   EXPECT_TRUE(config_->blackboard->get("updated_goal", updated_goal));
   EXPECT_TRUE(config_->blackboard->get("updated_goals", updated_goals));
 
@@ -181,31 +181,31 @@ TEST_F(GoalUpdaterTestFixture, test_get_latest_goal_update)
   auto goal_updater_pub =
     node_->create_publisher<geometry_msgs::msg::PoseStamped>("goal_update", 10);
   auto goals_updater_pub =
-    node_->create_publisher<geometry_msgs::msg::PoseStampedArray>("goals_update", 10);
+    node_->create_publisher<nav_msgs::msg::Goals>("goals_update", 10);
 
   // create new goal and set it on blackboard
   geometry_msgs::msg::PoseStamped goal;
-  geometry_msgs::msg::PoseStampedArray goals;
+  nav_msgs::msg::Goals goals;
   goal.header.stamp = node_->now();
   goal.pose.position.x = 1.0;
-  goals.poses.push_back(goal);
+  goals.goals.push_back(goal);
   config_->blackboard->set("goal", goal);
   config_->blackboard->set("goals", goals);
 
   // publish updated_goal older than goal
   geometry_msgs::msg::PoseStamped goal_to_update_1;
-  geometry_msgs::msg::PoseStampedArray goals_to_update_1;
+  nav_msgs::msg::Goals goals_to_update_1;
   goal_to_update_1.header.stamp = node_->now();
   goal_to_update_1.pose.position.x = 2.0;
   goals_to_update_1.header.stamp = goal_to_update_1.header.stamp;
-  goals_to_update_1.poses.push_back(goal_to_update_1);
+  goals_to_update_1.goals.push_back(goal_to_update_1);
 
   geometry_msgs::msg::PoseStamped goal_to_update_2;
-  geometry_msgs::msg::PoseStampedArray goals_to_update_2;
+  nav_msgs::msg::Goals goals_to_update_2;
   goal_to_update_2.header.stamp = node_->now();
   goal_to_update_2.pose.position.x = 3.0;
   goals_to_update_2.header.stamp = goal_to_update_2.header.stamp;
-  goals_to_update_2.poses.push_back(goal_to_update_2);
+  goals_to_update_2.goals.push_back(goal_to_update_2);
 
   goal_updater_pub->publish(goal_to_update_1);
   goals_updater_pub->publish(goals_to_update_1);
@@ -213,7 +213,7 @@ TEST_F(GoalUpdaterTestFixture, test_get_latest_goal_update)
   goals_updater_pub->publish(goals_to_update_2);
   tree_->rootNode()->executeTick();
   geometry_msgs::msg::PoseStamped updated_goal;
-  geometry_msgs::msg::PoseStampedArray updated_goals;
+  nav_msgs::msg::Goals updated_goals;
   EXPECT_TRUE(config_->blackboard->get("updated_goal", updated_goal));
   EXPECT_TRUE(config_->blackboard->get("updated_goals", updated_goals));
 

--- a/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
@@ -42,7 +42,7 @@ public:
     goal.header.stamp = node_->now();
     config_->blackboard->set("goal", goal);
 
-    geometry_msgs::msg::PoseStampedArray fake_poses;
+    nav_msgs::msg::Goals fake_poses;
     config_->blackboard->set("goals", fake_poses);  // NOLINT
 
     config_->input_ports["min_rate"] = 0.1;

--- a/nav2_behavior_tree/test/test_bt_utils.cpp
+++ b/nav2_behavior_tree/test/test_bt_utils.cpp
@@ -258,68 +258,68 @@ TEST(PoseStampedVectorPortTest, test_correct_syntax)
   EXPECT_EQ(values[1].pose.orientation.w, 14.0);
 }
 
-TEST(PoseStampedArrayPortTest, test_wrong_syntax)
+TEST(GoalsArrayPortTest, test_wrong_syntax)
 {
   std::string xml_txt =
     R"(
       <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
-            <PoseStampedArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;map;1.0;2.0;3.0;4.0;5.0;6.0" />
+            <GoalsArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;map;1.0;2.0;3.0;4.0;5.0;6.0" />
         </BehaviorTree>
       </root>)";
 
   BT::BehaviorTreeFactory factory;
-  factory.registerNodeType<TestNode<geometry_msgs::msg::PoseStampedArray>>(
-    "PoseStampedArrayPortTest");
+  factory.registerNodeType<TestNode<nav_msgs::msg::Goals>>(
+    "GoalsArrayPortTest");
   EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 
   xml_txt =
     R"(
       <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
-            <PoseStampedArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;8.0" />
+            <GoalsArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;8.0" />
         </BehaviorTree>
       </root>)";
 
   EXPECT_THROW(factory.createTreeFromText(xml_txt), std::exception);
 }
 
-TEST(PoseStampedArrayPortTest, test_correct_syntax)
+TEST(GoalsArrayPortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
       <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
-            <PoseStampedArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;odom;8.0;9.0;10.0;11.0;12.0;13.0;14.0" />
+            <GoalsArrayPortTest test="0;map;0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;0;odom;8.0;9.0;10.0;11.0;12.0;13.0;14.0" />
         </BehaviorTree>
       </root>)";
 
   BT::BehaviorTreeFactory factory;
-  factory.registerNodeType<TestNode<geometry_msgs::msg::PoseStampedArray>>(
-    "PoseStampedArrayPortTest");
+  factory.registerNodeType<TestNode<nav_msgs::msg::Goals>>(
+    "GoalsArrayPortTest");
   auto tree = factory.createTreeFromText(xml_txt);
 
   tree = factory.createTreeFromText(xml_txt);
-  geometry_msgs::msg::PoseStampedArray values;
+  nav_msgs::msg::Goals values;
   tree.rootNode()->getInput("test", values);
-  EXPECT_EQ(rclcpp::Time(values.poses[0].header.stamp).nanoseconds(), 0);
-  EXPECT_EQ(values.poses[0].header.frame_id, "map");
-  EXPECT_EQ(values.poses[0].pose.position.x, 1.0);
-  EXPECT_EQ(values.poses[0].pose.position.y, 2.0);
-  EXPECT_EQ(values.poses[0].pose.position.z, 3.0);
-  EXPECT_EQ(values.poses[0].pose.orientation.x, 4.0);
-  EXPECT_EQ(values.poses[0].pose.orientation.y, 5.0);
-  EXPECT_EQ(values.poses[0].pose.orientation.z, 6.0);
-  EXPECT_EQ(values.poses[0].pose.orientation.w, 7.0);
-  EXPECT_EQ(rclcpp::Time(values.poses[1].header.stamp).nanoseconds(), 0);
-  EXPECT_EQ(values.poses[1].header.frame_id, "odom");
-  EXPECT_EQ(values.poses[1].pose.position.x, 8.0);
-  EXPECT_EQ(values.poses[1].pose.position.y, 9.0);
-  EXPECT_EQ(values.poses[1].pose.position.z, 10.0);
-  EXPECT_EQ(values.poses[1].pose.orientation.x, 11.0);
-  EXPECT_EQ(values.poses[1].pose.orientation.y, 12.0);
-  EXPECT_EQ(values.poses[1].pose.orientation.z, 13.0);
-  EXPECT_EQ(values.poses[1].pose.orientation.w, 14.0);
+  EXPECT_EQ(rclcpp::Time(values.goals[0].header.stamp).nanoseconds(), 0);
+  EXPECT_EQ(values.goals[0].header.frame_id, "map");
+  EXPECT_EQ(values.goals[0].pose.position.x, 1.0);
+  EXPECT_EQ(values.goals[0].pose.position.y, 2.0);
+  EXPECT_EQ(values.goals[0].pose.position.z, 3.0);
+  EXPECT_EQ(values.goals[0].pose.orientation.x, 4.0);
+  EXPECT_EQ(values.goals[0].pose.orientation.y, 5.0);
+  EXPECT_EQ(values.goals[0].pose.orientation.z, 6.0);
+  EXPECT_EQ(values.goals[0].pose.orientation.w, 7.0);
+  EXPECT_EQ(rclcpp::Time(values.goals[1].header.stamp).nanoseconds(), 0);
+  EXPECT_EQ(values.goals[1].header.frame_id, "odom");
+  EXPECT_EQ(values.goals[1].pose.position.x, 8.0);
+  EXPECT_EQ(values.goals[1].pose.position.y, 9.0);
+  EXPECT_EQ(values.goals[1].pose.position.z, 10.0);
+  EXPECT_EQ(values.goals[1].pose.orientation.x, 11.0);
+  EXPECT_EQ(values.goals[1].pose.orientation.y, 12.0);
+  EXPECT_EQ(values.goals[1].pose.orientation.z, 13.0);
+  EXPECT_EQ(values.goals[1].pose.orientation.w, 14.0);
 }
 
 TEST(PathPortTest, test_wrong_syntax)

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -113,10 +113,10 @@ NavigateThroughPosesNavigator::onLoop()
 
   auto blackboard = bt_action_server_->getBlackboard();
 
-  geometry_msgs::msg::PoseStampedArray goal_poses;
+  nav_msgs::msg::Goals goal_poses;
   [[maybe_unused]] auto res = blackboard->get(goals_blackboard_id_, goal_poses);
 
-  if (goal_poses.poses.size() == 0) {
+  if (goal_poses.goals.size() == 0) {
     bt_action_server_->publishFeedback(feedback_msg);
     return;
   }
@@ -178,7 +178,7 @@ NavigateThroughPosesNavigator::onLoop()
   feedback_msg->number_of_recoveries = recovery_count;
   feedback_msg->current_pose = current_pose;
   feedback_msg->navigation_time = clock_->now() - start_time_;
-  feedback_msg->number_of_poses_remaining = goal_poses.poses.size();
+  feedback_msg->number_of_poses_remaining = goal_poses.goals.size();
 
   bt_action_server_->publishFeedback(feedback_msg);
 }
@@ -228,9 +228,9 @@ NavigateThroughPosesNavigator::initializeGoalPoses(ActionT::Goal::ConstSharedPtr
     return false;
   }
 
-  geometry_msgs::msg::PoseStampedArray pose_stamped_array = goal->poses;
+  nav_msgs::msg::Goals goals_array = goal->poses;
   int i = 0;
-  for (auto & goal_pose : pose_stamped_array.poses) {
+  for (auto & goal_pose : goals_array.goals) {
     if (!nav2_util::transformPoseInTargetFrame(
         goal_pose, goal_pose, *feedback_utils_.tf, feedback_utils_.global_frame,
         feedback_utils_.transform_tolerance))
@@ -246,11 +246,11 @@ NavigateThroughPosesNavigator::initializeGoalPoses(ActionT::Goal::ConstSharedPtr
     i++;
   }
 
-  if (pose_stamped_array.poses.size() > 0) {
+  if (goals_array.goals.size() > 0) {
     RCLCPP_INFO(
       logger_, "Begin navigating from current location through %zu poses to (%.2f, %.2f)",
-      pose_stamped_array.poses.size(), pose_stamped_array.poses.back().pose.position.x,
-        pose_stamped_array.poses.back().pose.position.y);
+      goals_array.goals.size(), goals_array.goals.back().pose.position.x,
+        goals_array.goals.back().pose.position.y);
   }
 
   // Reset state for new action feedback
@@ -259,8 +259,8 @@ NavigateThroughPosesNavigator::initializeGoalPoses(ActionT::Goal::ConstSharedPtr
   blackboard->set("number_recoveries", 0);  // NOLINT
 
   // Update the goal pose on the blackboard
-  blackboard->set<geometry_msgs::msg::PoseStampedArray>(goals_blackboard_id_,
-      std::move(pose_stamped_array));
+  blackboard->set<nav_msgs::msg::Goals>(goals_blackboard_id_,
+      std::move(goals_array));
 
   return true;
 }

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -1,5 +1,5 @@
 #goal definition
-geometry_msgs/PoseStampedArray goals
+nav_msgs/Goals goals
 geometry_msgs/PoseStamped start
 string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -1,6 +1,6 @@
 
 #goal definition
-geometry_msgs/PoseStampedArray poses
+nav_msgs/Goals poses
 string behavior_tree
 ---
 #result definition

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -394,7 +394,7 @@ void PlannerServer::computePlanThroughPoses()
 
     getPreemptedGoalIfRequested(action_server_poses_, goal);
 
-    if (goal->goals.poses.empty()) {
+    if (goal->goals.goals.empty()) {
       throw nav2_core::NoViapointsGiven("No viapoints given");
     }
 
@@ -409,7 +409,7 @@ void PlannerServer::computePlanThroughPoses()
       };
 
     // Get consecutive paths through these points
-    for (unsigned int i = 0; i != goal->goals.poses.size(); i++) {
+    for (unsigned int i = 0; i != goal->goals.goals.size(); i++) {
       // Get starting point
       if (i == 0) {
         curr_start = start;
@@ -419,7 +419,7 @@ void PlannerServer::computePlanThroughPoses()
         curr_start = concat_path.poses.back();
         curr_start.header = concat_path.header;
       }
-      curr_goal = goal->goals.poses[i];
+      curr_goal = goal->goals.goals[i];
 
       // Transform them into the global frame
       if (!transformPosesToGlobalFrame(curr_start, curr_goal)) {

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -102,7 +102,7 @@ private:
     std::vector<double> orientation);
   void startWaypointFollowing(std::vector<geometry_msgs::msg::PoseStamped> poses);
   void startNavigation(geometry_msgs::msg::PoseStamped);
-  void startNavThroughPoses(geometry_msgs::msg::PoseStampedArray poses);
+  void startNavThroughPoses(nav_msgs::msg::Goals poses);
   using NavigationGoalHandle =
     rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateToPose>;
   using WaypointFollowerGoalHandle =
@@ -196,8 +196,8 @@ private:
   QState * accumulated_wp_{nullptr};
   QState * accumulated_nav_through_poses_{nullptr};
 
-  geometry_msgs::msg::PoseStampedArray acummulated_poses_;
-  geometry_msgs::msg::PoseStampedArray store_poses_;
+  nav_msgs::msg::Goals acummulated_poses_;
+  nav_msgs::msg::Goals store_poses_;
 
   // Publish the visual markers with the waypoints
   void updateWpNavigationMarkers();

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -675,7 +675,7 @@ void Nav2Panel::loophandler()
 
 void Nav2Panel::handleGoalLoader()
 {
-  acummulated_poses_ = geometry_msgs::msg::PoseStampedArray();
+  acummulated_poses_ = nav_msgs::msg::Goals();
 
   std::cout << "Loading Waypoints!" << std::endl;
 
@@ -699,7 +699,7 @@ void Nav2Panel::handleGoalLoader()
     auto waypoint = waypoint_iter[it->first.as<std::string>()];
     auto pose = waypoint["pose"].as<std::vector<double>>();
     auto orientation = waypoint["orientation"].as<std::vector<double>>();
-    acummulated_poses_.poses.push_back(convert_to_msg(pose, orientation));
+    acummulated_poses_.goals.push_back(convert_to_msg(pose, orientation));
   }
 
   // Publishing Waypoint Navigation marker after loading wp's
@@ -731,7 +731,7 @@ void Nav2Panel::handleGoalSaver()
 {
 // Check if the waypoints are accumulated
 
-  if (acummulated_poses_.poses.empty()) {
+  if (acummulated_poses_.goals.empty()) {
     std::cout << "No accumulated Points to Save!" << std::endl;
     return;
   } else {
@@ -744,19 +744,19 @@ void Nav2Panel::handleGoalSaver()
   out << YAML::BeginMap;
 
   // Save WPs to data structure
-  for (unsigned int i = 0; i < acummulated_poses_.poses.size(); ++i) {
+  for (unsigned int i = 0; i < acummulated_poses_.goals.size(); ++i) {
     out << YAML::Key << "waypoint" + std::to_string(i);
     out << YAML::BeginMap;
     out << YAML::Key << "pose";
     std::vector<double> pose =
-    {acummulated_poses_.poses[i].pose.position.x, acummulated_poses_.poses[i].pose.position.y,
-      acummulated_poses_.poses[i].pose.position.z};
+    {acummulated_poses_.goals[i].pose.position.x, acummulated_poses_.goals[i].pose.position.y,
+      acummulated_poses_.goals[i].pose.position.z};
     out << YAML::Value << pose;
     out << YAML::Key << "orientation";
     std::vector<double> orientation =
-    {acummulated_poses_.poses[i].pose.orientation.w, acummulated_poses_.poses[i].pose.orientation.x,
-      acummulated_poses_.poses[i].pose.orientation.y,
-      acummulated_poses_.poses[i].pose.orientation.z};
+    {acummulated_poses_.goals[i].pose.orientation.w, acummulated_poses_.goals[i].pose.orientation.x,
+      acummulated_poses_.goals[i].pose.orientation.y,
+      acummulated_poses_.goals[i].pose.orientation.z};
     out << YAML::Value << orientation;
     out << YAML::EndMap;
   }
@@ -837,10 +837,10 @@ Nav2Panel::onInitialize()
       // Clearing all the stored values once reaching the final goal
       if (
         loop_count_ == stoi(nr_of_loops_->displayText().toStdString()) &&
-        goal_index_ == static_cast<int>(store_poses_.poses.size()) - 1 &&
+        goal_index_ == static_cast<int>(store_poses_.goals.size()) - 1 &&
         msg->status_list.back().status == action_msgs::msg::GoalStatus::STATUS_SUCCEEDED)
       {
-        store_poses_ = geometry_msgs::msg::PoseStampedArray();
+        store_poses_ = nav_msgs::msg::Goals();
         waypoint_status_indicator_->clear();
         loop_no_ = "0";
         loop_count_ = 0;
@@ -936,8 +936,8 @@ Nav2Panel::onCancel()
       &Nav2Panel::onCancelButtonPressed,
       this));
   waypoint_status_indicator_->clear();
-  store_poses_ = geometry_msgs::msg::PoseStampedArray();
-  acummulated_poses_ = geometry_msgs::msg::PoseStampedArray();
+  store_poses_ = nav_msgs::msg::Goals();
+  acummulated_poses_ = nav_msgs::msg::Goals();
 }
 
 void Nav2Panel::onResumedWp()
@@ -967,12 +967,12 @@ Nav2Panel::onNewGoal(double x, double y, double theta, QString frame)
   pose.pose.position.z = 0.0;
   pose.pose.orientation = orientationAroundZAxis(theta);
 
-  if (store_poses_.poses.empty()) {
+  if (store_poses_.goals.empty()) {
     if (state_machine_.configuration().contains(accumulating_)) {
       waypoint_status_indicator_->clear();
-      acummulated_poses_.poses.push_back(pose);
+      acummulated_poses_.goals.push_back(pose);
     } else {
-      acummulated_poses_ = geometry_msgs::msg::PoseStampedArray();
+      acummulated_poses_ = nav_msgs::msg::Goals();
       updateWpNavigationMarkers();
       std::cout << "Start navigation" << std::endl;
       startNavigation(pose);
@@ -1031,7 +1031,7 @@ Nav2Panel::onCancelButtonPressed()
 void
 Nav2Panel::onAccumulatedWp()
 {
-  if (acummulated_poses_.poses.empty()) {
+  if (acummulated_poses_.goals.empty()) {
     state_machine_.postEvent(new ROSActionQEvent(QActionState::INACTIVE));
     waypoint_status_indicator_->setText(
       "<b> Note: </b> Uh oh! Someone forgot to select the waypoints");
@@ -1053,7 +1053,7 @@ Nav2Panel::onAccumulatedWp()
 
   /** Making sure that the pose array does not get updated
    *  between the process**/
-  if (store_poses_.poses.empty()) {
+  if (store_poses_.goals.empty()) {
     std::cout << "Start waypoint" << std::endl;
 
     // Setting the final loop value on the text box for sanity
@@ -1066,12 +1066,12 @@ Nav2Panel::onAccumulatedWp()
     if (store_initial_pose_) {
       try {
         init_transform = tf2_buffer_->lookupTransform(
-          acummulated_poses_.poses[0].header.frame_id, base_frame_,
+          acummulated_poses_.goals[0].header.frame_id, base_frame_,
           tf2::TimePointZero);
       } catch (const tf2::TransformException & ex) {
         RCLCPP_INFO(
           client_node_->get_logger(), "Could not transform %s to %s: %s",
-          acummulated_poses_.poses[0].header.frame_id.c_str(), base_frame_.c_str(), ex.what());
+          acummulated_poses_.goals[0].header.frame_id.c_str(), base_frame_.c_str(), ex.what());
         return;
       }
 
@@ -1087,24 +1087,24 @@ Nav2Panel::onAccumulatedWp()
       initial_pose.pose.orientation.w = init_transform.transform.rotation.w;
 
       // inserting the acummulated pose
-      acummulated_poses_.poses.insert(acummulated_poses_.poses.begin(), initial_pose);
+      acummulated_poses_.goals.insert(acummulated_poses_.goals.begin(), initial_pose);
       updateWpNavigationMarkers();
       initial_pose_stored_ = true;
       if (loop_count_ == 0) {
         goal_index_ = 1;
       }
     } else if (!store_initial_pose_ && initial_pose_stored_) {
-      acummulated_poses_.poses.erase(
-        acummulated_poses_.poses.begin(),
-        acummulated_poses_.poses.begin());
+      acummulated_poses_.goals.erase(
+        acummulated_poses_.goals.begin(),
+        acummulated_poses_.goals.begin());
     }
   } else {
     std::cout << "Resuming waypoint" << std::endl;
   }
 
-  startWaypointFollowing(acummulated_poses_.poses);
+  startWaypointFollowing(acummulated_poses_.goals);
   store_poses_ = acummulated_poses_;
-  acummulated_poses_ = geometry_msgs::msg::PoseStampedArray();
+  acummulated_poses_ = nav_msgs::msg::Goals();
 }
 
 void
@@ -1117,8 +1117,8 @@ Nav2Panel::onAccumulatedNTP()
 void
 Nav2Panel::onAccumulating()
 {
-  acummulated_poses_ = geometry_msgs::msg::PoseStampedArray();
-  store_poses_ = geometry_msgs::msg::PoseStampedArray();
+  acummulated_poses_ = nav_msgs::msg::Goals();
+  store_poses_ = nav_msgs::msg::Goals();
   loop_count_ = 0;
   loop_no_ = "0";
   initial_pose_stored_ = false;
@@ -1255,7 +1255,7 @@ Nav2Panel::startWaypointFollowing(std::vector<geometry_msgs::msg::PoseStamped> p
 }
 
 void
-Nav2Panel::startNavThroughPoses(geometry_msgs::msg::PoseStampedArray poses)
+Nav2Panel::startNavThroughPoses(nav_msgs::msg::Goals poses)
 {
   auto is_action_server_ready =
     nav_through_poses_action_client_->wait_for_action_server(std::chrono::seconds(5));
@@ -1273,8 +1273,8 @@ Nav2Panel::startNavThroughPoses(geometry_msgs::msg::PoseStampedArray poses)
 
   RCLCPP_DEBUG(
     client_node_->get_logger(), "Sending a path of %zu waypoints:",
-    nav_through_poses_goal_.poses.poses.size());
-  for (auto waypoint : nav_through_poses_goal_.poses.poses) {
+    nav_through_poses_goal_.poses.goals.size());
+  for (auto waypoint : nav_through_poses_goal_.poses.goals) {
     RCLCPP_DEBUG(
       client_node_->get_logger(),
       "\t(%lf, %lf)", waypoint.pose.position.x, waypoint.pose.position.y);
@@ -1385,14 +1385,14 @@ Nav2Panel::updateWpNavigationMarkers()
 
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 
-  for (size_t i = 0; i < acummulated_poses_.poses.size(); i++) {
+  for (size_t i = 0; i < acummulated_poses_.goals.size(); i++) {
     // Draw a green arrow at the waypoint pose
     visualization_msgs::msg::Marker arrow_marker;
-    arrow_marker.header = acummulated_poses_.poses[i].header;
+    arrow_marker.header = acummulated_poses_.goals[i].header;
     arrow_marker.id = getUniqueId();
     arrow_marker.type = visualization_msgs::msg::Marker::ARROW;
     arrow_marker.action = visualization_msgs::msg::Marker::ADD;
-    arrow_marker.pose = acummulated_poses_.poses[i].pose;
+    arrow_marker.pose = acummulated_poses_.goals[i].pose;
     arrow_marker.scale.x = 0.3;
     arrow_marker.scale.y = 0.05;
     arrow_marker.scale.z = 0.02;
@@ -1406,11 +1406,11 @@ Nav2Panel::updateWpNavigationMarkers()
 
     // Draw a red circle at the waypoint pose
     visualization_msgs::msg::Marker circle_marker;
-    circle_marker.header = acummulated_poses_.poses[i].header;
+    circle_marker.header = acummulated_poses_.goals[i].header;
     circle_marker.id = getUniqueId();
     circle_marker.type = visualization_msgs::msg::Marker::SPHERE;
     circle_marker.action = visualization_msgs::msg::Marker::ADD;
-    circle_marker.pose = acummulated_poses_.poses[i].pose;
+    circle_marker.pose = acummulated_poses_.goals[i].pose;
     circle_marker.scale.x = 0.05;
     circle_marker.scale.y = 0.05;
     circle_marker.scale.z = 0.05;
@@ -1424,11 +1424,11 @@ Nav2Panel::updateWpNavigationMarkers()
 
     // Draw the waypoint number
     visualization_msgs::msg::Marker marker_text;
-    marker_text.header = acummulated_poses_.poses[i].header;
+    marker_text.header = acummulated_poses_.goals[i].header;
     marker_text.id = getUniqueId();
     marker_text.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker_text.action = visualization_msgs::msg::Marker::ADD;
-    marker_text.pose = acummulated_poses_.poses[i].pose;
+    marker_text.pose = acummulated_poses_.goals[i].pose;
     marker_text.pose.position.z += 0.2;  // draw it on top of the waypoint
     marker_text.scale.x = 0.07;
     marker_text.scale.y = 0.07;

--- a/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
+++ b/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
@@ -630,7 +630,7 @@ class BasicNavigator(Node):
         goal_msg.start = start
         goal_msg.goals.header.frame_id = 'map'
         goal_msg.goals.header.stamp = self.get_clock().now().to_msg()
-        goal_msg.goals.poses = goals
+        goal_msg.goals.goals = goals
         goal_msg.planner_id = planner_id
         goal_msg.use_start = use_start
 

--- a/nav2_system_tests/src/system/nav_through_poses_tester_error_msg_node.py
+++ b/nav2_system_tests/src/system/nav_through_poses_tester_error_msg_node.py
@@ -139,7 +139,7 @@ class NavTester(Node):
         goal_msg = NavigateThroughPoses.Goal()
         goal_msg.poses.header.frame_id = 'map'
         goal_msg.poses.header.stamp = self.get_clock().now().to_msg()
-        goal_msg.poses.poses = [
+        goal_msg.poses.goals = [
             self.getStampedPoseMsg(self.goal_pose),
             self.getStampedPoseMsg(self.goal_pose),
         ]

--- a/nav2_system_tests/src/system/nav_through_poses_tester_node.py
+++ b/nav2_system_tests/src/system/nav_through_poses_tester_node.py
@@ -96,7 +96,7 @@ class NavTester(Node):
         goal_msg = NavigateThroughPoses.Goal()
         goal_msg.poses.header.frame_id = 'map'
         goal_msg.poses.header.stamp = self.get_clock().now().to_msg()
-        goal_msg.poses.poses = [
+        goal_msg.poses.goals = [
             self.getStampedPoseMsg(self.goal_pose),
             self.getStampedPoseMsg(self.goal_pose),
         ]
@@ -172,7 +172,7 @@ class NavTester(Node):
             )
 
         goal_msg = NavigateThroughPoses.Goal()
-        goal_msg.poses.poses = [self.getStampedPoseMsg(self.initial_pose)]
+        goal_msg.poses.goals = [self.getStampedPoseMsg(self.initial_pose)]
 
         self.info_msg('Sending goal request...')
         send_goal_future = self.action_client.send_goal_async(goal_msg)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4976 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No|

---

## Description of contribution in a few bullet points

* Migrated `geometry_msgs/msg/PoseStampedArray` to `nav_msgs/msg/Goals` across the codebase.

## Description of documentation updates required from your changes

* The migration guide from Jazzy to Kilted needs to be updated for [BT Nodes](https://docs.nav2.org/migration/Jazzy.html#computepaththroughposes-navigatethroughposes-and-other-bt-nodes-now-use-posestampedarray-instead-of-vector-posestamped) to use `nav_msgs/msg/Goals` instead.


## Description of how this change was tested

* Syntax migration tested through a simple `colcon build` from the workspace.
* Unit tests were run using `colcon test`. 


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
