### PR TITLE
* Parametrize collision checking in nav2_graceful_controller

### DIFF
--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -53,6 +53,7 @@ struct Parameters
   double rotation_scaling_factor;
   bool allow_backward;
   double in_place_collision_resolution;
+  bool use_collision_detection;
 };
 
 /**

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -56,10 +56,9 @@ void GracefulController::configure(
     params_->v_linear_min, params_->v_linear_max, params_->v_angular_max);
 
   // Initialize footprint collision checker
-  if(params_->use_collision_detection)
-  {
+  if(params_->use_collision_detection) {
     collision_checker_ = std::make_unique<nav2_costmap_2d::
-    FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
+        FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
   }
 
   // Publishers

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -56,8 +56,11 @@ void GracefulController::configure(
     params_->v_linear_min, params_->v_linear_max, params_->v_angular_max);
 
   // Initialize footprint collision checker
-  collision_checker_ = std::make_unique<nav2_costmap_2d::
-      FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
+  if(params_->use_collision_detection)
+  {
+    collision_checker_ = std::make_unique<nav2_costmap_2d::
+    FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
+  }
 
   // Publishers
   transformed_plan_pub_ = node->create_publisher<nav_msgs::msg::Path>("transformed_global_plan", 1);
@@ -169,6 +172,7 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
     // Need to check at least the end pose
     num_steps = std::max(static_cast<size_t>(1), num_steps);
     bool collision_free = true;
+    bool use_collision_detection = params_->use_collision_detection;
     for (size_t i = 1; i <= num_steps; ++i) {
       double step = static_cast<double>(i) / static_cast<double>(num_steps);
       double yaw = step * angle_to_goal;
@@ -177,7 +181,7 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
       next_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw);
       geometry_msgs::msg::PoseStamped costmap_pose;
       tf2::doTransform(next_pose, costmap_pose, costmap_transform);
-      if (inCollision(
+      if (use_collision_detection && inCollision(
           costmap_pose.pose.position.x, costmap_pose.pose.position.y,
           tf2::getYaw(costmap_pose.pose.orientation)))
       {
@@ -348,7 +352,7 @@ bool GracefulController::simulateTrajectory(
     // Check for collision
     geometry_msgs::msg::PoseStamped global_pose;
     tf2::doTransform(next_pose, global_pose, costmap_transform);
-    if (inCollision(
+    if (params_->use_collision_detection && inCollision(
         global_pose.pose.position.x, global_pose.pose.position.y,
         tf2::getYaw(global_pose.pose.orientation)))
     {

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -171,7 +171,6 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
     // Need to check at least the end pose
     num_steps = std::max(static_cast<size_t>(1), num_steps);
     bool collision_free = true;
-    bool use_collision_detection = params_->use_collision_detection;
     for (size_t i = 1; i <= num_steps; ++i) {
       double step = static_cast<double>(i) / static_cast<double>(num_steps);
       double yaw = step * angle_to_goal;
@@ -180,7 +179,7 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
       next_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw);
       geometry_msgs::msg::PoseStamped costmap_pose;
       tf2::doTransform(next_pose, costmap_pose, costmap_transform);
-      if (use_collision_detection && inCollision(
+      if (params_->use_collision_detection && inCollision(
           costmap_pose.pose.position.x, costmap_pose.pose.position.y,
           tf2::getYaw(costmap_pose.pose.orientation)))
       {

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -70,6 +70,8 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".allow_backward", rclcpp::ParameterValue(false));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".in_place_collision_resolution", rclcpp::ParameterValue(0.1));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_collision_detection", rclcpp::ParameterValue(true));
 
   node->get_parameter(plugin_name_ + ".transform_tolerance", params_.transform_tolerance);
   node->get_parameter(plugin_name_ + ".min_lookahead", params_.min_lookahead);
@@ -103,6 +105,8 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(plugin_name_ + ".allow_backward", params_.allow_backward);
   node->get_parameter(
     plugin_name_ + ".in_place_collision_resolution", params_.in_place_collision_resolution);
+  node->get_parameter(
+    plugin_name_ + ".use_collision_detection", params_.use_collision_detection);
 
   if (params_.initial_rotation && params_.allow_backward) {
     RCLCPP_WARN(

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -191,6 +191,8 @@ ParameterHandler::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
           continue;
         }
         params_.allow_backward = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_collision_detection") {
+        params_.use_collision_detection = parameter.as_bool();
       }
     }
   }

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -248,6 +248,8 @@ TEST(GracefulControllerTest, dynamicParameters) {
     node, "test.initial_rotation", rclcpp::ParameterValue(true));
   nav2_util::declare_parameter_if_not_declared(
     node, "test.allow_backward", rclcpp::ParameterValue(true));
+  nav2_util::declare_parameter_if_not_declared(
+    node, "test.use_collision_detection", rclcpp::ParameterValue(true));
 
   // Create controller
   auto controller = std::make_shared<GMControllerFixture>();
@@ -282,6 +284,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.prefer_final_rotation", false),
       rclcpp::Parameter("test.rotation_scaling_factor", 13.0),
       rclcpp::Parameter("test.allow_backward", true),
+      rclcpp::Parameter("test.use_collision_detection", false),
       rclcpp::Parameter("test.in_place_collision_resolution", 15.0)});
 
   // Spin
@@ -305,6 +308,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.prefer_final_rotation").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.rotation_scaling_factor").as_double(), 13.0);
   EXPECT_EQ(node->get_parameter("test.allow_backward").as_bool(), true);
+  EXPECT_EQ(node->get_parameter("test.use_collision_detection").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.in_place_collision_resolution").as_double(), 15.0);
 
   // Set initial rotation to true


### PR DESCRIPTION

## Basic Info
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #5005 ) |
| Primary OS tested on | (Ubuntu 24.04 running Jazzy) |
| Robotic platform tested on | (Simulation of a custom diff-drive robot) |
| Does this PR contain AI generated software? | (No) |

---

## Description of contribution in a few bullet points

* I added a parameter to nav2_graceful_controller to enable/disable collision checking

## Description of documentation updates required from your changes

* Added new parameter, so need to add that to default configs and documentation page.

## Description of how this change was tested

* I ran the test with a huge robot radius in the local_costmap to always have collision in the controller's path. The parametrization worked to enable/disable it.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
