### PR TITLE
Fix lattice backward 180 deg issue

### DIFF
--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -494,7 +494,6 @@ void NodeLattice::getNeighbors(
   NodeVector & neighbors)
 {
   uint64_t index = 0;
-  float angle;
   bool backwards = false;
   NodePtr neighbor = nullptr;
   Coordinates initial_node_coords, motion_projection;
@@ -510,6 +509,24 @@ void NodeLattice::getNeighbors(
     motion_projection.y = this->pose.y + (end_pose._y / grid_resolution);
     motion_projection.theta = motion_primitives[i]->end_angle /*this is the ending angular bin*/;
 
+    // if i >= idx, then we're in a reversing primitive. In that situation,
+    // the orientation of the robot is mirrored from what it would otherwise
+    // appear to be from the motion primitives file. We want to take this into
+    // account in case the robot base footprint is asymmetric.
+    backwards = false;
+    if (i >= direction_change_index) {
+      backwards = true;
+      float opposite_heading_theta =
+        motion_projection.theta - (motion_table.num_angle_quantization / 2);
+      if (opposite_heading_theta < 0) {
+        opposite_heading_theta += motion_table.num_angle_quantization;
+      }
+      if (opposite_heading_theta > motion_table.num_angle_quantization) {
+        opposite_heading_theta -= motion_table.num_angle_quantization;
+      }
+      motion_projection.theta = opposite_heading_theta;
+    }
+
     index = NodeLattice::getIndex(
       static_cast<unsigned int>(motion_projection.x),
       static_cast<unsigned int>(motion_projection.y),
@@ -519,28 +536,12 @@ void NodeLattice::getNeighbors(
       // Cache the initial pose in case it was visited but valid
       // don't want to disrupt continuous coordinate expansion
       initial_node_coords = neighbor->pose;
-      // if i >= idx, then we're in a reversing primitive. In that situation,
-      // the orientation of the robot is mirrored from what it would otherwise
-      // appear to be from the motion primitives file. We want to take this into
-      // account in case the robot base footprint is asymmetric.
-      backwards = false;
-      angle = motion_projection.theta;
-      if (i >= direction_change_index) {
-        backwards = true;
-        angle = motion_projection.theta - (motion_table.num_angle_quantization / 2);
-        if (angle < 0) {
-          angle += motion_table.num_angle_quantization;
-        }
-        if (angle > motion_table.num_angle_quantization) {
-          angle -= motion_table.num_angle_quantization;
-        }
-      }
 
       neighbor->setPose(
         Coordinates(
           motion_projection.x,
           motion_projection.y,
-          angle));
+          motion_projection.theta));
 
       // Using a special isNodeValid API here, giving the motion primitive to use to
       // validity check the transition of the current node to the new node over


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/5133 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  gazebo simulation  |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This is a fix of an issue with backward flag in lattice node, which sometimes lead to 180 degree plan error. See details in the [issue](https://github.com/ros-navigation/navigation2/issues/5133)

## Description of documentation updates required from your changes

* No documentation updates required as it is a bug-fix

## Description of how this change was tested

* I run existing unit tests for smac planner

---

## Future work that may be required in bullet points

<!--
* I think one need to update lattice node index logic and to get rid of (or use in into a single place at least) backward heading angle logic, but this improvement need deep refactoring and looks risky. 
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
