### PR TITLE
[BtActionServer] default enable_groot_monitoring_ to false to solve `Original error: Address already in use` migration error

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -285,7 +285,7 @@ protected:
   bool always_reload_bt_xml_ = false;
 
   // Parameters for Groot2 monitoring
-  bool enable_groot_monitoring_ = true;
+  bool enable_groot_monitoring_ = false;
   int groot_server_port_ = 1667;
 
   // User-provided callbacks


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory simulation|
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Since https://github.com/ros-navigation/navigation2/pull/5065, groot monitoring is enabled by default for all `BtActionServer`s : https://github.com/ros-navigation/navigation2/blob/7f561b0f5aa8e229334bb6f71a7a99e6074efd75/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp#L288

This causes issue for users of simple `BtActionServer`s that by default are not calling `setGrootMonitoring`: https://github.com/ros-navigation/navigation2/blob/7f561b0f5aa8e229334bb6f71a7a99e6074efd75/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp#L239.
And hence, if they have more than one such action, they are faced with a `Original error: Address already in use` error.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Full launch of Dexory stack

---

## Future work that may be required in bullet points

For non `BehaviorTreeNavigator` actions, it would have been simpler to have `enable_groot_monitoring` and `groot_server_port` as parameters of `BtActionServer` (like for instance `bt_loop_duration`, `default_server_timeout`, `wait_for_service_timeout` and `always_reload_bt_xml`) but I understand the need for being able to set different values for 2 different pluggins of 1 `bt_navigator`.
Or maybe a future work could combine both ? 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
