### PR TITLE
Use fixed thresholds for Trinary yaml

### DIFF
--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -602,8 +602,18 @@ void tryWriteMapToFile(
     e << YAML::Key << "origin" << YAML::Flow << YAML::BeginSeq << map.info.origin.position.x <<
       map.info.origin.position.y << yaw << YAML::EndSeq;
     e << YAML::Key << "negate" << YAML::Value << 0;
-    e << YAML::Key << "occupied_thresh" << YAML::Value << save_parameters.occupied_thresh;
-    e << YAML::Key << "free_thresh" << YAML::Value << save_parameters.free_thresh;
+
+    if (save_parameters.mode == MapMode::Trinary) {
+      // For Trinary mode, the thresholds depend on the pixel values in the saved map,
+      // not on the thresholds used to threshold the map.
+      // As these values are fixed above, the thresholds must also be fixed to separate the
+      // pixel values into occupied, free and unknown.
+      e << YAML::Key << "occupied_thresh" << YAML::Value << 0.65;
+      e << YAML::Key << "free_thresh" << YAML::Value << 0.196;
+    } else {
+      e << YAML::Key << "occupied_thresh" << YAML::Value << save_parameters.occupied_thresh;
+      e << YAML::Key << "free_thresh" << YAML::Value << save_parameters.free_thresh;
+    }
 
     if (!e.good()) {
       RCLCPP_ERROR_STREAM(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  gazebo simulation , Jazzy |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Supersedes #5138 

This PR uses fixed values for the threshold saved to the yaml file, in Trinary mode. Similarly to [ROS 1](https://github.com/ros-planning/navigation/blob/9ad644198e132d0e950579a3bc72c29da46e60b0/map_server/src/map_saver.cpp#L95-L116).
With this change, Trinary maps loaded created and loaded with the map_server, will now load correctly. This is because the pixel values saved in this mode are constants, so when loading the map the thresholds must lie between the pixel values for correct loading. The thresholds supplied by the user are still used for thresholding the input map before saving (to reduce noise)

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes
None
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Use `ros2 run nav2_map_server map_saver_cli` with various arguments. The threshold saved should be fixed to 0.65 and 0.196 in Trinary mode. Other modes should not be affected.

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
