### PR TITLE
Save 2 minutes in Main-Jazzy build times to align with other CI job lengths

### DIFF
--- a/.github/workflows/build_main_against_distros.yml
+++ b/.github/workflows/build_main_against_distros.yml
@@ -41,7 +41,7 @@ jobs:
           rosdep install --from-paths src --ignore-src -r -y \
           --skip-keys=slam_toolbox
 
-        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup nav2_simple_commander nav2_loopback_sim' > /tmp/docker_context/Dockerfile
+        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup nav2_simple_commander nav2_loopback_sim navigation2' > /tmp/docker_context/Dockerfile
 
 
     - name: Build Docker image

--- a/.github/workflows/build_main_against_distros.yml
+++ b/.github/workflows/build_main_against_distros.yml
@@ -41,7 +41,7 @@ jobs:
           rosdep install --from-paths src --ignore-src -r -y \
           --skip-keys=slam_toolbox
 
-        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build' > /tmp/docker_context/Dockerfile
+        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup' > /tmp/docker_context/Dockerfile
 
 
     - name: Build Docker image

--- a/.github/workflows/build_main_against_distros.yml
+++ b/.github/workflows/build_main_against_distros.yml
@@ -41,7 +41,7 @@ jobs:
           rosdep install --from-paths src --ignore-src -r -y \
           --skip-keys=slam_toolbox
 
-        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup' > /tmp/docker_context/Dockerfile
+        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup nav2_simple_commander nav2_loopback_sim' > /tmp/docker_context/Dockerfile
 
 
     - name: Build Docker image


### PR DESCRIPTION
We're building and not running tests anyway, this is just checking API compatibility, so we can skip some packages that won't yield us helpful information. So anything fully Python3 can be removed and the `nav2_system_tests` can be removed 