### PR TITLE
Revert "Removing underlay workspace from Main"

### DIFF
--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -1,8 +1,8 @@
 repositories:
-  # BehaviorTree/BehaviorTree.CPP:
-  #   type: git
-  #   url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-  #   version: 4.6.2
+  BehaviorTree/BehaviorTree.CPP:
+    type: git
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: 4.6.2
   # ros/angles:
   #   type: git
   #   url: https://github.com/ros/angles.git
@@ -35,7 +35,7 @@ repositories:
   #   type: git
   #   url:  https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
   #  version: 091b5ff12436890a54de6325df3573ae110e912b
-  # ros/common_interfaces:
-  #   type: git
-  #   url:  https://github.com/ros2/common_interfaces.git
-  #   version: rolling
+  ros/common_interfaces:
+    type: git
+    url:  https://github.com/ros2/common_interfaces.git
+    version: rolling

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -35,7 +35,7 @@ repositories:
   #   type: git
   #   url:  https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
   #  version: 091b5ff12436890a54de6325df3573ae110e912b
-  ros/common_interfaces:
-    type: git
-    url:  https://github.com/ros2/common_interfaces.git
-    version: rolling
+  # ros/common_interfaces:
+  #   type: git
+  #   url:  https://github.com/ros2/common_interfaces.git
+  #   version: rolling


### PR DESCRIPTION
Reverts ros-navigation/navigation2#5200 Seems that it is still necessary due to BT.CPP binaries not in Rolling still