### PR TITLE
Fix compilation of nav2_smac_planner on Windows

### DIFF
--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -42,9 +42,17 @@ add_library(${library_name}_common SHARED
   src/node_lattice.cpp
   src/smoother.cpp
 )
+# Add GenerateExportHeader support for symbol visibility, as we are using
+# static members we need to explicitly export them on Windows, as
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS does not work with static members.
+include(GenerateExportHeader)
+generate_export_header(${library_name}_common
+  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME}/${library_name}_common_visibility_control.hpp"
+)
 target_include_directories(${library_name}_common
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
     ${OMPL_INCLUDE_DIRS}
 )
@@ -165,6 +173,10 @@ install(TARGETS ${library_name}_common ${library_name} ${library_name}_2d ${libr
 )
 
 install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME}/${library_name}_common_visibility_control.hpp"
   DESTINATION include/${PROJECT_NAME}
 )
 

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -26,6 +26,7 @@
 #include "nav2_smac_planner/types.hpp"
 #include "nav2_smac_planner/collision_checker.hpp"
 #include "nav2_smac_planner/costmap_downsampler.hpp"
+#include "nav2_smac_planner/nav2_smac_planner_common_visibility_control.hpp"
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "nav2_costmap_2d/inflation_layer.hpp"
 
@@ -473,16 +474,16 @@ public:
   Coordinates pose;
 
   // Constants required across all nodes but don't want to allocate more than once
-  static float travel_distance_cost;
-  static HybridMotionTable motion_table;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static float travel_distance_cost;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static HybridMotionTable motion_table;
   // Wavefront lookup and queue for continuing to expand as needed
-  static LookupTable obstacle_heuristic_lookup_table;
-  static ObstacleHeuristicQueue obstacle_heuristic_queue;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static LookupTable obstacle_heuristic_lookup_table;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static ObstacleHeuristicQueue obstacle_heuristic_queue;
 
-  static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
-  static LookupTable dist_heuristic_lookup_table;
-  static float size_lookup;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static LookupTable dist_heuristic_lookup_table;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static float size_lookup;
 
 private:
   float _cell_cost;

--- a/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
@@ -27,6 +27,7 @@
 #include "nav2_smac_planner/collision_checker.hpp"
 #include "nav2_smac_planner/node_hybrid.hpp"
 #include "nav2_smac_planner/utils.hpp"
+#include "nav2_smac_planner/nav2_smac_planner_common_visibility_control.hpp"
 
 namespace nav2_smac_planner
 {
@@ -415,10 +416,10 @@ public:
 
   NodeLattice * parent;
   Coordinates pose;
-  static LatticeMotionTable motion_table;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static LatticeMotionTable motion_table;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
-  static LookupTable dist_heuristic_lookup_table;
-  static float size_lookup;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static LookupTable dist_heuristic_lookup_table;
+  NAV2_SMAC_PLANNER_COMMON_EXPORT static float size_lookup;
 
 private:
   float _cell_cost;


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Windows |
| Robotic platform tested on | None, compilation fix. |
| Does this PR contain AI generated software? | No. |

---

## Description of contribution in a few bullet points

`navigation2` uses the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` to build shared libraries on Windows, see https://github.com/ros-navigation/navigation2/pull/1704 for more details. However, `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` can't automatically export public static members, see https://www.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/ . 

In case that public static members are needed, it is necessary to manually annotate them with visibility macros. This PR does that for the static members that are actually used in the code, in `node_hybrid` and `node_lattice` files.

## Description of documentation updates required from your changes

None.


## Description of how this change was tested

I compiled the package on Windows.


## Future work that may be required in bullet points

None


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
