### PR TITLE
Adding parameter util to node utils

### DIFF
--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -142,9 +142,14 @@ rclcpp::ParameterValue declare_or_get_parameter(
   const rclcpp::ParameterType & param_type,
   const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
-  return node->has_parameter(parameter_name) ?
-         node->get_parameter(parameter_name).get_parameter_value() :
-         node->declare_parameter(parameter_name, param_type, parameter_descriptor);
+  if (node->has_parameter(parameter_name)) {
+    try {
+      return node->get_parameter(parameter_name).get_parameter_value();
+    } catch (const std::exception & exception) {
+      return rclcpp::ParameterValue();
+    }
+  }
+  return node->declare_parameter(parameter_name, param_type, parameter_descriptor);
 }
 
 using NodeParamInterfacePtr = rclcpp::node_interfaces::NodeParametersInterface::SharedPtr;
@@ -210,8 +215,7 @@ ParamType declare_or_get_parameter(
   const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
   return declare_or_get_parameter(node->get_logger(), node->get_node_parameters_interface(),
-      parameter_name,
-      default_value, warn_if_no_override, parameter_descriptor);
+      parameter_name, default_value, warn_if_no_override, parameter_descriptor);
 }
 
 /// Gets the type of plugin for the selected node and its plugin

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -81,25 +81,26 @@ rclcpp::Node::SharedPtr generate_internal_node(const std::string & prefix = "");
  */
 std::string time_to_string(size_t len);
 
+using ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor;
+
 /// Declares static ROS2 parameter and sets it to a given value if it was not already declared
 /* Declares static ROS2 parameter and sets it to a given value
  * if it was not already declared.
  *
  * \param[in] node A node in which given parameter to be declared
- * \param[in] param_name The name of parameter
+ * \param[in] parameter_name The name of parameter
  * \param[in] default_value Parameter value to initialize with
  * \param[in] parameter_descriptor Parameter descriptor (optional)
  */
 template<typename NodeT>
 void declare_parameter_if_not_declared(
   NodeT node,
-  const std::string & param_name,
+  const std::string & parameter_name,
   const rclcpp::ParameterValue & default_value,
-  const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
-  rcl_interfaces::msg::ParameterDescriptor())
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
-  if (!node->has_parameter(param_name)) {
-    node->declare_parameter(param_name, default_value, parameter_descriptor);
+  if (!node->has_parameter(parameter_name)) {
+    node->declare_parameter(parameter_name, default_value, parameter_descriptor);
   }
 }
 
@@ -107,25 +108,46 @@ void declare_parameter_if_not_declared(
 /* Declares static ROS2 parameter with given type if it was not already declared.
  *
  * \param[in] node A node in which given parameter to be declared
+ * \param[in] parameter_name Name of the parameter
  * \param[in] param_type The type of parameter
- * \param[in] default_value Parameter value to initialize with
  * \param[in] parameter_descriptor Parameter descriptor (optional)
  */
 template<typename NodeT>
 void declare_parameter_if_not_declared(
   NodeT node,
-  const std::string & param_name,
+  const std::string & parameter_name,
   const rclcpp::ParameterType & param_type,
-  const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
-  rcl_interfaces::msg::ParameterDescriptor())
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
-  if (!node->has_parameter(param_name)) {
-    node->declare_parameter(param_name, param_type, parameter_descriptor);
+  if (!node->has_parameter(parameter_name)) {
+    node->declare_parameter(parameter_name, param_type, parameter_descriptor);
   }
 }
 
+/// Declares a parameter with the specified type if it was not already declared
+/// and returns its value if available.
+/* Declares a parameter with the specified type if it was not already declared.
+ * If the parameter was overridden, its value is returned, otherwise a
+ * parameter not set type is returned.
+ *
+ * \param[in] node A node in which given parameter to be declared
+ * \param[in] parameter_name Name of the parameter
+ * \param[in] param_type The type of parameter
+ * \param[in] parameter_descriptor Parameter descriptor (optional)
+ */
+template<typename NodeT>
+rclcpp::ParameterValue declare_or_get_parameter(
+  NodeT node,
+  const std::string & parameter_name,
+  const rclcpp::ParameterType & param_type,
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
+{
+  return node->has_parameter(parameter_name) ?
+         node->get_parameter(parameter_name).get_parameter_value() :
+         node->declare_parameter(parameter_name, param_type, parameter_descriptor);
+}
+
 using NodeParamInterfacePtr = rclcpp::node_interfaces::NodeParametersInterface::SharedPtr;
-using ParamDescriptor = rcl_interfaces::msg::ParameterDescriptor;
 
 /// If the parameter is already declared, returns its value,
 /// otherwise declares it and returns the default value
@@ -136,31 +158,34 @@ using ParamDescriptor = rcl_interfaces::msg::ParameterDescriptor;
  *
  * \param[in] logger Node logging interface
  * \param[in] param_interface Node parameter interface
- * \param[in] param_name Name of the parameter
+ * \param[in] parameter_name Name of the parameter
  * \param[in] default_value Default value of the parameter
  * \param[in] warn_if_no_override If true, prints a warning whenever the parameter override is missing
- * \param[in] param_descriptor Optional parameter descriptor
+ * \param[in] parameter_descriptor Optional parameter descriptor
  * \return The value of the param from the override if existent, otherwise the default value
  */
 template<typename ParamType>
-ParamType declare_or_get_param(
+ParamType declare_or_get_parameter(
   const rclcpp::Logger & logger, NodeParamInterfacePtr param_interface,
-  const std::string & param_name, const ParamType & default_value, bool warn_if_no_override = true,
-  const ParamDescriptor & param_descriptor = ParamDescriptor())
+  const std::string & parameter_name, const ParamType & default_value,
+  bool warn_if_no_override = false,
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
-  if (param_interface->has_parameter(param_name)) {
-    rclcpp::Parameter param(param_name, default_value);
-    param_interface->get_parameter(param_name, param);
+  if (param_interface->has_parameter(parameter_name)) {
+    rclcpp::Parameter param(parameter_name, default_value);
+    param_interface->get_parameter(parameter_name, param);
     return param.get_value<ParamType>();
   }
-  if (warn_if_no_override && param_interface->get_parameter_overrides().find(param_name) ==
+  if (warn_if_no_override && param_interface->get_parameter_overrides().find(parameter_name) ==
     param_interface->get_parameter_overrides().end())
   {
     RCLCPP_WARN_STREAM(
-        logger, "Failed to get param " << param_name << " from overrides, using default value.");
+        logger,
+        "Failed to get param " << parameter_name << " from overrides, using default value.");
   }
   return param_interface
-         ->declare_parameter(param_name, rclcpp::ParameterValue{default_value}, param_descriptor)
+         ->declare_parameter(parameter_name, rclcpp::ParameterValue{default_value},
+      parameter_descriptor)
          .get<ParamType>();
 }
 
@@ -172,20 +197,21 @@ ParamType declare_or_get_param(
  * The method will by default print a warning when the override is missing.
  *
  * \param[in] node Pointer to a node object
- * \param[in] param_name Name of the parameter
+ * \param[in] parameter_name Name of the parameter
  * \param[in] default_value Default value of the parameter
  * \param[in] warn_if_no_override If true, prints a warning whenever the parameter override is missing
- * \param[in] param_descriptor Optional parameter descriptor
+ * \param[in] parameter_descriptor Optional parameter descriptor
  * \return The value of the param from the override if existent, otherwise the default value
  */
 template<typename ParamType, typename NodeT>
-ParamType declare_or_get_param(
-  NodeT node, const std::string & param_name,
-  const ParamType & default_value, bool warn_if_no_override = true,
-  const ParamDescriptor & param_descriptor = ParamDescriptor())
+ParamType declare_or_get_parameter(
+  NodeT node, const std::string & parameter_name,
+  const ParamType & default_value, bool warn_if_no_override = false,
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor())
 {
-  return declare_or_get_param(node->get_logger(), node->get_node_parameters_interface(), param_name,
-      default_value, warn_if_no_override, param_descriptor);
+  return declare_or_get_parameter(node->get_logger(), node->get_node_parameters_interface(),
+      parameter_name,
+      default_value, warn_if_no_override, parameter_descriptor);
 }
 
 /// Gets the type of plugin for the selected node and its plugin

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -25,6 +25,7 @@ using nav2_util::generate_internal_node;
 using nav2_util::add_namespaces;
 using nav2_util::time_to_string;
 using nav2_util::declare_parameter_if_not_declared;
+using nav2_util::declare_or_get_param;
 using nav2_util::get_plugin_type_param;
 
 TEST(SanitizeNodeName, SanitizeNodeName)
@@ -76,6 +77,22 @@ TEST(DeclareParameterIfNotDeclared, DeclareParameterIfNotDeclared)
   declare_parameter_if_not_declared(node, "waldo", rclcpp::ParameterValue{"fred"});
   node->get_parameter("waldo", param);
   ASSERT_EQ(param, "fred");
+}
+
+TEST(DeclareOrGetParam, DeclareOrGetParam)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+
+  // test declared parameter
+  node->declare_parameter("foobar", "foo");
+  std::string param = declare_or_get_param(node, "foobar", std::string{"bar"});
+  ASSERT_EQ(param, "foo");
+  node->get_parameter("foobar", param);
+  ASSERT_EQ(param, "foo");
+
+  // test undeclared parameter
+  int int_param = declare_or_get_param(node, "waldo", 3);
+  ASSERT_EQ(int_param, 3);
 }
 
 TEST(GetPluginTypeParam, GetPluginTypeParam)

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -85,7 +85,7 @@ TEST(DeclareOrGetParam, DeclareOrGetParam)
 
   // test declared parameter
   node->declare_parameter("foobar", "foo");
-  std::string param = declare_or_get_parameter(node, "foobar", std::string{"bar"});
+  std::string param = declare_or_get_parameter(node, "foobar", std::string{"bar"}, true);
   EXPECT_EQ(param, "foo");
   node->get_parameter("foobar", param);
   EXPECT_EQ(param, "foo");

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -90,7 +90,7 @@ TEST(DeclareOrGetParam, DeclareOrGetParam)
   node->get_parameter("foobar", param);
   EXPECT_EQ(param, "foo");
   // test undeclared parameter
-  int int_param = declare_or_get_parameter(node, "waldo", 3);
+  int int_param = declare_or_get_parameter(node, "waldo", 3, true);
   EXPECT_EQ(int_param, 3);
   // test declaration by type of existing param
   rclcpp::ParameterValue int_value = declare_or_get_parameter(node, "waldo",

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -25,7 +25,7 @@ using nav2_util::generate_internal_node;
 using nav2_util::add_namespaces;
 using nav2_util::time_to_string;
 using nav2_util::declare_parameter_if_not_declared;
-using nav2_util::declare_or_get_param;
+using nav2_util::declare_or_get_parameter;
 using nav2_util::get_plugin_type_param;
 
 TEST(SanitizeNodeName, SanitizeNodeName)
@@ -85,14 +85,20 @@ TEST(DeclareOrGetParam, DeclareOrGetParam)
 
   // test declared parameter
   node->declare_parameter("foobar", "foo");
-  std::string param = declare_or_get_param(node, "foobar", std::string{"bar"});
-  ASSERT_EQ(param, "foo");
+  std::string param = declare_or_get_parameter(node, "foobar", std::string{"bar"});
+  EXPECT_EQ(param, "foo");
   node->get_parameter("foobar", param);
-  ASSERT_EQ(param, "foo");
-
+  EXPECT_EQ(param, "foo");
   // test undeclared parameter
-  int int_param = declare_or_get_param(node, "waldo", 3);
-  ASSERT_EQ(int_param, 3);
+  int int_param = declare_or_get_parameter(node, "waldo", 3);
+  EXPECT_EQ(int_param, 3);
+  // test declaration by type of existing param
+  rclcpp::ParameterValue int_value = declare_or_get_parameter(node, "waldo",
+    rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(int_param, int_value.get<int>());
+  // test declaration by type of non existing param
+  int_value = declare_or_get_parameter(node, "wololo", rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(int_value.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
 }
 
 TEST(GetPluginTypeParam, GetPluginTypeParam)

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -93,15 +93,18 @@ TEST(DeclareOrGetParam, DeclareOrGetParam)
   int int_param = declare_or_get_parameter(node, "waldo", 3, true);
   EXPECT_EQ(int_param, 3);
   // test declaration by type of existing param
-  rclcpp::ParameterValue int_value = declare_or_get_parameter(node, "waldo",
+  int_param = declare_or_get_parameter<int>(node, "waldo",
     rclcpp::ParameterType::PARAMETER_INTEGER);
-  EXPECT_EQ(int_param, int_value.get<int>());
+  EXPECT_EQ(int_param, 3);
   // test declaration by type of non existing param
-  int_value = declare_or_get_parameter(node, "wololo", rclcpp::ParameterType::PARAMETER_INTEGER);
-  EXPECT_EQ(int_value.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
-  // test that a subsequent call doesn't throw
-  int_value = declare_or_get_parameter(node, "wololo", rclcpp::ParameterType::PARAMETER_INTEGER);
-  EXPECT_EQ(int_value.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+  bool got_exception{false};
+  try {
+    int_param = declare_or_get_parameter<int>(node, "wololo",
+      rclcpp::ParameterType::PARAMETER_INTEGER);
+  } catch (const rclcpp::exceptions::InvalidParameterValueException & exc) {
+    got_exception = true;
+  }
+  EXPECT_TRUE(got_exception);
 }
 
 TEST(GetPluginTypeParam, GetPluginTypeParam)

--- a/nav2_util/test/test_node_utils.cpp
+++ b/nav2_util/test/test_node_utils.cpp
@@ -99,6 +99,9 @@ TEST(DeclareOrGetParam, DeclareOrGetParam)
   // test declaration by type of non existing param
   int_value = declare_or_get_parameter(node, "wololo", rclcpp::ParameterType::PARAMETER_INTEGER);
   EXPECT_EQ(int_value.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+  // test that a subsequent call doesn't throw
+  int_value = declare_or_get_parameter(node, "wololo", rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(int_value.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
 }
 
 TEST(GetPluginTypeParam, GetPluginTypeParam)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Independent |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

The added utility tackles 2 issues:
- Reduces the amount of boilerplate code required to declare and get parameters, and consequently makes it less likely to introduce typos: it combines declare_parameter_if_not_declared and get_parameter in a single instruction.

Example:

```
nav2_util::declare_parameter_if_not_declared(
    node,
    "max_rotational_vel", rclcpp::ParameterValue(1.0));
  node->get_parameter("max_rotational_vel", max_rotational_vel_);
```

Can be rewritten as

`max_rotational_vel_ = nav2_util::declare_or_get_param(node, "max_rotational_vel", 1.0);`

- Helps tracking typos / mismatching namespaces in the parameters overrides: if a parameter is not found in the overrides, resulting in the default value being used, the utility can optionally print a WARN message. This can often help the developers catch configuration mistakes, and is particularly useful when relying on the default value likely results in degraded performance.

The utility can be used either through a generic node pointer, or (useful when using derived nodes) using the internal node interfaces.

## Description of how this change was tested

- Added a unit test.
- As I didn't add the utilty to any node yet, it won't affect any existing behavior.

---

## Future work that may be required in bullet points

- The utility can be used for refactoring purposes or for the development of new modules.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
