### PR TITLE
Clear costmap if reset distance exceeds costmap bounds.

### DIFF
--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -129,6 +129,15 @@ void ClearCostmapService::clearLayerRegion(
 {
   std::unique_lock<Costmap2D::mutex_t> lock(*(costmap->getMutex()));
 
+  // If the reset distance is greater than the costmap size, clear the entire costmap
+  if (reset_distance >= costmap->getSizeInMetersX() &&
+    reset_distance >= costmap->getSizeInMetersY())
+  {
+    RCLCPP_INFO(logger_, "Reset area exceeds local costmap size. Clearing entire costmap.");
+    clearEntirely();
+    return;
+  }
+
   double start_point_x = pose_x - reset_distance / 2;
   double start_point_y = pose_y - reset_distance / 2;
   double end_point_x = start_point_x + reset_distance;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot3 simulation in Gazebo |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Cleared the entire costmap if `reset_distance` is greater than the length and breadth of the target costmap.

## Description of documentation updates required from your changes

* The `reset_distance` parameter description needs to be updated in [ClearCostmapExceptRegion](https://docs.nav2.org/configuration/packages/bt-plugins/actions/ClearCostmapExceptRegion.html#input-ports) and [ClearCostmapAroundRobot](https://docs.nav2.org/configuration/packages/bt-plugins/actions/ClearCostmapAroundRobot.html#input-ports) to include the clearing ability if outside bounds.
>

## Description of how this change was tested

* Launch the turtlebot3 simulation with nav2 and gazebo:

   ```bash
   ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
   ```
* View the costmap behavior in RViz after setting the `reset_distance` to more and less than 3 (width of the local costmap):

   ```bash
  ros2 service call /local_costmap/clear_around_local_costmap nav2_msgs/srv/ClearCostmapAroundRobot "{reset_distance: 5.0}"
   ```
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
