### PR TITLE
Pass node options to costmap node

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -68,7 +68,7 @@ ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
   // The costmap node is used in the implementation of the controller
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "local_costmap", std::string{get_namespace()},
-    get_parameter("use_sim_time").as_bool());
+    get_parameter("use_sim_time").as_bool(), options);
 }
 
 ControllerServer::~ControllerServer()

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -91,7 +91,8 @@ public:
   explicit Costmap2DROS(
     const std::string & name,
     const std::string & parent_namespace = "/",
-    const bool & use_sim_time = false);
+    const bool & use_sim_time = false,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /**
    * @brief Common initialization for constructors
@@ -429,6 +430,27 @@ protected:
   rcl_interfaces::msg::SetParametersResult
   dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 };
+
+// free functions
+
+/**
+  * @brief Given a specified argument name, replaces it with the specified
+  * new value. If the argument is not in the existing list, a new argument
+  * is created with the specified option.
+  */
+void replaceOrAddArgument(
+  std::vector<std::string> & arguments, const std::string & option,
+  const std::string & arg_name, const std::string & new_argument);
+
+/**
+  * @brief Given the node options of a parent node, expands of replaces
+  *         the fields for the node name, namespace and use_sim_time
+  */
+rclcpp::NodeOptions getChildNodeOptions(
+  const std::string & name,
+  const std::string & parent_namespace,
+  const bool & use_sim_time,
+  const rclcpp::NodeOptions & parent_options);
 
 }  // namespace nav2_costmap_2d
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -64,7 +64,7 @@ PlannerServer::PlannerServer(const rclcpp::NodeOptions & options)
   // Setup the global costmap
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "global_costmap", std::string{get_namespace()},
-    get_parameter("use_sim_time").as_bool());
+    get_parameter("use_sim_time").as_bool(), options);
 }
 
 PlannerServer::~PlannerServer()


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Currently it is impossible to remap the publishers and subscribers of the costmap objects, because the node options of the controller server are not passed to the child node.
The change allows the child costmap node to inherit the node options of the parent, while still using customized options for the name, namespace and use_sim_time.

## Description of how this change was tested

- verified that the costmap nodes retain the expected name and namespace
- verified that the costmap topics retain the expected name and namespace
- verified that the costmap services retain the expected name and namespace
- verified that it's possible to remap topic names for the costmap subscribers.

---

## Future work that may be required in bullet points

The free functions might be moved to utils and used where other child nodes are created if the use-case arises.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
