### PR TITLE
Parametrizing obstacle layer tf filter tolerance

### DIFF
--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -46,6 +46,7 @@
 #include "pluginlib/class_list_macros.hpp"
 #include "sensor_msgs/point_cloud2_iterator.hpp"
 #include "nav2_costmap_2d/costmap_math.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "rclcpp/version.h"
 
 PLUGINLIB_EXPORT_CLASS(nav2_costmap_2d::ObstacleLayer, nav2_costmap_2d::Layer)
@@ -100,6 +101,8 @@ void ObstacleLayer::onInitialize()
   node->get_parameter("track_unknown_space", track_unknown_space);
   node->get_parameter("transform_tolerance", transform_tolerance);
   node->get_parameter(name_ + "." + "observation_sources", topics_string);
+  double tf_filter_tolerance = nav2_util::declare_or_get_parameter(node, name_ + "." +
+      "tf_filter_tolerance", 0.05);
 
   int combination_method_param{};
   node->get_parameter(name_ + "." + "combination_method", combination_method_param);
@@ -278,7 +281,8 @@ void ObstacleLayer::onInitialize()
       observation_subscribers_.push_back(sub);
 
       observation_notifiers_.push_back(filter);
-      observation_notifiers_.back()->setTolerance(rclcpp::Duration::from_seconds(0.05));
+      observation_notifiers_.back()->setTolerance(rclcpp::Duration::from_seconds(
+          tf_filter_tolerance));
 
     } else {
       // For Kilted and Older Support from Message Filters API change


### PR DESCRIPTION
## Basic Info

| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation and Hardware |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Setting a tf filter tolerance != 0 might be undesired as it increases the chance of the messages being delayed or even discarded if the tf_timeout tolerance associated with the buffer is not big enough. Hence the option to set it to a different value through a parameter.

Also note that this tolerance is not set for pointcloud sources.

## Description of documentation updates required from your changes

Added new parameter

## Description of how this change was tested

Simulation and hardware -> it was verified that setting the parameter to 0.0 with a transform tolerance of 100ms prevents the filter from dropping messages, while a bigger tolerance is required with the default value of 0.05.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
