### PR TITLE
correctly initialize drive on heading action node

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
@@ -86,9 +86,6 @@ public:
    * @brief Function to perform some user-defined operation upon cancellation of the action
    */
   BT::NodeStatus on_cancelled() override;
-
-private:
-  bool initialized_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -24,8 +24,7 @@ DriveOnHeadingAction::DriveOnHeadingAction(
   const std::string & xml_tag_name,
   const std::string & action_name,
   const BT::NodeConfiguration & conf)
-: BtActionNode<nav2_msgs::action::DriveOnHeading>(xml_tag_name, action_name, conf),
-  initialized_(false)
+: BtActionNode<nav2_msgs::action::DriveOnHeading>(xml_tag_name, action_name, conf)
 {
 }
 
@@ -47,12 +46,11 @@ void DriveOnHeadingAction::initialize()
   goal_.speed = speed;
   goal_.time_allowance = rclcpp::Duration::from_seconds(time_allowance);
   goal_.disable_collision_checks = disable_collision_checks;
-  initialized_ = true;
 }
 
 void DriveOnHeadingAction::on_tick()
 {
-  if (!initialized_) {
+  if (!BT::isStatusActive(status())) {
     initialize();
   }
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | ubuntu |
| Robotic platform tested on | gazebo sim |
| Does this PR contain AI generated software? | no |

---

## Description of testing performed

linting and sim testing

## Description of contribution in a few bullet points
 In #3988 we moved initialization for BT nodes to a separate step. In #4744 this was modified. In #4887 goal-clearing between calls was introduced which is only compatible with the version from #4744 . However, somehow the drive on heading node was not adapted and still uses logic from #3988 .
 
 Thus, from the second goal on it will use an empty goal and become a no-op.
 
 5: [behavior_server-27] [INFO] [1743743039.305621213] [behavior_server]: Initial position: (16.49, -1.37), Current position: (16.49, -1.27), Distance: 0.10; cmd 0.10
5: [behavior_server-27] [INFO] [1743743039.305772278] [behavior_server]: drive_on_heading completed successfully
5: [behavior_server-27] [INFO] [1743743039.306973596] [behavior_server]: Running drive_on_heading
5: [behavior_server-27] [INFO] [1743743039.307092971] [behavior_server]: Initial position: (16.49, -1.27), Current position: (16.49, -1.27), Distance: 0.00; cmd 0.00
5: [behavior_server-27] [INFO] [1743743039.307198530] [behavior_server]: drive_on_heading completed successfully

This PR aligns the logic to #4744 . I could not find any other missed occurance.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

not needed

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
