### PR TITLE
Option to Reduce Lethal to High-Cost Navigable To Get Out of Keepout Zones if Wandered In

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -229,6 +229,8 @@ local_costmap:
         plugin: "nav2_costmap_2d::KeepoutFilter"
         enabled: True
         filter_info_topic: "keepout_costmap_filter_info"
+        override_lethal_cost: True
+        lethal_override_cost: 200
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
@@ -281,6 +283,8 @@ global_costmap:
         plugin: "nav2_costmap_2d::KeepoutFilter"
         enabled: True
         filter_info_topic: "keepout_costmap_filter_info"
+        override_lethal_cost: True
+        lethal_override_cost: 200
       speed_filter:
         plugin: "nav2_costmap_2d::SpeedFilter"
         enabled: True

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
@@ -106,8 +106,8 @@ private:
   bool override_lethal_cost_{false};  // If true, lethal cost will be overridden
   unsigned char lethal_override_cost_{252};  // Value to override lethal cost with
   bool last_pose_lethal_{false};  // If true, last pose was lethal
-  unsigned int lethal_state_update_min_x_, lethal_state_update_min_y_;
-  unsigned int lethal_state_update_max_x_, lethal_state_update_max_y_;
+  unsigned int lethal_state_update_min_x_{999999u}, lethal_state_update_min_y_{999999u};
+  unsigned int lethal_state_update_max_x_{0u}, lethal_state_update_max_y_{0u};
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
@@ -102,6 +102,12 @@ private:
   nav_msgs::msg::OccupancyGrid::SharedPtr filter_mask_;
 
   std::string global_frame_;  // Frame of current layer (master_grid)
+
+  bool override_lethal_cost_{false};  // If true, lethal cost will be overridden
+  unsigned char lethal_override_cost_{252};  // Value to override lethal cost with
+  bool last_pose_lethal_{false};  // If true, last pose was lethal
+  unsigned int lethal_state_update_min_x_, lethal_state_update_min_y_;
+  unsigned int lethal_state_update_max_x_, lethal_state_update_max_y_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -254,7 +254,7 @@ void KeepoutFilter::process(
   unsigned int mg_max_x_u = static_cast<unsigned int>(mg_max_x);
   unsigned int mg_max_y_u = static_cast<unsigned int>(mg_max_y);
 
-  // Lets find the pose's cost if we are allowed to override the lethal cost
+  // Let's find the pose's cost if we are allowed to override the lethal cost
   bool is_pose_lethal = false;
   if (override_lethal_cost_) {
     geometry_msgs::msg::Pose2D mask_pose;

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -261,8 +261,8 @@ void KeepoutFilter::process(
     if (transformPose(global_frame_, pose, filter_mask_->header.frame_id, mask_pose)) {
       unsigned int mask_robot_i, mask_robot_j;
       if (worldToMask(filter_mask_, mask_pose.x, mask_pose.y, mask_robot_i, mask_robot_j)) {
-        auto keepout_mask_data = getMaskCost(filter_mask_, mask_robot_i, mask_robot_j);
-        is_pose_lethal = (keepout_mask_data == 253 || keepout_mask_data == 254);
+        auto data = getMaskCost(filter_mask_, mask_robot_i, mask_robot_j);
+        is_pose_lethal = (data == INSCRIBED_INFLATED_OBSTACLE || data == LETHAL_OBSTACLE);
         if (is_pose_lethal) {
           RCLCPP_WARN_THROTTLE(
             logger_, *(clock_), 2000,

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -75,7 +75,7 @@ void KeepoutFilter::initializeFilter(
 
   global_frame_ = layered_costmap_->getGlobalFrameID();
 
-  declareParameter("override_lethal_cost", rclcpp::ParameterValue(true));
+  declareParameter("override_lethal_cost", rclcpp::ParameterValue(false));
   node->get_parameter(name_ + "." + "override_lethal_cost", override_lethal_cost_);
   declareParameter("lethal_override_cost", rclcpp::ParameterValue(252));
   node->get_parameter(name_ + "." + "lethal_override_cost", lethal_override_cost_);

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -79,7 +79,7 @@ void KeepoutFilter::initializeFilter(
   node->get_parameter(name_ + "." + "override_lethal_cost", override_lethal_cost_);
   declareParameter("lethal_override_cost", rclcpp::ParameterValue(MAX_NON_OBSTACLE));
   node->get_parameter(name_ + "." + "lethal_override_cost", lethal_override_cost_);
-  
+
   // clamp lethal_override_cost_ in case if higher than MAX_NON_OBSTACLE is given
   lethal_override_cost_ = \
     std::clamp<unsigned int>(lethal_override_cost_, FREE_SPACE, MAX_NON_OBSTACLE);

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -74,6 +74,11 @@ void KeepoutFilter::initializeFilter(
     std::bind(&KeepoutFilter::filterInfoCallback, this, std::placeholders::_1));
 
   global_frame_ = layered_costmap_->getGlobalFrameID();
+
+  declareParameter("override_lethal_cost", rclcpp::ParameterValue(true));
+  node->get_parameter(name_ + "." + "override_lethal_cost", override_lethal_cost_);
+  declareParameter("lethal_override_cost", rclcpp::ParameterValue(252));
+  node->get_parameter(name_ + "." + "lethal_override_cost", lethal_override_cost_);
 }
 
 void KeepoutFilter::filterInfoCallback(
@@ -149,7 +154,7 @@ void KeepoutFilter::maskCallback(
 void KeepoutFilter::process(
   nav2_costmap_2d::Costmap2D & master_grid,
   int min_i, int min_j, int max_i, int max_j,
-  const geometry_msgs::msg::Pose2D & /*pose*/)
+  const geometry_msgs::msg::Pose2D & pose)
 {
   std::lock_guard<CostmapFilter::mutex_t> guard(*getMutex());
 
@@ -244,10 +249,49 @@ void KeepoutFilter::process(
   }
 
   // unsigned<-signed conversions.
-  unsigned const int mg_min_x_u = static_cast<unsigned int>(mg_min_x);
-  unsigned const int mg_min_y_u = static_cast<unsigned int>(mg_min_y);
-  unsigned const int mg_max_x_u = static_cast<unsigned int>(mg_max_x);
-  unsigned const int mg_max_y_u = static_cast<unsigned int>(mg_max_y);
+  unsigned int mg_min_x_u = static_cast<unsigned int>(mg_min_x);
+  unsigned int mg_min_y_u = static_cast<unsigned int>(mg_min_y);
+  unsigned int mg_max_x_u = static_cast<unsigned int>(mg_max_x);
+  unsigned int mg_max_y_u = static_cast<unsigned int>(mg_max_y);
+
+  // Lets find the pose's cost if we are allowed to override the lethal cost
+  bool is_pose_lethal = false;
+  if (override_lethal_cost_) {
+    geometry_msgs::msg::Pose2D mask_pose;
+    if (transformPose(global_frame_, pose, filter_mask_->header.frame_id, mask_pose)) {
+      unsigned int mask_robot_i, mask_robot_j;
+      if (worldToMask(filter_mask_, mask_pose.x, mask_pose.y, mask_robot_i, mask_robot_j)) {
+        auto keepout_mask_data = getMaskCost(filter_mask_, mask_robot_i, mask_robot_j);
+        is_pose_lethal = (keepout_mask_data == 253 || keepout_mask_data == 254);
+        if (is_pose_lethal) {
+          RCLCPP_WARN_THROTTLE(
+            logger_, *(clock_), 2000,
+            "KeepoutFilter: Pose is in keepout zone, reducing cost override to navigate out.");
+        }
+      }
+    }
+  }
+
+  if (override_lethal_cost_) {
+    // If in lethal space or just exited lethal space,
+    // we need to update all possible spaces touched during this state
+    if (is_pose_lethal || (last_pose_lethal_ && !is_pose_lethal)) {
+      lethal_state_update_min_x_ = std::min(mg_min_x_u, lethal_state_update_min_x_);
+      mg_min_x_u = lethal_state_update_min_x_;
+      lethal_state_update_min_y_ = std::min(mg_min_y_u, lethal_state_update_min_y_);
+      mg_min_y_u = lethal_state_update_min_y_;
+      lethal_state_update_max_x_ = std::max(mg_max_x_u, lethal_state_update_max_x_);
+      mg_max_x_u = lethal_state_update_max_x_;
+      lethal_state_update_max_y_ = std::max(mg_max_y_u, lethal_state_update_max_y_);
+      mg_max_y_u = lethal_state_update_max_y_;
+    } else {
+      // If out of lethal space, reset managed lethal state sizes
+      lethal_state_update_min_x_ = master_grid.getSizeInCellsX();
+      lethal_state_update_min_y_ = master_grid.getSizeInCellsY();
+      lethal_state_update_max_x_ = 0u;
+      lethal_state_update_max_y_ = 0u;
+    }
+  }
 
   unsigned int i, j;  // master_grid iterators
   unsigned int index;  // corresponding index of master_grid
@@ -284,12 +328,19 @@ void KeepoutFilter::process(
         if (data == NO_INFORMATION) {
           continue;
         }
+
         if (data > old_data || old_data == NO_INFORMATION) {
-          master_array[index] = data;
+          if (override_lethal_cost_ && is_pose_lethal) {
+            master_array[index] = lethal_override_cost_;
+          } else {
+            master_array[index] = data;
+          }
         }
       }
     }
   }
+
+  last_pose_lethal_ = is_pose_lethal;
 }
 
 void KeepoutFilter::resetFilter()

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -77,7 +77,7 @@ void KeepoutFilter::initializeFilter(
 
   declareParameter("override_lethal_cost", rclcpp::ParameterValue(false));
   node->get_parameter(name_ + "." + "override_lethal_cost", override_lethal_cost_);
-  declareParameter("lethal_override_cost", rclcpp::ParameterValue(252));
+  declareParameter("lethal_override_cost", rclcpp::ParameterValue(MAX_NON_OBSTACLE));
   node->get_parameter(name_ + "." + "lethal_override_cost", lethal_override_cost_);
   
   // clamp lethal_override_cost_ in case if higher than MAX_NON_OBSTACLE is given

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -79,6 +79,10 @@ void KeepoutFilter::initializeFilter(
   node->get_parameter(name_ + "." + "override_lethal_cost", override_lethal_cost_);
   declareParameter("lethal_override_cost", rclcpp::ParameterValue(252));
   node->get_parameter(name_ + "." + "lethal_override_cost", lethal_override_cost_);
+  
+  // clamp lethal_override_cost_ in case if higher than MAX_NON_OBSTACLE is given
+  lethal_override_cost_ = \
+    std::clamp<unsigned int>(lethal_override_cost_, FREE_SPACE, MAX_NON_OBSTACLE);
 }
 
 void KeepoutFilter::filterInfoCallback(

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -270,9 +270,7 @@ void KeepoutFilter::process(
         }
       }
     }
-  }
 
-  if (override_lethal_cost_) {
     // If in lethal space or just exited lethal space,
     // we need to update all possible spaces touched during this state
     if (is_pose_lethal || (last_pose_lethal_ && !is_pose_lethal)) {


### PR DESCRIPTION
This resolves https://github.com/ros-navigation/navigation2/issues/5139

In it, we check if we're in a lethal keepout zone. If optionally enabled (default off, but on in `nav2_params.yaml`), we reduce the lethal cost to a very high but navigable cost (252) in order to allow the robot to leave on its own but in a very efficient way. 

This cost can be tuned by users to weight the incentives to continue towards the goal (lower cost) with incentives to leave the keepout zone immediately (252 max). 

We update the costmap in the full window size during this mode in order to make sure we set all cells as lethal again once exiting the keepout zone (to keep them in update scope).