### PR TITLE
Show error if inflation radius is smaller than circumscribed radius

### DIFF
--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -96,6 +96,19 @@ float CostCritic::findCircumscribedCost(
     inflation_layer_name_);
   if (inflation_layer != nullptr) {
     const double resolution = costmap->getCostmap()->getResolution();
+    double inflation_radius = inflation_layer->getInflationRadius();
+    if (inflation_radius < circum_radius) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("computeCircumscribedCost"),
+        "The inflation radius (%f) is smaller than the circumscribed radius (%f) "
+        "If this is an SE2-collision checking plugin, it cannot use costmap potential "
+        "field to speed up collision checking by only checking the full footprint "
+        "when robot is within possibly-inscribed radius of an obstacle. This may "
+        "significantly slow down planning times!", 
+        inflation_radius, circum_radius);
+      result = 0.0;
+      return result;
+    }
     result = inflation_layer->computeCost(circum_radius / resolution);
   } else {
     RCLCPP_WARN(

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -104,7 +104,7 @@ float CostCritic::findCircumscribedCost(
         "If this is an SE2-collision checking plugin, it cannot use costmap potential "
         "field to speed up collision checking by only checking the full footprint "
         "when robot is within possibly-inscribed radius of an obstacle. This may "
-        "significantly slow down planning times!", 
+        "significantly slow down planning times!",
         inflation_radius, circum_radius);
       result = 0.0;
       return result;

--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -82,6 +82,19 @@ inline double findCircumscribedCost(std::shared_ptr<nav2_costmap_2d::Costmap2DRO
   if (inflation_layer != nullptr) {
     double circum_radius = costmap->getLayeredCostmap()->getCircumscribedRadius();
     double resolution = costmap->getCostmap()->getResolution();
+    double inflation_radius = inflation_layer->getInflationRadius();
+    if (inflation_radius < circum_radius) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("computeCircumscribedCost"),
+        "The inflation radius (%f) is smaller than the circumscribed radius (%f) "
+        "If this is an SE2-collision checking plugin, it cannot use costmap potential "
+        "field to speed up collision checking by only checking the full footprint "
+        "when robot is within possibly-inscribed radius of an obstacle. This may "
+        "significantly slow down planning times!", 
+        inflation_radius, circum_radius);
+      result = 0.0;
+      return result;
+    }
     result = static_cast<double>(inflation_layer->computeCost(circum_radius / resolution));
   } else {
     RCLCPP_WARN(

--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -90,7 +90,7 @@ inline double findCircumscribedCost(std::shared_ptr<nav2_costmap_2d::Costmap2DRO
         "If this is an SE2-collision checking plugin, it cannot use costmap potential "
         "field to speed up collision checking by only checking the full footprint "
         "when robot is within possibly-inscribed radius of an obstacle. This may "
-        "significantly slow down planning times!", 
+        "significantly slow down planning times!",
         inflation_radius, circum_radius);
       result = 0.0;
       return result;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/4271 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Custom simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Add Error message if inflation radius is smaller than the circumscribed radius


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested


* Set the inflation radius smaller than the circumscribed radius and verify that the error is triggered


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
