### PR TITLE
Remove duplicate test

### DIFF
--- a/nav2_system_tests/src/system/CMakeLists.txt
+++ b/nav2_system_tests/src/system/CMakeLists.txt
@@ -40,20 +40,6 @@ ament_add_test(test_bt_navigator_with_dijkstra
     PLANNER=nav2_navfn_planner::NavfnPlanner
 )
 
-ament_add_test(test_bt_navigator_2
-  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_launch.py"
-  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-  TIMEOUT 180
-  ENV
-    TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-    BT_NAVIGATOR_XML=navigate_to_pose_w_replanning_and_recovery.xml
-    TESTER=nav_to_pose_tester_node.py
-    ASTAR=False
-    CONTROLLER=dwb_core::DWBLocalPlanner
-    PLANNER=nav2_navfn_planner::NavfnPlanner
-)
-
 ament_add_test(test_dynamic_obstacle
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_with_obstacle_launch.py"


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of testing performed
Github Actions

## Description of contribution in a few bullet points
- There remained a duplicate test with test_system_launch after Groot monitoring was removed, added in PR #1958 and removed in PR #2696 after which it was exactly the same as `test_bt_navigator_with_dijkstra`. This should reduce the time to run the nav2_system_tests

## Description of documentation updates required from your changes
N/A

## Description of how this change was tested
Github Actions

---

## Future work that may be required in bullet points
Further inspecting long-duration tests.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
