### PR TITLE
Add wrap_around parameter to RoundRobin node to control wrap-around behavior

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -82,11 +82,17 @@ public:
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */
-  static BT::PortsList providedPorts() {return {};}
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::InputPort<bool>("wrap_around", false, "Enable wrap-around to first child after last child fails")
+    };
+  }
 
 private:
   unsigned int current_child_idx_{0};
   unsigned int num_failed_children_{0};
+  bool wrap_around_{false};
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -388,7 +388,9 @@
       <input_port name="number_of_retries">Number of retries</input_port>
     </Control>
 
-    <Control ID="RoundRobin"/>
+    <Control ID="RoundRobin">
+      <input_port name="wrap_around" default="false">Enable wrap-around to first child after last child fails</input_port>
+    </Control>
 
     <!-- ############################### DECORATOR NODES ############################## -->
     <Decorator ID="RateController">

--- a/nav2_behavior_tree/plugins/control/round_robin_node.cpp
+++ b/nav2_behavior_tree/plugins/control/round_robin_node.cpp
@@ -20,7 +20,7 @@ namespace nav2_behavior_tree
 {
 
 RoundRobinNode::RoundRobinNode(const std::string & name)
-: BT::ControlNode::ControlNode(name, {})
+: BT::ControlNode::ControlNode(name, {}), wrap_around_(false)
 {
 }
 
@@ -29,6 +29,7 @@ RoundRobinNode::RoundRobinNode(
   const BT::NodeConfiguration & config)
 : BT::ControlNode(name, config)
 {
+  getInput("wrap_around", wrap_around_);
 }
 
 BT::NodeStatus RoundRobinNode::tick()
@@ -43,9 +44,14 @@ BT::NodeStatus RoundRobinNode::tick()
     const BT::NodeStatus child_status = child_node->executeTick();
 
     if (child_status != BT::NodeStatus::RUNNING) {
-      // Increment index and wrap around to the first child
+      // Increment index and wrap around to the first child if enabled
       if (++current_child_idx_ == num_children) {
-        current_child_idx_ = 0;
+        if (wrap_around_) {
+          current_child_idx_ = 0;
+        } else {
+          // Exit early if wrap around is disabled and we've reached the end
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
This PR implements the feature requested in #5033 to add a boolean parameter that controls whether the RoundRobin behavior tree node wraps around to its first child after the last one fails.

## Changes

- Added `wrap_around` boolean parameter (default: false) to RoundRobin node
- When `wrap_around=false`, node returns FAILURE instead of wrapping to first child
- Updated XML node definition to include new parameter
- Existing behavior tree XMLs will use new non-wrap-around behavior by default

## Problem Solved

Addresses issue where RoundRobin index can become misaligned with RecoveryNode retry counter when used in recovery sequences. The new default behavior (no wrap-around) ensures each recovery action is performed once and only once.

Fixes #5033

Generated with [Claude Code](https://claude.ai/code)