### PR TITLE
Backward docking without sensors 

### DIFF
--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -201,7 +201,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller_frequency         | Control frequency (Hz) for vision-control loop          | double | 50.0      |
 | initial_perception_timeout   | Timeout (s) to wait to obtain initial perception of the dock | double | 5.0   |
 | wait_charge_timeout          | Timeout (s) to wait to see if charging starts after docking  | double | 5.0  |
-| dock_approach_timeout        | timeout (s) to attempt vision-control approach loop    | double |  30.0      |
+| dock_approach_timeout        | Timeout (s) to attempt vision-control approach loop    | double |  30.0      |
+| rotate_to_dock_timeout       | Timeout (s) to attempt rotate-to-dock loop             | double |  10.0      |
 | undock_linear_tolerance      | Tolerance (m) to exit the undocking control loop at staging pose    | double |  0.05      |
 | undock_angular_tolerance     | Angular tolerance (rad) to exit undocking loop at staging pose    | double |  0.05      |
 | max_retries        | Maximum number of retries to attempt    | int |  3      |

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -207,7 +207,6 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | max_retries        | Maximum number of retries to attempt    | int |  3      |
 | base_frame        | Robot's base frame for control law   | string |  "base_link"      |
 | fixed_frame        | Fixed frame to use, recommended to be a smooth odometry frame **not** map   | string |  "odom"      |
-| backward_blind        | Initial forward detection, then dock in reverse | bool |  false      |
 | odom_topic        | The topic to use for the odometry data | string |  "odom"      |
 | rotation_angular_tolerance  | Angular tolerance (rad) to exit the rotation loop when backward_blind is enable | double | 0.05      |
 | dock_prestaging_tolerance  |  L2 distance in X,Y,Theta from the staging pose to bypass navigation | double |  0.5      |
@@ -256,6 +255,7 @@ Note: `dock_plugins` and either `docks` or `dock_database` are required.
 | staging_x_offset        | Staging pose offset forward (negative) of dock pose (m)    | double |  -0.7    |
 | staging_yaw_offset        | Staging pose angle relative to dock pose (rad)    | double |  0.0    |
 | dock_direction        | Whether the robot is docking with the dock forward or backward in motion | string |  "forward"  or "backward"    |
+| backward_blind        | Initial forward detection, then dock in reverse | bool |  false      |
 
 Note: The external detection rotation angles are setup to work out of the box with Apriltags detectors in `image_proc` and `isaac_ros`.
 

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -203,11 +203,13 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | wait_charge_timeout          | Timeout (s) to wait to see if charging starts after docking  | double | 5.0  |
 | dock_approach_timeout        | timeout (s) to attempt vision-control approach loop    | double |  30.0      |
 | undock_linear_tolerance      | Tolerance (m) to exit the undocking control loop at staging pose    | double |  0.05      |
-| undock_angular_tolerance     | Angular Tolerance (rad) to exist undocking loop at staging pose    | double |  0.05      |
+| undock_angular_tolerance     | Angular tolerance (rad) to exit undocking loop at staging pose    | double |  0.05      |
 | max_retries        | Maximum number of retries to attempt    | int |  3      |
 | base_frame        | Robot's base frame for control law   | string |  "base_link"      |
 | fixed_frame        | Fixed frame to use, recommended to be a smooth odometry frame **not** map   | string |  "odom"      |
 | backward_blind        | Initial forward detection, then dock in reverse | bool |  false      |
+| odom_topic        | The topic to use for the odometry data | string |  "odom"      |
+| rotation_angular_tolerance  | Angular tolerance (rad) to exit the rotation loop when backward_blind is enable | double | 0.05      |
 | dock_prestaging_tolerance  |  L2 distance in X,Y,Theta from the staging pose to bypass navigation | double |  0.5      |
 | dock_plugins  | A set of dock plugins to load | vector<string> |  N/A      |
 | dock_database  |  The filepath to the dock database to use for this environment | string |  N/A  |
@@ -221,6 +223,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.v_linear_max | Maximum linear velocity (m/s) | double | 0.25    |
 | controller.v_angular_max | Maximum angular velocity (rad/s) produced by the control law | double | 0.75    |
 | controller.slowdown_radius | Radius (m) around the goal pose in which the robot will start to slow down | double | 0.25     |
+| controller.rotate_to_heading_angular_vel | Angular velocity (rad/s) to rotate to the goal heading when backward_blind is enable | double | 1.0    |
+| controller.rotate_to_heading_max_angular_accel | Maximum angular acceleration (rad/s^2) to rotate to the goal heading when backward_blind is enable | double | 3.2    |
 | controller.use_collision_detection | Whether to use collision detection to avoid obstacles | bool | true     |
 | controller.costmap_topic | The topic to use for the costmap | string | "local_costmap/costmap_raw"     |
 | controller.footprint_topic | The topic to use for the robot's footprint | string | "local_costmap/published_footprint"     |

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -209,7 +209,7 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | base_frame        | Robot's base frame for control law   | string |  "base_link"      |
 | fixed_frame        | Fixed frame to use, recommended to be a smooth odometry frame **not** map   | string |  "odom"      |
 | odom_topic        | The topic to use for the odometry data | string |  "odom"      |
-| rotation_angular_tolerance  | Angular tolerance (rad) to exit the rotation loop when backward_blind is enable | double | 0.05      |
+| rotation_angular_tolerance  | Angular tolerance (rad) to exit the rotation loop when rotate_to_dock is enabled | double | 0.05      |
 | dock_prestaging_tolerance  |  L2 distance in X,Y,Theta from the staging pose to bypass navigation | double |  0.5      |
 | dock_plugins  | A set of dock plugins to load | vector<string> |  N/A      |
 | dock_database  |  The filepath to the dock database to use for this environment | string |  N/A  |
@@ -223,8 +223,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.v_linear_max | Maximum linear velocity (m/s) | double | 0.25    |
 | controller.v_angular_max | Maximum angular velocity (rad/s) produced by the control law | double | 0.75    |
 | controller.slowdown_radius | Radius (m) around the goal pose in which the robot will start to slow down | double | 0.25     |
-| controller.rotate_to_heading_angular_vel | Angular velocity (rad/s) to rotate to the goal heading when backward_blind is enable | double | 1.0    |
-| controller.rotate_to_heading_max_angular_accel | Maximum angular acceleration (rad/s^2) to rotate to the goal heading when backward_blind is enable | double | 3.2    |
+| controller.rotate_to_heading_angular_vel | Angular velocity (rad/s) to rotate to the goal heading when rotate_to_dock is enabled | double | 1.0    |
+| controller.rotate_to_heading_max_angular_accel | Maximum angular acceleration (rad/s^2) to rotate to the goal heading when rotate_to_dock is enabled | double | 3.2    |
 | controller.use_collision_detection | Whether to use collision detection to avoid obstacles | bool | true     |
 | controller.costmap_topic | The topic to use for the costmap | string | "local_costmap/costmap_raw"     |
 | controller.footprint_topic | The topic to use for the robot's footprint | string | "local_costmap/published_footprint"     |
@@ -256,7 +256,7 @@ Note: `dock_plugins` and either `docks` or `dock_database` are required.
 | staging_x_offset        | Staging pose offset forward (negative) of dock pose (m)    | double |  -0.7    |
 | staging_yaw_offset        | Staging pose angle relative to dock pose (rad)    | double |  0.0    |
 | dock_direction        | Whether the robot is docking with the dock forward or backward in motion | string |  "forward"  or "backward"    |
-| backward_blind        | Initial forward detection, then dock in reverse | bool |  false      |
+| rotate_to_dock        | Rotate the robot 180º before docking | bool |  false      |
 
 Note: The external detection rotation angles are setup to work out of the box with Apriltags detectors in `image_proc` and `isaac_ros`.
 

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -256,7 +256,7 @@ Note: `dock_plugins` and either `docks` or `dock_database` are required.
 | staging_x_offset        | Staging pose offset forward (negative) of dock pose (m)    | double |  -0.7    |
 | staging_yaw_offset        | Staging pose angle relative to dock pose (rad)    | double |  0.0    |
 | dock_direction        | Whether the robot is docking with the dock forward or backward in motion | string |  "forward"  or "backward"    |
-| rotate_to_dock        | Rotate the robot 180º before docking | bool |  false      |
+| rotate_to_dock        | Enables backward docking without requiring a sensor for detection during the final approach. When enabled, the robot approaches the staging pose facing forward with sensor coverage for dock detection; after detection, it rotates and backs into the dock using only the initially detected pose for dead reckoning. | bool |  false      |
 
 Note: The external detection rotation angles are setup to work out of the box with Apriltags detectors in `image_proc` and `isaac_ros`.
 

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -207,6 +207,7 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | max_retries        | Maximum number of retries to attempt    | int |  3      |
 | base_frame        | Robot's base frame for control law   | string |  "base_link"      |
 | fixed_frame        | Fixed frame to use, recommended to be a smooth odometry frame **not** map   | string |  "odom"      |
+| backward_blind        | Initial forward detection, then dock in reverse | bool |  false      |
 | dock_prestaging_tolerance  |  L2 distance in X,Y,Theta from the staging pose to bypass navigation | double |  0.5      |
 | dock_plugins  | A set of dock plugins to load | vector<string> |  N/A      |
 | dock_database  |  The filepath to the dock database to use for this environment | string |  N/A  |

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
@@ -67,6 +67,18 @@ public:
     const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::Twist & cmd, bool is_docking,
     bool backward = false);
 
+  /**
+   * @brief Perform a command for in-place rotation.
+   * @param angular_distance_to_heading Angular distance to goal
+   * @param current_velocity Current angular velocity
+   * @param dt Control loop duration [s]
+   * @returns TwistStamped command.
+   */
+  geometry_msgs::msg::Twist computeRotateToHeadingCommand(
+    const double & angular_distance_to_heading,
+    const geometry_msgs::msg::Twist & current_velocity,
+    const double & dt);
+
 protected:
   /**
    * @brief Check if a trajectory is collision free.
@@ -110,6 +122,7 @@ protected:
   std::unique_ptr<nav2_graceful_controller::SmoothControlLaw> control_law_;
   double k_phi_, k_delta_, beta_, lambda_;
   double slowdown_radius_, v_linear_min_, v_linear_max_, v_angular_max_;
+  double rotate_to_heading_angular_vel_, rotate_to_heading_max_angular_accel_;
 
   // The trajectory of the robot while dock / undock for visualization / debug purposes
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
@@ -69,10 +69,10 @@ public:
 
   /**
    * @brief Perform a command for in-place rotation.
-   * @param angular_distance_to_heading Angular distance to goal
-   * @param current_velocity Current angular velocity
-   * @param dt Control loop duration [s]
-   * @returns TwistStamped command.
+   * @param angular_distance_to_heading Angular distance to goal.
+   * @param current_velocity Current angular velocity.
+   * @param dt Control loop duration [s].
+   * @returns TwistStamped command for in-place rotation.
    */
   geometry_msgs::msg::Twist computeRotateToHeadingCommand(
     const double & angular_distance_to_heading,

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -27,6 +27,7 @@
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/simple_action_server.hpp"
 #include "nav2_util/twist_publisher.hpp"
+#include "nav_2d_utils/odom_subscriber.hpp"
 #include "opennav_docking/controller.hpp"
 #include "opennav_docking/utils.hpp"
 #include "opennav_docking/types.hpp"
@@ -93,6 +94,12 @@ public:
    *          any internal error, will throw.
    */
   bool approachDock(Dock * dock, geometry_msgs::msg::PoseStamped & dock_pose, bool backward);
+
+  /**
+   * @brief Perform a pure rotation to dock orientation.
+   * @param dock_pose The target pose that will be used to rotate.
+   */
+  void rotateToDock(const geometry_msgs::msg::PoseStamped & dock_pose);
 
   /**
    * @brief Wait for charging to begin.
@@ -248,11 +255,16 @@ protected:
   std::optional<bool> dock_backwards_;
   // The tolerance to the dock's staging pose not requiring navigation
   double dock_prestaging_tolerance_;
+  // Enable docking with initial detection only, without any update
+  bool backward_blind_;
+  // Angle at which robot can stop initial rotation
+  double backward_rotation_tolerance_;
 
   // This is a class member so it can be accessed in publish feedback
   rclcpp::Time action_start_time_;
 
   std::unique_ptr<nav2_util::TwistPublisher> vel_publisher_;
+  std::unique_ptr<nav_2d_utils::OdomSubscriber> odom_sub_;
   std::unique_ptr<DockingActionServer> docking_action_server_;
   std::unique_ptr<UndockingActionServer> undocking_action_server_;
 

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -257,8 +257,8 @@ protected:
   double dock_prestaging_tolerance_;
   // Enable docking with initial detection only, without any update
   bool backward_blind_;
-  // Angle at which robot can stop initial rotation
-  double backward_rotation_tolerance_;
+  // Angular tolerance to exit the rotation loop when backward_blind is enable
+  double rotation_angular_tolerance_;
 
   // This is a class member so it can be accessed in publish feedback
   rclcpp::Time action_start_time_;

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -243,6 +243,8 @@ protected:
   double wait_charge_timeout_;
   // Timeout to approach into the dock and reset its approach is retrying
   double dock_approach_timeout_;
+  // Timeout to rotate to the dock
+  double rotate_to_dock_timeout_;
   // When undocking, these are the tolerances for arriving at the staging pose
   double undock_linear_tolerance_, undock_angular_tolerance_;
   // Maximum number of times the robot will return to staging pose and retry docking
@@ -255,8 +257,6 @@ protected:
   std::optional<bool> dock_backwards_;
   // The tolerance to the dock's staging pose not requiring navigation
   double dock_prestaging_tolerance_;
-  // Enable docking with initial detection only, without any update
-  bool backward_blind_;
   // Angular tolerance to exit the rotation loop when backward_blind is enable
   double rotation_angular_tolerance_;
 

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -257,7 +257,7 @@ protected:
   std::optional<bool> dock_backwards_;
   // The tolerance to the dock's staging pose not requiring navigation
   double dock_prestaging_tolerance_;
-  // Angular tolerance to exit the rotation loop when backward_blind is enable
+  // Angular tolerance to exit the rotation loop when rotate_to_dock is enabled
   double rotation_angular_tolerance_;
 
   // This is a class member so it can be accessed in publish feedback

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -139,6 +139,14 @@ geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
     current_velocity.angular.z + rotate_to_heading_max_angular_accel_ * dt;
   cmd_vel.angular.z =
     std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+
+  // Check if we need to slow down to avoid overshooting
+  double max_vel_to_stop =
+    std::sqrt(2 * rotate_to_heading_max_angular_accel_ * fabs(angular_distance_to_heading));
+  if (fabs(cmd_vel.angular.z) > max_vel_to_stop) {
+    cmd_vel.angular.z = sign * max_vel_to_stop;
+  }
+
   return cmd_vel;
 }
 

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -78,9 +78,6 @@ Controller::Controller(
   node->get_parameter("controller.v_linear_max", v_linear_max_);
   node->get_parameter("controller.v_angular_max", v_angular_max_);
   node->get_parameter("controller.slowdown_radius", slowdown_radius_);
-  node->get_parameter("controller.rotate_to_heading_angular_vel", rotate_to_heading_angular_vel_);
-  node->get_parameter("controller.rotate_to_heading_max_angular_accel",
-    rotate_to_heading_max_angular_accel_);
   control_law_ = std::make_unique<nav2_graceful_controller::SmoothControlLaw>(
     k_phi_, k_delta_, beta_, lambda_, slowdown_radius_, v_linear_min_, v_linear_max_,
     v_angular_max_);
@@ -101,6 +98,10 @@ Controller::Controller(
     node->get_parameter("controller.dock_collision_threshold", dock_collision_threshold_);
     configureCollisionChecker(node, costmap_topic, footprint_topic, transform_tolerance_);
   }
+
+  node->get_parameter("controller.rotate_to_heading_angular_vel", rotate_to_heading_angular_vel_);
+  node->get_parameter("controller.rotate_to_heading_max_angular_accel",
+    rotate_to_heading_max_angular_accel_);
 
   trajectory_pub_ =
     node->create_publisher<nav_msgs::msg::Path>("docking_trajectory", 1);

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -130,6 +130,8 @@ geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
   const geometry_msgs::msg::Twist & current_velocity,
   const double & dt)
 {
+  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
   geometry_msgs::msg::Twist cmd_vel;
   const double sign = angular_distance_to_heading > 0.0 ? 1.0 : -1.0;
   const double angular_vel = sign * rotate_to_heading_angular_vel_;
@@ -153,6 +155,8 @@ geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
 bool Controller::isTrajectoryCollisionFree(
   const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward)
 {
+  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
   // Visualization of the trajectory
   nav_msgs::msg::Path trajectory;
   trajectory.header.frame_id = base_frame_;

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -130,8 +130,6 @@ geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
   const geometry_msgs::msg::Twist & current_velocity,
   const double & dt)
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
-
   geometry_msgs::msg::Twist cmd_vel;
   const double sign = angular_distance_to_heading > 0.0 ? 1.0 : -1.0;
   const double angular_vel = sign * rotate_to_heading_angular_vel_;
@@ -155,8 +153,6 @@ geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
 bool Controller::isTrajectoryCollisionFree(
   const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward)
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
-
   // Visualization of the trajectory
   nav_msgs::msg::Path trajectory;
   trajectory.header.frame_id = base_frame_;

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -509,7 +509,7 @@ bool DockingServer::approachDock(
     }
 
     // Update perception
-    if (!dock->plugin->shouldRotateToDock() && !dock->plugin->getRefinedPose(dock_pose, dock->id)) {
+    if (!dock->plugin->getRefinedPose(dock_pose, dock->id) && !dock->plugin->shouldRotateToDock()) {
       throw opennav_docking_core::FailedToDetectDock("Failed dock detection");
     }
 

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -753,14 +753,13 @@ void DockingServer::undockRobot()
           command->twist, staging_pose, undock_linear_tolerance_, undock_angular_tolerance_, false,
           !dock_backward))
       {
-        RCLCPP_INFO(get_logger(), "Robot has reached staging pose");
-
         // Perform a 180º to the original staging pose
         if (dock->shouldRotateToDock()) {
           rotateToDock(staging_pose);
         }
 
         // Have reached staging_pose
+        RCLCPP_INFO(get_logger(), "Robot has reached staging pose");
         vel_publisher_->publish(std::move(command));
         if (!dock->isCharger() || dock->hasStoppedCharging()) {
           RCLCPP_INFO(get_logger(), "Robot has undocked!");

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -306,8 +306,8 @@ void DockingServer::dockRobot()
     rclcpp::Time dock_contact_time;
     while (rclcpp::ok()) {
       try {
-        // Perform pure rotation to dock orientation
-        if (dock->plugin->isBackwardBlind()) {
+        // Perform a 180º to face away from the dock if needed
+        if (dock->plugin->shouldRotateToDock()) {
           rotateToDock(dock_pose);
         }
         // Approach the dock using control law
@@ -501,7 +501,7 @@ bool DockingServer::approachDock(
     }
 
     // Update perception
-    if (!dock->plugin->isBackwardBlind() && !dock->plugin->getRefinedPose(dock_pose, dock->id)) {
+    if (!dock->plugin->shouldRotateToDock() && !dock->plugin->getRefinedPose(dock_pose, dock->id)) {
       throw opennav_docking_core::FailedToDetectDock("Failed dock detection");
     }
 

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -471,7 +471,7 @@ void DockingServer::rotateToDock(const geometry_msgs::msg::PoseStamped & dock_po
     vel_publisher_->publish(std::move(command));
 
     if (this->now() - start > timeout) {
-      throw opennav_docking_core::FailedToCharge("Timed out rotating to dock");
+      throw opennav_docking_core::FailedToControl("Timed out rotating to dock");
     }
 
     loop_rate.sleep();

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -83,7 +83,7 @@ void SimpleChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
   nav2_util::declare_parameter_if_not_declared(
-    node_, name + ".backward_blind", rclcpp::ParameterValue(false));
+    node_, name + ".rotate_to_dock", rclcpp::ParameterValue(false));
 
   node_->get_parameter(name + ".use_battery_status", use_battery_status_);
   node_->get_parameter(name + ".use_external_detection_pose", use_external_detection_pose_);
@@ -112,9 +112,9 @@ void SimpleChargingDock::configure(
     throw std::runtime_error{"Dock direction is not valid. Valid options are: forward or backward"};
   }
 
-  node_->get_parameter(name + ".backward_blind", backward_blind_);
-  if (backward_blind_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
-    throw std::runtime_error{"Parameter backward_blind is enabled but dock direction is not "
+  node_->get_parameter(name + ".rotate_to_dock", rotate_to_dock_);
+  if (rotate_to_dock_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
+    throw std::runtime_error{"Parameter rotate_to_dock is enabled but dock direction is not "
             "backward. Please set dock direction to backward."};
   }
 

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -79,7 +79,7 @@ void SimpleChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".staging_yaw_offset", rclcpp::ParameterValue(0.0));
 
-  // Direction of docking and backward blind
+  // Direction of docking and if we should rotate to dock
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
   nav2_util::declare_parameter_if_not_declared(

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -79,9 +79,11 @@ void SimpleChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".staging_yaw_offset", rclcpp::ParameterValue(0.0));
 
-  // Direction of docking
+  // Direction of docking and backward blind
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
+  nav2_util::declare_parameter_if_not_declared(
+    node_, name + ".backward_blind", rclcpp::ParameterValue(false));
 
   node_->get_parameter(name + ".use_battery_status", use_battery_status_);
   node_->get_parameter(name + ".use_external_detection_pose", use_external_detection_pose_);
@@ -108,6 +110,12 @@ void SimpleChargingDock::configure(
   dock_direction_ = utils::getDockDirectionFromString(dock_direction);
   if (dock_direction_ == opennav_docking_core::DockDirection::UNKNOWN) {
     throw std::runtime_error{"Dock direction is not valid. Valid options are: forward or backward"};
+  }
+
+  node_->get_parameter(name + ".backward_blind", backward_blind_);
+  if (backward_blind_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
+    throw std::runtime_error{"Parameter backward_blind is enabled but dock direction is not "
+            "backward. Please set dock direction to backward."};
   }
 
   // Setup filter

--- a/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
@@ -74,7 +74,7 @@ void SimpleNonChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
   nav2_util::declare_parameter_if_not_declared(
-    node_, name + ".backward_blind", rclcpp::ParameterValue(false));
+    node_, name + ".rotate_to_dock", rclcpp::ParameterValue(false));
 
   node_->get_parameter(name + ".use_external_detection_pose", use_external_detection_pose_);
   node_->get_parameter(name + ".external_detection_timeout", external_detection_timeout_);
@@ -101,9 +101,9 @@ void SimpleNonChargingDock::configure(
     throw std::runtime_error{"Dock direction is not valid. Valid options are: forward or backward"};
   }
 
-  node_->get_parameter(name + ".backward_blind", backward_blind_);
-  if (backward_blind_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
-    throw std::runtime_error{"Parameter backward_blind is enabled but dock direction is not "
+  node_->get_parameter(name + ".rotate_to_dock", rotate_to_dock_);
+  if (rotate_to_dock_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
+    throw std::runtime_error{"Parameter rotate_to_dock is enabled but dock direction is not "
             "backward. Please set dock direction to backward."};
   }
 

--- a/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
@@ -70,7 +70,7 @@ void SimpleNonChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".staging_yaw_offset", rclcpp::ParameterValue(0.0));
 
-  // Direction of docking and backward blind
+  // Direction of docking and if we should rotate to dock
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
   nav2_util::declare_parameter_if_not_declared(

--- a/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
@@ -70,9 +70,11 @@ void SimpleNonChargingDock::configure(
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".staging_yaw_offset", rclcpp::ParameterValue(0.0));
 
-  // Direction of docking
+  // Direction of docking and backward blind
   nav2_util::declare_parameter_if_not_declared(
     node_, name + ".dock_direction", rclcpp::ParameterValue(std::string("forward")));
+  nav2_util::declare_parameter_if_not_declared(
+    node_, name + ".backward_blind", rclcpp::ParameterValue(false));
 
   node_->get_parameter(name + ".use_external_detection_pose", use_external_detection_pose_);
   node_->get_parameter(name + ".external_detection_timeout", external_detection_timeout_);
@@ -97,6 +99,12 @@ void SimpleNonChargingDock::configure(
   dock_direction_ = utils::getDockDirectionFromString(dock_direction);
   if (dock_direction_ == opennav_docking_core::DockDirection::UNKNOWN) {
     throw std::runtime_error{"Dock direction is not valid. Valid options are: forward or backward"};
+  }
+
+  node_->get_parameter(name + ".backward_blind", backward_blind_);
+  if (backward_blind_ && dock_direction_ != opennav_docking_core::DockDirection::BACKWARD) {
+    throw std::runtime_error{"Parameter backward_blind is enabled but dock direction is not "
+            "backward. Please set dock direction to backward."};
   }
 
   // Setup filter

--- a/nav2_docking/opennav_docking/test/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/test/CMakeLists.txt
@@ -128,3 +128,9 @@ ament_add_pytest_test(test_docking_server_backward test_docking_server.py
   NON_CHARGING_DOCK=False
   BACKWARD=True
 )
+
+ament_add_pytest_test(test_docking_server_backward_blind test_docking_server.py
+  ENV
+  NON_CHARGING_DOCK=False
+  BACKWARD_BLIND=True
+)

--- a/nav2_docking/opennav_docking/test/docking_params.yaml
+++ b/nav2_docking/opennav_docking/test/docking_params.yaml
@@ -1,7 +1,6 @@
 docking_server:
   ros__parameters:
     wait_charge_timeout: 1.0
-    backward_blind: False
     controller:
       use_collision_detection: False
       transform_tolerance: 0.5
@@ -10,6 +9,7 @@ docking_server:
       plugin: opennav_docking::SimpleChargingDock
       use_battery_status: True
       dock_direction: forward
+      backward_blind: False
       staging_yaw_offset: 0.0
     docks: [test_dock]
     test_dock:

--- a/nav2_docking/opennav_docking/test/docking_params.yaml
+++ b/nav2_docking/opennav_docking/test/docking_params.yaml
@@ -1,6 +1,7 @@
 docking_server:
   ros__parameters:
     wait_charge_timeout: 1.0
+    backward_blind: False
     controller:
       use_collision_detection: False
       transform_tolerance: 0.5

--- a/nav2_docking/opennav_docking/test/docking_params.yaml
+++ b/nav2_docking/opennav_docking/test/docking_params.yaml
@@ -9,7 +9,7 @@ docking_server:
       plugin: opennav_docking::SimpleChargingDock
       use_battery_status: True
       dock_direction: forward
-      backward_blind: False
+      rotate_to_dock: False
       staging_yaw_offset: 0.0
     docks: [test_dock]
     test_dock:

--- a/nav2_docking/opennav_docking/test/test_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_controller.cpp
@@ -603,7 +603,7 @@ TEST(ControllerTests, RotateToHeading) {
   cmd_vel =
     controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
   EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
-  EXPECT_DOUBLE_EQ(cmd_vel.angular.z, -rotate_to_heading_max_angular_accel * dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.angular.z, 0.0);
 
   controller.reset();
 }

--- a/nav2_docking/opennav_docking/test/test_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_controller.cpp
@@ -229,7 +229,9 @@ TEST(ControllerTests, DynamicParameters) {
       rclcpp::Parameter("controller.slowdown_radius", 8.0),
       rclcpp::Parameter("controller.projection_time", 9.0),
       rclcpp::Parameter("controller.simulation_time_step", 10.0),
-      rclcpp::Parameter("controller.dock_collision_threshold", 11.0)});
+      rclcpp::Parameter("controller.dock_collision_threshold", 11.0),
+      rclcpp::Parameter("controller.rotate_to_heading_angular_vel", 12.0),
+      rclcpp::Parameter("controller.rotate_to_heading_max_angular_accel", 13.0)});
 
   // Spin
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
@@ -246,6 +248,9 @@ TEST(ControllerTests, DynamicParameters) {
   EXPECT_EQ(node->get_parameter("controller.projection_time").as_double(), 9.0);
   EXPECT_EQ(node->get_parameter("controller.simulation_time_step").as_double(), 10.0);
   EXPECT_EQ(node->get_parameter("controller.dock_collision_threshold").as_double(), 11.0);
+  EXPECT_EQ(node->get_parameter("controller.rotate_to_heading_angular_vel").as_double(), 12.0);
+  EXPECT_EQ(
+    node->get_parameter("controller.rotate_to_heading_max_angular_accel").as_double(), 13.0);
 }
 
 TEST(ControllerTests, TFException)
@@ -537,6 +542,71 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
   collision_tester->deactivate();
 }
 
+TEST(ControllerTests, RotateToHeading) {
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
+
+  float rotate_to_heading_angular_vel = 1.0;
+  float rotate_to_heading_max_angular_accel = 3.2;
+  nav2_util::declare_parameter_if_not_declared(
+    node, "controller.rotate_to_heading_angular_vel",
+      rclcpp::ParameterValue(rotate_to_heading_angular_vel));
+  nav2_util::declare_parameter_if_not_declared(
+    node, "controller.rotate_to_heading_max_angular_accel",
+      rclcpp::ParameterValue(rotate_to_heading_max_angular_accel));
+
+  auto controller = std::make_unique<opennav_docking::Controller>(
+    node, nullptr, "test_base_frame", "test_base_frame");
+
+  geometry_msgs::msg::Twist current_velocity;
+  double angular_distance_to_heading;
+  double dt = 0.1;
+
+  // Case 1: Positive angular distance, within feasible range
+  angular_distance_to_heading = 0.5;
+  current_velocity.angular.z = 0.1;
+  auto cmd_vel =
+    controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_GE(cmd_vel.angular.z, 0.0);
+  EXPECT_LE(cmd_vel.angular.z, rotate_to_heading_angular_vel);
+
+  // Case 2: Negative angular distance, within feasible range
+  angular_distance_to_heading = -0.5;
+  current_velocity.angular.z = -0.1;
+  cmd_vel =
+    controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_LE(cmd_vel.angular.z, 0.0);
+  EXPECT_GE(cmd_vel.angular.z, -rotate_to_heading_angular_vel);
+
+  // Case 3: Positive angular distance, exceeding max feasible speed
+  angular_distance_to_heading = 1.0;
+  current_velocity.angular.z = 0.5;
+  cmd_vel =
+    controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(cmd_vel.angular.z,
+      current_velocity.angular.z + rotate_to_heading_max_angular_accel * dt);
+
+  // Case 4: Negative angular distance, exceeding max feasible speed
+  angular_distance_to_heading = -1.0;
+  current_velocity.angular.z = -0.5;
+  cmd_vel =
+    controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(cmd_vel.angular.z,
+      current_velocity.angular.z - rotate_to_heading_max_angular_accel * dt);
+
+  // Case 5: Zero angular distance
+  angular_distance_to_heading = 0.0;
+  current_velocity.angular.z = 0.0;
+  cmd_vel =
+    controller->computeRotateToHeadingCommand(angular_distance_to_heading, current_velocity, dt);
+  EXPECT_DOUBLE_EQ(cmd_vel.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(cmd_vel.angular.z, -rotate_to_heading_max_angular_accel * dt);
+
+  controller.reset();
+}
 
 }  // namespace opennav_docking
 

--- a/nav2_docking/opennav_docking/test/test_docking_server.py
+++ b/nav2_docking/opennav_docking/test/test_docking_server.py
@@ -69,7 +69,7 @@ def generate_test_description() -> LaunchDescription:
 
     if os.getenv('BACKWARD_BLIND') == 'True':
         param_substitutions.update({'dock_direction': 'backward'})
-        param_substitutions.update({'backward_blind': 'True'})
+        param_substitutions.update({'rotate_to_dock': 'True'})
 
     configured_params = RewrittenYaml(
         source_file=params_file,

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -247,13 +247,11 @@ TEST(DockingServerTests, testDynamicParams)
       rclcpp::Parameter("undock_angular_tolerance", 0.125),
       rclcpp::Parameter("base_frame", std::string("hi")),
       rclcpp::Parameter("fixed_frame", std::string("hi")),
+      rclcpp::Parameter("max_retries", 7),
       rclcpp::Parameter("backward_blind", true),
-      rclcpp::Parameter("dock_backwards", true),
-      rclcpp::Parameter("max_retries", 7)});
+      rclcpp::Parameter("rotation_angular_tolerance", 0.42)});
 
-  rclcpp::spin_until_future_complete(
-    node->get_node_base_interface(),
-    results);
+  rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
 
   EXPECT_EQ(node->get_parameter("controller_frequency").as_double(), 0.2);
   EXPECT_EQ(node->get_parameter("initial_perception_timeout").as_double(), 1.0);
@@ -264,7 +262,7 @@ TEST(DockingServerTests, testDynamicParams)
   EXPECT_EQ(node->get_parameter("fixed_frame").as_string(), std::string("hi"));
   EXPECT_EQ(node->get_parameter("max_retries").as_int(), 7);
   EXPECT_EQ(node->get_parameter("backward_blind").as_bool(), true);
-  EXPECT_EQ(node->get_parameter("dock_backwards").as_bool(), true);
+  EXPECT_EQ(node->get_parameter("rotation_angular_tolerance").as_double(), 0.42);
 
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -248,7 +248,6 @@ TEST(DockingServerTests, testDynamicParams)
       rclcpp::Parameter("base_frame", std::string("hi")),
       rclcpp::Parameter("fixed_frame", std::string("hi")),
       rclcpp::Parameter("max_retries", 7),
-      rclcpp::Parameter("backward_blind", true),
       rclcpp::Parameter("rotation_angular_tolerance", 0.42)});
 
   rclcpp::spin_until_future_complete(node->get_node_base_interface(), results);
@@ -261,7 +260,6 @@ TEST(DockingServerTests, testDynamicParams)
   EXPECT_EQ(node->get_parameter("base_frame").as_string(), std::string("hi"));
   EXPECT_EQ(node->get_parameter("fixed_frame").as_string(), std::string("hi"));
   EXPECT_EQ(node->get_parameter("max_retries").as_int(), 7);
-  EXPECT_EQ(node->get_parameter("backward_blind").as_bool(), true);
   EXPECT_EQ(node->get_parameter("rotation_angular_tolerance").as_double(), 0.42);
 
   node->on_deactivate(rclcpp_lifecycle::State());

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -247,6 +247,8 @@ TEST(DockingServerTests, testDynamicParams)
       rclcpp::Parameter("undock_angular_tolerance", 0.125),
       rclcpp::Parameter("base_frame", std::string("hi")),
       rclcpp::Parameter("fixed_frame", std::string("hi")),
+      rclcpp::Parameter("backward_blind", true),
+      rclcpp::Parameter("dock_backwards", true),
       rclcpp::Parameter("max_retries", 7)});
 
   rclcpp::spin_until_future_complete(
@@ -261,6 +263,8 @@ TEST(DockingServerTests, testDynamicParams)
   EXPECT_EQ(node->get_parameter("base_frame").as_string(), std::string("hi"));
   EXPECT_EQ(node->get_parameter("fixed_frame").as_string(), std::string("hi"));
   EXPECT_EQ(node->get_parameter("max_retries").as_int(), 7);
+  EXPECT_EQ(node->get_parameter("backward_blind").as_bool(), true);
+  EXPECT_EQ(node->get_parameter("dock_backwards").as_bool(), true);
 
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());

--- a/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
@@ -363,39 +363,39 @@ TEST(SimpleChargingDockTests, GetDockDirection)
   dock.reset();
 }
 
-TEST(SimpleChargingDockTests, BackwardBlind)
+TEST(SimpleChargingDockTests, ShouldRotateToDock)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
 
-  // Case 1: Direction to BACKWARD and backward_blind to true
+  // Case 1: Direction to BACKWARD and rotate_to_dock to true
   node->declare_parameter("my_dock.dock_direction", rclcpp::ParameterValue("backward"));
-  node->declare_parameter("my_dock.backward_blind", rclcpp::ParameterValue(true));
+  node->declare_parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(true));
 
   auto dock = std::make_unique<opennav_docking::SimpleChargingDock>();
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), true);
+  EXPECT_EQ(dock->shouldRotateToDock(), true);
   dock->cleanup();
 
-  // Case 2: Direction to BACKWARD and backward_blind to false
+  // Case 2: Direction to BACKWARD and rotate_to_dock to false
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(false)));
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), false);
+  EXPECT_EQ(dock->shouldRotateToDock(), false);
 
-  // Case 3: Direction to FORWARD and backward_blind to true
+  // Case 3: Direction to FORWARD and rotate_to_dock to true
   node->set_parameter(
     rclcpp::Parameter("my_dock.dock_direction", rclcpp::ParameterValue("forward")));
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(true)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(true)));
   EXPECT_THROW(dock->configure(node, "my_dock", nullptr), std::runtime_error);
-  EXPECT_EQ(dock->isBackwardBlind(), true);
+  EXPECT_EQ(dock->shouldRotateToDock(), true);
   dock->cleanup();
 
-  // Case 4: Direction to FORWARD and backward_blind to false
+  // Case 4: Direction to FORWARD and rotate_to_dock to false
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(false)));
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), false);
+  EXPECT_EQ(dock->shouldRotateToDock(), false);
 
   dock->cleanup();
   dock.reset();

--- a/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
@@ -363,6 +363,44 @@ TEST(SimpleChargingDockTests, GetDockDirection)
   dock.reset();
 }
 
+TEST(SimpleChargingDockTests, BackwardBlind)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
+
+  // Case 1: Direction to BACKWARD and backward_blind to true
+  node->declare_parameter("my_dock.dock_direction", rclcpp::ParameterValue("backward"));
+  node->declare_parameter("my_dock.backward_blind", rclcpp::ParameterValue(true));
+
+  auto dock = std::make_unique<opennav_docking::SimpleChargingDock>();
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), true);
+  dock->cleanup();
+
+  // Case 2: Direction to BACKWARD and backward_blind to false
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), false);
+
+  // Case 3: Direction to FORWARD and backward_blind to true
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.dock_direction", rclcpp::ParameterValue("forward")));
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(true)));
+  EXPECT_THROW(dock->configure(node, "my_dock", nullptr), std::runtime_error);
+  EXPECT_EQ(dock->isBackwardBlind(), true);
+  dock->cleanup();
+
+  // Case 4: Direction to FORWARD and backward_blind to false
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), false);
+
+  dock->cleanup();
+  dock.reset();
+}
+
 }  // namespace opennav_docking
 
 int main(int argc, char **argv)

--- a/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
@@ -324,39 +324,39 @@ TEST(SimpleNonChargingDockTests, GetDockDirection)
   dock.reset();
 }
 
-TEST(SimpleChargingDockTests, BackwardBlind)
+TEST(SimpleChargingDockTests, ShouldRotateToDock)
 {
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
 
-  // Case 1: Direction to BACKWARD and backward_blind to true
+  // Case 1: Direction to BACKWARD and rotate_to_dock to true
   node->declare_parameter("my_dock.dock_direction", rclcpp::ParameterValue("backward"));
-  node->declare_parameter("my_dock.backward_blind", rclcpp::ParameterValue(true));
+  node->declare_parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(true));
 
   auto dock = std::make_unique<opennav_docking::SimpleNonChargingDock>();
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), true);
+  EXPECT_EQ(dock->shouldRotateToDock(), true);
   dock->cleanup();
 
-  // Case 2: Direction to BACKWARD and backward_blind to false
+  // Case 2: Direction to BACKWARD and rotate_to_dock to false
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(false)));
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), false);
+  EXPECT_EQ(dock->shouldRotateToDock(), false);
 
-  // Case 3: Direction to FORWARD and backward_blind to true
+  // Case 3: Direction to FORWARD and rotate_to_dock to true
   node->set_parameter(
     rclcpp::Parameter("my_dock.dock_direction", rclcpp::ParameterValue("forward")));
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(true)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(true)));
   EXPECT_THROW(dock->configure(node, "my_dock", nullptr), std::runtime_error);
-  EXPECT_EQ(dock->isBackwardBlind(), true);
+  EXPECT_EQ(dock->shouldRotateToDock(), true);
   dock->cleanup();
 
-  // Case 4: Direction to FORWARD and backward_blind to false
+  // Case 4: Direction to FORWARD and rotate_to_dock to false
   node->set_parameter(
-    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+    rclcpp::Parameter("my_dock.rotate_to_dock", rclcpp::ParameterValue(false)));
   EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
-  EXPECT_EQ(dock->isBackwardBlind(), false);
+  EXPECT_EQ(dock->shouldRotateToDock(), false);
 
   dock->cleanup();
   dock.reset();

--- a/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
@@ -324,6 +324,44 @@ TEST(SimpleNonChargingDockTests, GetDockDirection)
   dock.reset();
 }
 
+TEST(SimpleChargingDockTests, BackwardBlind)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
+
+  // Case 1: Direction to BACKWARD and backward_blind to true
+  node->declare_parameter("my_dock.dock_direction", rclcpp::ParameterValue("backward"));
+  node->declare_parameter("my_dock.backward_blind", rclcpp::ParameterValue(true));
+
+  auto dock = std::make_unique<opennav_docking::SimpleNonChargingDock>();
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), true);
+  dock->cleanup();
+
+  // Case 2: Direction to BACKWARD and backward_blind to false
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), false);
+
+  // Case 3: Direction to FORWARD and backward_blind to true
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.dock_direction", rclcpp::ParameterValue("forward")));
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(true)));
+  EXPECT_THROW(dock->configure(node, "my_dock", nullptr), std::runtime_error);
+  EXPECT_EQ(dock->isBackwardBlind(), true);
+  dock->cleanup();
+
+  // Case 4: Direction to FORWARD and backward_blind to false
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.backward_blind", rclcpp::ParameterValue(false)));
+  EXPECT_NO_THROW(dock->configure(node, "my_dock", nullptr));
+  EXPECT_EQ(dock->isBackwardBlind(), false);
+
+  dock->cleanup();
+  dock.reset();
+}
+
 }  // namespace opennav_docking
 
 int main(int argc, char **argv)

--- a/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
+++ b/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
@@ -137,17 +137,18 @@ public:
   DockDirection getDockDirection() {return dock_direction_;}
 
   /**
-   * @brief Indicates if the dock is backward blind
-   * @return bool True if the dock is backward blind
+   * @brief Determines whether the robot should rotate 180º to face away from the dock.
+   * For example, to perform a backward docking without detections.
+   * @return bool If the robot should rotate to face away from the dock.
    */
-  bool isBackwardBlind() {return backward_blind_;}
+  bool shouldRotateToDock() {return rotate_to_dock_;}
 
   std::string getName() {return name_;}
 
 protected:
   std::string name_;
   DockDirection dock_direction_{DockDirection::UNKNOWN};
-  bool backward_blind_{false};
+  bool rotate_to_dock_{false};
 };
 
 }  // namespace opennav_docking_core

--- a/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
+++ b/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
@@ -136,11 +136,18 @@ public:
    */
   DockDirection getDockDirection() {return dock_direction_;}
 
+  /**
+   * @brief Indicates if the dock is backward blind
+   * @return bool True if the dock is backward blind
+   */
+  bool isBackwardBlind() {return backward_blind_;}
+
   std::string getName() {return name_;}
 
 protected:
   std::string name_;
   DockDirection dock_direction_{DockDirection::UNKNOWN};
+  bool backward_blind_{false};
 };
 
 }  // namespace opennav_docking_core


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4403, [#68](https://github.com/open-navigation/opennav_docking/issues/68) and [PR4749](https://github.com/ros-navigation/navigation2/pull/4749)
| Primary OS tested on | Ubuntu 24.04|
| Robotic platform tested on | Morphia robot |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Enhanced the docking server to allow backward docking without continuous pose refinement, using only the initially detected docking pose.
* Added a parameter ```backward_blind``` to the SimpleChargingDock and SimpleNonChargingDock.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
