### PR TITLE
Remove unused unistd.h include from route_tool.cpp

### DIFF
--- a/nav2_rviz_plugins/src/route_tool.cpp
+++ b/nav2_rviz_plugins/src/route_tool.cpp
@@ -15,7 +15,6 @@
 #include "nav2_rviz_plugins/route_tool.hpp"
 #include <QDesktopServices>
 #include <QUrl>
-#include <unistd.h>
 #include <sys/types.h>
 #include <QFileDialog>
 #include "rviz_common/display_context.hpp"


### PR DESCRIPTION


## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Windows |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | None |

---

## Description of contribution in a few bullet points

The `unistd.h` header seems unused, and removing it permit to compile the project on Windows.

## Description of documentation updates required from your changes

None.

## Description of how this change was tested

Tested if compilation was successful.



## Future work that may be required in bullet points

None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
