### PR TITLE
action timeout in BT client edits error code and string

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -188,6 +188,15 @@ public:
   }
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  virtual void on_timeout()
+  {
+    return;
+  }
+
+  /**
    * @brief The main override required by a BT action
    * @return BT::NodeStatus Status of tick execution
    */
@@ -231,6 +240,7 @@ public:
             "Timed out while waiting for action server to acknowledge goal request for %s",
             action_name_.c_str());
           future_goal_handle_.reset();
+          on_timeout();
           return BT::NodeStatus::FAILURE;
         }
       }
@@ -261,6 +271,7 @@ public:
               "Timed out while waiting for action server to acknowledge goal request for %s",
               action_name_.c_str());
             future_goal_handle_.reset();
+            on_timeout();
             return BT::NodeStatus::FAILURE;
           }
         }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
@@ -67,6 +67,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -67,6 +67,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
@@ -65,6 +65,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to perform some user-defined operation after a timeout
    * waiting for a result that hasn't been received yet
    * @param feedback shared_ptr to latest feedback message

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -70,6 +70,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -67,6 +67,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
@@ -65,6 +65,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
@@ -88,6 +88,12 @@ public:
    * @brief Function to perform some user-defined operation upon cancellation of the action
    */
   BT::NodeStatus on_cancelled() override;
+
+  /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -67,6 +67,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to perform some user-defined operation after a timeout
    * waiting for a result that hasn't been received yet
    * @param feedback shared_ptr to latest feedback message

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -68,6 +68,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
@@ -68,6 +68,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
@@ -66,6 +66,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
@@ -51,6 +51,12 @@ public:
   void on_tick() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
@@ -51,6 +51,12 @@ public:
   void on_tick() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();

--- a/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
@@ -69,6 +69,12 @@ BT::NodeStatus AssistedTeleopAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void AssistedTeleopAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -78,6 +78,12 @@ BT::NodeStatus BackUpAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void BackUpAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
@@ -75,6 +75,12 @@ BT::NodeStatus ComputeAndTrackRouteAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void ComputeAndTrackRouteAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void ComputeAndTrackRouteAction::on_wait_for_result(
   std::shared_ptr<const Action::Feedback>/*feedback*/)
 {

--- a/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
@@ -66,6 +66,12 @@ BT::NodeStatus ComputePathThroughPosesAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void ComputePathThroughPosesAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void ComputePathThroughPosesAction::halt()
 {
   nav_msgs::msg::Path empty_path;

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -82,6 +82,12 @@ BT::NodeStatus ComputePathToPoseAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void ComputePathToPoseAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void ComputePathToPoseAction::halt()
 {
   nav_msgs::msg::Path empty_path;

--- a/nav2_behavior_tree/plugins/action/compute_route_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_route_action.cpp
@@ -87,6 +87,12 @@ BT::NodeStatus ComputeRouteAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void ComputeRouteAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void ComputeRouteAction::halt()
 {
   resetPorts();

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -76,6 +76,12 @@ BT::NodeStatus DriveOnHeadingAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void DriveOnHeadingAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -58,6 +58,12 @@ BT::NodeStatus FollowPathAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void FollowPathAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::CONTROLLER_TIMED_OUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void FollowPathAction::on_wait_for_result(
   std::shared_ptr<const Action::Feedback>/*feedback*/)
 {

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -61,6 +61,11 @@ BT::NodeStatus NavigateThroughPosesAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void NavigateThroughPosesAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
 
 }  // namespace nav2_behavior_tree
 

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -60,6 +60,12 @@ BT::NodeStatus NavigateToPoseAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void NavigateToPoseAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
@@ -65,6 +65,12 @@ BT::NodeStatus SmoothPathAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void SmoothPathAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/spin_action.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_action.cpp
@@ -68,6 +68,12 @@ BT::NodeStatus SpinAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void SpinAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -73,6 +73,12 @@ BT::NodeStatus WaitAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void WaitAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
@@ -69,6 +69,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
@@ -69,6 +69,12 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
+   * @brief Function to perform work in a BT Node when the action server times out
+   * Such as setting the error code ID status to timed out for action clients.
+   */
+  void on_timeout() override;
+
+  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;

--- a/nav2_docking/opennav_docking_bt/src/dock_robot.cpp
+++ b/nav2_docking/opennav_docking_bt/src/dock_robot.cpp
@@ -67,6 +67,12 @@ BT::NodeStatus DockRobotAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void DockRobotAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void DockRobotAction::halt()
 {
   BtActionNode::halt();

--- a/nav2_docking/opennav_docking_bt/src/undock_robot.cpp
+++ b/nav2_docking/opennav_docking_bt/src/undock_robot.cpp
@@ -58,6 +58,12 @@ BT::NodeStatus UndockRobotAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
+void UndockRobotAction::on_timeout()
+{
+  setOutput("error_code_id", ActionResult::TIMEOUT);
+  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+}
+
 void UndockRobotAction::halt()
 {
   BtActionNode::halt();

--- a/nav2_msgs/action/DockRobot.action
+++ b/nav2_msgs/action/DockRobot.action
@@ -21,6 +21,7 @@ uint16 FAILED_TO_STAGE=903
 uint16 FAILED_TO_DETECT_DOCK=904
 uint16 FAILED_TO_CONTROL=905
 uint16 FAILED_TO_CHARGE=906
+uint16 TIMEOUT=907
 uint16 UNKNOWN=999
 
 bool success True  # docking success status

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -11,6 +11,7 @@ uint16 NONE=0
 uint16 UNKNOWN=9100
 uint16 FAILED_TO_LOAD_BEHAVIOR_TREE=9101
 uint16 TF_ERROR=9102
+uint16 TIMEOUT=9103
 
 uint16 error_code
 string error_msg

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -10,6 +10,7 @@ uint16 NONE=0
 uint16 UNKNOWN=9000
 uint16 FAILED_TO_LOAD_BEHAVIOR_TREE=9001
 uint16 TF_ERROR=9002
+uint16 TIMEOUT=9003
 
 uint16 error_code
 string error_msg

--- a/nav2_msgs/action/UndockRobot.action
+++ b/nav2_msgs/action/UndockRobot.action
@@ -16,6 +16,7 @@ float32 max_undocking_time 30.0 # Maximum time to undock
 uint16 NONE=0
 uint16 DOCK_NOT_VALID=902
 uint16 FAILED_TO_CONTROL=905
+uint16 TIMEOUT=907
 uint16 UNKNOWN=999
 
 bool success True  # docking success status

--- a/nav2_msgs/action/Wait.action
+++ b/nav2_msgs/action/Wait.action
@@ -8,6 +8,7 @@ string error_msg
 
 uint16 NONE=0
 uint16 UNKNOWN=740
+uint16 TIMEOUT=741
 ---
 #feedback definition
 builtin_interfaces/Duration time_left


### PR DESCRIPTION
Addresses https://github.com/ros-navigation/navigation2/issues/4946

For all actions that contain timeout error codes (or are sensible to have them added), this PR enables the `TIMEOUT` error code ID to be returned if the action client in the behavior tree is not able to communicate properly with the action server and returns a timeout. 