### PR TITLE
[Safety] Zero velocity should always be published on controller failure

### DIFF
--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -179,7 +179,7 @@ protected:
   /**
    * @brief Called on goal exit
    */
-  void onGoalExit();
+  void onGoalExit(bool force_stop);
   /**
    * @brief Checks if goal is reached
    * @return true or false


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |https://github.com/ros-navigation/navigation2/issues/5273|
| Primary OS tested on | (Ubuntu 24.04) |
| Robotic platform tested on | (TB4 Simulation) |
| Does this PR contain AI generated software? | (Yes) |

---

## Description of contribution in a few bullet points

* Modified `onGoalExit()` in `nav2_controller` to accept a `bool force_stop` argument.
* Ensured that a zero velocity is always published in cases of failure or exception, regardless of the `publish_zero_velocity` parameter setting.
* Improves safety behavior by guaranteeing that the robot stops on controller failure, cancellation, or internal exception.
* Updated all exit points in `computeControl()` to call `onGoalExit(true)` on failure and `onGoalExit(false)` on success.

## Description of documentation updates required from your changes

* No new parameters introduced.
* Minor clarification could be added to the `publish_zero_velocity` parameter documentation:
  > This parameter only affects zero-velocity publishing on successful goal completion. Failures or cancellations will now always publish zero velocity regardless of this setting.

## Description of testing

Tested using the Nav2 TurtleBot4 simulation:

```bash
ros2 launch nav2_bringup tb4_simulation_launch.py headless:=False
```

- Sent a navigation goal via RViz, then canceled it mid-execution.
- Verified that `/cmd_vel_nav` published a zero velocity immediately after cancellation:

```bash
ros2 topic echo /cmd_vel_nav 
```

- Confirmed that a zero velocity was sent even when `publish_zero_velocity := false`.

---

## Future work that may be required in bullet points

* Consider introducing an explicit `always_stop_on_failure` parameter for full user control over emergency stop policy.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
