### PR TITLE
Clear costmap if reset distance exceeds costmap bounds.

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
@@ -174,6 +174,15 @@ public:
   void mapToWorld(unsigned int mx, unsigned int my, double & wx, double & wy) const;
 
   /**
+  * @brief  Convert from map coordinates to world coordinates with no bounds checking
+  * @param  wx The x world coordinate
+  * @param  wy The y world coordinate
+  * @param  mx Will be set to the associated map x coordinate
+  * @param  my Will be set to the associated map y coordinate
+  */
+  void mapToWorldNoBounds(int mx, int my, double & wx, double & wy) const;
+
+  /**
    * @brief  Convert from world coordinates to map coordinates
    * @param  wx The x world coordinate
    * @param  wy The y world coordinate

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -135,8 +135,8 @@ void ClearCostmapService::clearLayerRegion(
   double end_point_y = start_point_y + reset_distance;
 
   int start_x, start_y, end_x, end_y;
-  costmap->worldToMapEnforceBounds(start_point_x, start_point_y, start_x, start_y);
-  costmap->worldToMapEnforceBounds(end_point_x, end_point_y, end_x, end_y);
+  costmap->worldToMapNoBounds(start_point_x, start_point_y, start_x, start_y);
+  costmap->worldToMapNoBounds(end_point_x, end_point_y, end_x, end_y);
 
   costmap->clearArea(start_x, start_y, end_x, end_y, invert);
 

--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -282,6 +282,12 @@ void Costmap2D::mapToWorld(unsigned int mx, unsigned int my, double & wx, double
   wy = origin_y_ + (my + 0.5) * resolution_;
 }
 
+void Costmap2D::mapToWorldNoBounds(int mx, int my, double & wx, double & wy) const
+{
+  wx = origin_x_ + (mx + 0.5) * resolution_;
+  wy = origin_y_ + (my + 0.5) * resolution_;
+}
+
 bool Costmap2D::worldToMap(double wx, double wy, unsigned int & mx, unsigned int & my) const
 {
   if (wx < origin_x_ || wy < origin_y_) {

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -66,10 +66,19 @@ void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y, boo
 {
   current_ = false;
   unsigned char * grid = getCharMap();
-  for (int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
+
+  int size_x = getSizeInCellsX();
+  int size_y = getSizeInCellsY();
+
+  start_x = std::clamp(start_x, 0, size_x);
+  start_y = std::clamp(start_y, 0, size_y);
+  end_x = std::clamp(end_x, 0, size_x);
+  end_y = std::clamp(end_y, 0, size_y);
+
+  for (int x = 0; x < size_x; x++) {
     bool xrange = x > start_x && x < end_x;
 
-    for (int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
+    for (int y = 0; y < size_y; y++) {
       if ((xrange && y > start_y && y < end_y) == invert) {
         continue;
       }

--- a/nav2_costmap_2d/test/unit/CMakeLists.txt
+++ b/nav2_costmap_2d/test/unit/CMakeLists.txt
@@ -62,3 +62,8 @@ ament_add_gtest(lifecycle_test lifecycle_test.cpp)
 target_link_libraries(lifecycle_test
   nav2_costmap_2d_core
 )
+
+ament_add_gtest(coordinate_transform_test coordinate_transform_test.cpp)
+target_link_libraries(coordinate_transform_test
+  nav2_costmap_2d_core
+)

--- a/nav2_costmap_2d/test/unit/coordinate_transform_test.cpp
+++ b/nav2_costmap_2d/test/unit/coordinate_transform_test.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+
+
+/**
+ * Test for mapToWorldNoBounds
+ */
+
+TEST(mapToWorldNoBounds, MapToWorldNoBoundsNegativeMapCoords)
+{
+  double wx, wy;
+
+  std::unique_ptr<nav2_costmap_2d::Costmap2D> map;
+
+  map = std::make_unique<nav2_costmap_2d::Costmap2D>(10, 10, 1.0, 0.0, 0.0);
+  map->mapToWorldNoBounds(-1, -1, wx, wy);
+  EXPECT_DOUBLE_EQ(wx, -0.5);
+  EXPECT_DOUBLE_EQ(wy, -0.5);
+
+  map = std::make_unique<nav2_costmap_2d::Costmap2D>(10, 10, 1.0, 1.0, 2.0);
+  map->mapToWorldNoBounds(-5, -5, wx, wy);
+  EXPECT_DOUBLE_EQ(wx, -3.5);
+  EXPECT_DOUBLE_EQ(wy, -2.5);
+
+  map = std::make_unique<nav2_costmap_2d::Costmap2D>(10, 10, 2.0, 3.0, 4.0);
+  map->mapToWorldNoBounds(-10, -10, wx, wy);
+  EXPECT_DOUBLE_EQ(wx, -16.0);
+  EXPECT_DOUBLE_EQ(wy, -15.0);
+}
+
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4995  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot3 simulation in Gazebo |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Shifted bound checking in the clearArea function, so that the STVL layer can safely override and implement voxel clearing for `reset_distance` greater than costmap width.
* Added `mapToWorldNoBounds` function for STVL overrides.

## Description of documentation updates required from your changes

* N/A

## Description of how this change was tested

* Add an STVL layer to global costmap, and use a depthimage to pointcloud converter node for the turtlebot4 example provided.

* Launch the turtlebot3 simulation with nav2 and gazebo:

   ```bash
   ros2 launch nav2_bringup tb4_simulation_launch.py headless:=False
   ```
* View the costmap behaviour in RViz after setting the `reset_distance` to 1000:

   ```bash
  ros2 service call /local_costmap/clear_around_local_costmap nav2_msgs/srv/ClearCostmapAroundRobot "{reset_distance: 1000.0}"
   ```
   This would still clear the STVL voxels displayed on RViz.
   
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
