### PR TITLE
Adding options to override the footprint subscription qos

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -44,6 +44,8 @@
 #include <vector>
 #include <utility>
 
+#include "rclcpp/qos.hpp"
+#include "rclcpp/subscription_options.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "nav2_util/execution_timer.hpp"
 #include "nav2_util/node_utils.hpp"
@@ -210,11 +212,18 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
     RCLCPP_INFO(get_logger(), "Initialized costmap filter \"%s\"", filter_names_[i].c_str());
   }
 
+  // Allowing the user to reconfigure the qos through parameters (ex to latch the topic)
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.qos_overriding_options =
+    rclcpp::QosOverridingOptions({rclcpp::QosPolicyKind::Depth, rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::Reliability});
+
   // Create the publishers and subscribers
   footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(
     "footprint",
     rclcpp::SystemDefaultsQoS(),
-    std::bind(&Costmap2DROS::setRobotFootprintPolygon, this, std::placeholders::_1));
+    std::bind(&Costmap2DROS::setRobotFootprintPolygon, this, std::placeholders::_1),
+    sub_options);
 
   footprint_pub_ = create_publisher<geometry_msgs::msg::PolygonStamped>(
     "published_footprint", rclcpp::SystemDefaultsQoS());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

It is common for robots to publish their footprint on a latched topic.
This change allows the final user to configure the desired qos for the footprint subscription in the costmap objects.
Ex to set the topic as latched in the local costmap:

```
local_costmap:
  local_costmap:
    ros__parameters:
      qos_overrides:
        /footprint_topic_name:
          subscription:
            reliability: "reliable"
            depth: 1
            durability: "transient_local"
```

## Description of documentation updates required from your changes

New parameters available

## Description of how this change was tested

Validated in simulation that the qos changes using the cli.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
