### PR TITLE
Adding initial prototype for a MPPI trajectory validator

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -141,6 +141,11 @@ controller_server:
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3
+      TrajectoryValidator:
+        plugin: "mppi::DefaultOptimalTrajectoryValidator"
+        # The validator can be configured with additional parameters if needed.
+        # For example, you can set a threshold for the trajectory validation.
+        # validation_threshold: 0.5
       AckermannConstraints:
         min_turning_r: 0.2
       critics:

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -142,10 +142,10 @@ controller_server:
         trajectory_step: 5
         time_step: 3
       TrajectoryValidator:
-        plugin: "mppi::DefaultOptimalTrajectoryValidator"
         # The validator can be configured with additional parameters if needed.
-        # For example, you can set a threshold for the trajectory validation.
-        # validation_threshold: 0.5
+        plugin: "mppi::DefaultOptimalTrajectoryValidator"
+        collision_lookahead_time: 2.0  # Time to look ahead to check for collisions
+        consider_footprint: false  # Whether to consider the full robot's footprint (or circle) in trajectory validation collision checks
       AckermannConstraints:
         min_turning_r: 0.2
       critics:

--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -107,7 +107,35 @@ target_link_libraries(mppi_critics PRIVATE
   pluginlib::pluginlib
 )
 
-install(TARGETS mppi_controller mppi_critics
+add_library(mppi_trajectory_validators SHARED
+  src/trajectory_validators/optimal_trajectory_validator.cpp
+)
+target_compile_options(mppi_trajectory_validators PUBLIC -O3)
+target_include_directories(mppi_trajectory_validators
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+    "$<BUILD_INTERFACE:${nav2_ros_common_INCLUDE_DIRS}>")
+target_link_libraries(mppi_trajectory_validators PUBLIC
+  angles::angles
+  ${geometry_msgs_TARGETS}
+  nav2_core::nav2_core
+  nav2_costmap_2d::layers
+  nav2_costmap_2d::nav2_costmap_2d_core
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${std_msgs_TARGETS}
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+  ${visualization_msgs_TARGETS}
+)
+target_link_libraries(mppi_trajectory_validators PRIVATE
+  pluginlib::pluginlib
+)
+
+install(TARGETS mppi_controller mppi_critics mppi_trajectory_validators
   EXPORT nav2_mppi_controller
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -153,5 +181,6 @@ ament_export_targets(nav2_mppi_controller)
 
 pluginlib_export_plugin_description_file(nav2_core mppic.xml)
 pluginlib_export_plugin_description_file(nav2_mppi_controller critics.xml)
+pluginlib_export_plugin_description_file(nav2_mppi_controller trajectory_validators.xml)
 
 ament_package()

--- a/nav2_mppi_controller/benchmark/optimizer_benchmark.cpp
+++ b/nav2_mppi_controller/benchmark/optimizer_benchmark.cpp
@@ -28,6 +28,7 @@
 #include <nav2_costmap_2d/costmap_2d.hpp>
 #include <nav2_costmap_2d/costmap_2d_ros.hpp>
 #include <nav2_core/goal_checker.hpp>
+#include "tf2_ros/buffer.h"
 
 #include "nav2_mppi_controller/optimizer.hpp"
 #include "nav2_mppi_controller/motion_models.hpp"
@@ -81,7 +82,8 @@ void prepareAndRunBenchmark(
   auto node = getDummyNode(optimizer_settings, critics);
   std::string name = "test";
   auto parameters_handler = std::make_unique<mppi::ParametersHandler>(node, name);
-  auto optimizer = getDummyOptimizer(node, costmap_ros, parameters_handler.get());
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  auto optimizer = getDummyOptimizer(node, costmap_ros, tf_buffer, parameters_handler.get());
 
   // evalControl args
   auto pose = getDummyPointStamped(node, start_pose);
@@ -90,7 +92,8 @@ void prepareAndRunBenchmark(
   nav2_core::GoalChecker * dummy_goal_checker{nullptr};
 
   for (auto _ : state) {
-    optimizer->evalControl(pose, velocity, path, path.poses.back().pose, dummy_goal_checker);
+    auto [cmd, trajectory] = optimizer->evalControl(pose, velocity, path, path.poses.back().pose,
+      dummy_goal_checker);
   }
 }
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__OPTIMAL_TRAJECTORY_VALIDATOR_HPP_
+#define NAV2_MPPI_CONTROLLER__OPTIMAL_TRAJECTORY_VALIDATOR_HPP_
+
+#include <Eigen/Core>
+#include <string>
+#include <memory>
+
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
+#include "tf2_ros/buffer.h"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav_msgs/msg/path.hpp"
+
+#include "nav2_mppi_controller/tools/parameters_handler.hpp"
+#include "nav2_mppi_controller/models/control_sequence.hpp"
+
+namespace mppi
+{
+
+enum class ValidationResult
+{
+  SUCCESS,
+  SOFT_RESET,
+  FAILURE,
+};
+
+/**
+ * @class mppi::OptimalTrajectoryValidator
+ * @brief Abstract base class for validating optimal trajectories from MPPI optimization
+ */
+class OptimalTrajectoryValidator
+{
+public:
+  using Ptr = std::shared_ptr<OptimalTrajectoryValidator>;
+
+  /**
+   * @brief Constructor for mppi::OptimalTrajectoryValidator
+   */
+  OptimalTrajectoryValidator() = default;
+
+  /**
+   * @brief Destructor for mppi::OptimalTrajectoryValidator
+   */
+  virtual ~OptimalTrajectoryValidator() = default;
+
+  /**
+   * @brief Initialize the trajectory validator
+   * @param node Weak pointer to the lifecycle node
+   * @param name Name of the validator plugin
+   * @param costmap Shared pointer to the costmap ROS wrapper
+   * @param param_handler Pointer to the parameters handler
+   * @param tf_buffer Shared pointer to the TF buffer
+   */
+  virtual void initialize(
+    const nav2::LifecycleNode::WeakPtr & node,
+    const std::string & name,
+    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap,
+    ParametersHandler * param_handler,
+    const std::shared_ptr<tf2_ros::Buffer> tf_buffer)
+  {
+    param_handler_ = param_handler;
+    name_ = name;
+    node_ = node;
+    costmap_ = costmap;
+    tf_buffer_ = tf_buffer;
+  }
+
+  /**
+   * @brief Validate the optimal control sequence from MPPI optimization
+   * @param optimal_control The optimal control sequence to validate
+   * @param robot_pose The current pose of the robot
+   * @param robot_speed The current speed of the robot
+   * @param plan The planned path for the robot
+   * @param goal The goal pose for the robot
+   * @return True if the trajectory is valid, false otherwise
+   */
+  virtual ValidationResult validateTrajectory(
+    const Eigen::ArrayXXf & /*optimal_control*/,
+    const geometry_msgs::msg::PoseStamped /*robot_pose*/,
+    const geometry_msgs::msg::Twist /*robot_speed*/,
+    const nav_msgs::msg::Path & /*plan*/,
+    const geometry_msgs::msg::Pose & /*goal*/)
+  {
+    return ValidationResult::SUCCESS;
+  }
+
+protected:
+  nav2::LifecycleNode::WeakPtr node_;
+  std::string name_;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_;
+  ParametersHandler * param_handler_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+};
+
+}  // namespace mppi
+
+#endif  // NAV2_MPPI_CONTROLLER__OPTIMAL_TRAJECTORY_VALIDATOR_HPP_

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
@@ -98,7 +98,7 @@ public:
     getParam(consider_footprint_, "consider_footprint", false);
     if (consider_footprint_) {
       collision_checker_ = std::make_unique<nav2_costmap_2d::FootprintCollisionChecker<
-        nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
+            nav2_costmap_2d::Costmap2D *>>(costmap_ros_->getCostmap());
     }
   }
 
@@ -167,7 +167,7 @@ protected:
   unsigned int traj_samples_to_evaluate_{0u};
   bool consider_footprint_{false};
   std::unique_ptr<nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>>
-    collision_checker_;
+  collision_checker_;
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimal_trajectory_validator.hpp
@@ -81,8 +81,9 @@ public:
   }
 
   /**
-   * @brief Validate the optimal control sequence from MPPI optimization
-   * @param optimal_control The optimal control sequence to validate
+   * @brief Validate the optimal trajectory from MPPI optimization
+   * @param optimal_trajectory The optimal trajectory to validate
+   * @param control_sequence The control sequence to validate
    * @param robot_pose The current pose of the robot
    * @param robot_speed The current speed of the robot
    * @param plan The planned path for the robot
@@ -90,7 +91,8 @@ public:
    * @return True if the trajectory is valid, false otherwise
    */
   virtual ValidationResult validateTrajectory(
-    const Eigen::ArrayXXf & /*optimal_control*/,
+    const Eigen::ArrayXXf & /*optimal_trajectory*/,
+    const models::ControlSequence & /*control_sequence*/,
     const geometry_msgs::msg::PoseStamped /*robot_pose*/,
     const geometry_msgs::msg::Twist /*robot_speed*/,
     const nav_msgs::msg::Path & /*plan*/,

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -19,12 +19,15 @@
 
 #include <string>
 #include <memory>
+#include <tuple>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "nav2_core/goal_checker.hpp"
 #include "nav2_core/controller_exceptions.hpp"
+#include "tf2_ros/buffer.h"
+#include "pluginlib/class_loader.hpp"
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -40,6 +43,7 @@
 #include "nav2_mppi_controller/tools/noise_generator.hpp"
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
+#include "nav2_mppi_controller/optimal_trajectory_validator.hpp"
 
 namespace mppi
 {
@@ -68,10 +72,12 @@ public:
    * @param name Name of plugin
    * @param costmap_ros Costmap2DROS object of environment
    * @param dynamic_parameter_handler Parameter handler object
+   * @param tf_buffer TF buffer for transformations
    */
   void initialize(
     nav2::LifecycleNode::WeakPtr parent, const std::string & name,
     std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros,
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer,
     ParametersHandler * dynamic_parameters_handler);
 
   /**
@@ -86,9 +92,9 @@ public:
    * @param plan Path plan to track
    * @param goal Given Goal pose to reach.
    * @param goal_checker Object to check if goal is completed
-   * @return TwistStamped of the MPPI control
+   * @return Tuple of [TwistStamped command, optimal trajectory]
    */
-  geometry_msgs::msg::TwistStamped evalControl(
+  std::tuple<geometry_msgs::msg::TwistStamped, Eigen::ArrayXXf> evalControl(
     const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::Twist & robot_speed, const nav_msgs::msg::Path & plan,
     const geometry_msgs::msg::Pose & goal, nav2_core::GoalChecker * goal_checker);
@@ -260,6 +266,9 @@ protected:
   ParametersHandler * parameters_handler_;
   CriticManager critic_manager_;
   NoiseGenerator noise_generator_;
+
+  std::unique_ptr<pluginlib::ClassLoader<OptimalTrajectoryValidator>> validator_loader_;
+  OptimalTrajectoryValidator::Ptr trajectory_validator_;
 
   models::OptimizerSettings settings_;
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -260,6 +260,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav2_costmap_2d::Costmap2D * costmap_;
   std::string name_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
   std::shared_ptr<MotionModel> motion_model_;
 

--- a/nav2_mppi_controller/package.xml
+++ b/nav2_mppi_controller/package.xml
@@ -39,6 +39,7 @@
     <build_type>ament_cmake</build_type>
     <nav2_core plugin="${prefix}/mppic.xml" />
     <nav2_mppi_controller plugin="${prefix}/critics.xml" />
+    <nav2_mppi_controller plugin="${prefix}/trajectory_validators.xml" />
   </export>
 
 </package>

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -41,7 +41,7 @@ void MPPIController::configure(
   getParam(publish_optimal_trajectory_, "publish_optimal_trajectory", false);
 
   // Configure composed objects
-  optimizer_.initialize(parent_, name_, costmap_ros_, parameters_handler_.get());
+  optimizer_.initialize(parent_, name_, costmap_ros_, tf_buffer_, parameters_handler_.get());
   path_handler_.initialize(parent_, name_, costmap_ros_, tf_buffer_, parameters_handler_.get());
   trajectory_visualizer_.on_configure(
     parent_, name_,
@@ -106,7 +106,7 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
   nav2_costmap_2d::Costmap2D * costmap = costmap_ros_->getCostmap();
   std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> costmap_lock(*(costmap->getMutex()));
 
-  geometry_msgs::msg::TwistStamped cmd =
+  auto [cmd, optimal_trajectory] =
     optimizer_.evalControl(robot_pose, robot_speed, transformed_plan, goal, goal_checker);
 
 #ifdef BENCHMARK_TESTING
@@ -115,9 +115,7 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
   RCLCPP_INFO(logger_, "Control loop execution time: %ld [ms]", duration);
 #endif
 
-  Eigen::ArrayXXf optimal_trajectory;
   if (publish_optimal_trajectory_ && opt_traj_pub_->get_subscription_count() > 0) {
-    optimal_trajectory = optimizer_.getOptimizedTrajectory();
     auto trajectory_msg = utils::toTrajectoryMsg(
       optimal_trajectory,
       optimizer_.getOptimalControlSequence(),
@@ -139,12 +137,7 @@ void MPPIController::visualize(
   const Eigen::ArrayXXf & optimal_trajectory)
 {
   trajectory_visualizer_.add(optimizer_.getGeneratedTrajectories(), "Candidate Trajectories");
-  if (optimal_trajectory.size() > 0) {
-    trajectory_visualizer_.add(optimal_trajectory, "Optimal Trajectory", cmd_stamp);
-  } else {
-    trajectory_visualizer_.add(
-      optimizer_.getOptimizedTrajectory(), "Optimal Trajectory", cmd_stamp);
-  }
+  trajectory_visualizer_.add(optimal_trajectory, "Optimal Trajectory", cmd_stamp);
   trajectory_visualizer_.visualize(std::move(transformed_plan));
 }
 

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -24,7 +24,7 @@ namespace mppi::critics
 void ObstaclesCritic::initialize()
 {
   auto getParentParam = parameters_handler_->getParamGetter(parent_name_);
-  getParentParam(enforce_path_inversion_, "enforce_path_inversion1", false);
+  getParentParam(enforce_path_inversion_, "enforce_path_inversion", false);
 
   auto getParam = parameters_handler_->getParamGetter(name_);
   getParam(consider_footprint_, "consider_footprint", false);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -186,7 +186,7 @@ std::tuple<geometry_msgs::msg::TwistStamped, Eigen::ArrayXXf> Optimizer::evalCon
     optimize();
     optimal_trajectory = getOptimizedTrajectory();
     mppi::ValidationResult validation_result = trajectory_validator_->validateTrajectory(
-      optimal_trajectory, robot_pose, robot_speed, plan, goal);
+      optimal_trajectory, control_sequence_, robot_pose, robot_speed, plan, goal);
     switch (validation_result) {
       case mppi::ValidationResult::SOFT_RESET:
         trajectory_valid = false;

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -50,7 +50,10 @@ void Optimizer::initialize(
   critic_manager_.on_configure(parent_, name_, costmap_ros_, parameters_handler_);
   noise_generator_.initialize(settings_, isHolonomic(), name_, parameters_handler_);
 
-  // This may throw an exception if not valid and fail controller server initialization
+  // This may throw an exception if not valid and fail initialization
+  nav2::declare_parameter_if_not_declared(
+    node, name_ + ".TrajectoryValidator.plugin",
+    rclcpp::ParameterValue("mppi::DefaultOptimalTrajectoryValidator"));
   std::string validator_plugin_type = nav2::get_plugin_type_param(
     node, name_ + ".TrajectoryValidator");
   validator_loader_ = std::make_unique<pluginlib::ClassLoader<OptimalTrajectoryValidator>>(

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -41,6 +41,7 @@ void Optimizer::initialize(
   costmap_ros_ = costmap_ros;
   costmap_ = costmap_ros_->getCostmap();
   parameters_handler_ = param_handler;
+  tf_buffer_ = tf_buffer;
 
   auto node = parent_.lock();
   logger_ = node->get_logger();
@@ -60,7 +61,8 @@ void Optimizer::initialize(
     "nav2_mppi_controller", "mppi::OptimalTrajectoryValidator");
   trajectory_validator_ = validator_loader_->createUniqueInstance(validator_plugin_type);
   trajectory_validator_->initialize(
-    parent_, name_ + ".TrajectoryValidator", costmap_ros_, parameters_handler_, tf_buffer);
+    parent_, name_ + ".TrajectoryValidator",
+    costmap_ros_, parameters_handler_, tf_buffer, settings_);
   RCLCPP_INFO(logger_, "Loaded trajectory validator plugin: %s", validator_plugin_type.c_str());
 
   reset();
@@ -165,6 +167,9 @@ void Optimizer::reset(bool reset_dynamic_speed_limits)
 
   noise_generator_.reset(settings_, isHolonomic());
   motion_model_->initialize(settings_.constraints, settings_.model_dt);
+  trajectory_validator_->initialize(
+    parent_, name_ + ".TrajectoryValidator",
+    costmap_ros_, parameters_handler_, tf_buffer_, settings_);
 
   RCLCPP_INFO(logger_, "Optimizer reset");
 }

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -193,9 +193,9 @@ std::tuple<geometry_msgs::msg::TwistStamped, Eigen::ArrayXXf> Optimizer::evalCon
   do {
     optimize();
     optimal_trajectory = getOptimizedTrajectory();
-    mppi::ValidationResult validation_result = trajectory_validator_->validateTrajectory(
-      optimal_trajectory, control_sequence_, robot_pose, robot_speed, plan, goal);
-    switch (validation_result) {
+    switch (trajectory_validator_->validateTrajectory(
+      optimal_trajectory, control_sequence_, robot_pose, robot_speed, plan, goal))
+    {
       case mppi::ValidationResult::SOFT_RESET:
         trajectory_valid = false;
         RCLCPP_WARN(logger_, "Soft reset triggered by trajectory validator");

--- a/nav2_mppi_controller/src/trajectory_validators/optimal_trajectory_validator.cpp
+++ b/nav2_mppi_controller/src/trajectory_validators/optimal_trajectory_validator.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/optimal_trajectory_validator.hpp"
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(mppi::OptimalTrajectoryValidator, mppi::OptimalTrajectoryValidator)

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_mppi_controller/optimizer.hpp"
+#include "tf2_ros/buffer.h"
 
 // Tests main optimizer functions
 
@@ -233,7 +234,8 @@ TEST(OptimizerTests, BasicInitializedFunctions)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test value of ax_min, ay_min it should be negative
   auto & constraints = optimizer_tester.getControlConstraints();
@@ -271,7 +273,8 @@ TEST(OptimizerTests, TestOptimizerMotionModels)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Diff Drive should be non-holonomic
   optimizer_tester.resetMotionModel();
@@ -304,7 +307,8 @@ TEST(OptimizerTests, setOffsetTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test offsets are properly set based on relationship of model_dt and controller frequency
   // Also tests getting set model_dt parameter.
@@ -328,7 +332,8 @@ TEST(OptimizerTests, resetTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Tests resetting the full state of all the functions after filling with garbage
   optimizer_tester.fillOptimizerWithGarbage();
@@ -349,7 +354,8 @@ TEST(OptimizerTests, FallbackTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test fallback logic, also tests getting set param retry_attempt_limit
   // Because retry set to 2, it should attempt soft resets 2x before throwing exception
@@ -374,7 +380,8 @@ TEST(OptimizerTests, PrepareTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test Prepare function to set the state of the robot pose/speed on new cycle
   // Populate the contents with things easily identifiable if correct
@@ -403,7 +410,8 @@ TEST(OptimizerTests, shiftControlSequenceTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test shiftControlSequence by setting the 2nd value to something unique to neighbors
   auto & sequence = optimizer_tester.grabControlSequence();
@@ -447,7 +455,8 @@ TEST(OptimizerTests, SpeedLimitTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test Speed limits API
   auto [v_min, v_max] = optimizer_tester.getVelLimits();
@@ -488,7 +497,8 @@ TEST(OptimizerTests, applyControlSequenceConstraintsTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test constraints being applied to ensure feasibility of trajectories
   // Also tests param get of set vx/vy/wz min/maxes
@@ -550,7 +560,8 @@ TEST(OptimizerTests, updateStateVelocitiesTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test settings of the state to the initial robot speed to start rollout
   // Set model to omni to consider holonomic vy elements
@@ -576,7 +587,8 @@ TEST(OptimizerTests, getControlFromSequenceAsTwistTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
 
   // Test conversion of control sequence into a Twist command to execute
   auto & sequence = optimizer_tester.grabControlSequence();
@@ -612,7 +624,8 @@ TEST(OptimizerTests, integrateStateVelocitiesTests)
   ParametersHandler param_handler(node, name);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
   optimizer_tester.resetMotionModel();
   optimizer_tester.testSetOmniModel();
 
@@ -679,7 +692,8 @@ TEST(OptimizerTests, TestGetters)
   ParametersHandler param_handler(node, test);
   rclcpp_lifecycle::State lstate;
   costmap_ros->on_configure(lstate);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
   EXPECT_EQ(optimizer_tester.getSettings().model_dt, 0.05f);
 }
 

--- a/nav2_mppi_controller/test/utils/factory.hpp
+++ b/nav2_mppi_controller/test/utils/factory.hpp
@@ -147,15 +147,15 @@ getDummyNode(rclcpp::NodeOptions options, std::string node_name = std::string("d
   return node;
 }
 
-template<typename TNode, typename TCostMap, typename TParamHandler>
+template<typename TNode, typename TCostMap, typename TFBuffer, typename TParamHandler>
 std::shared_ptr<mppi::Optimizer> getDummyOptimizer(
-  TNode node, TCostMap costmap_ros,
+  TNode node, TCostMap costmap_ros, TFBuffer tf_buffer,
   TParamHandler * params_handler)
 {
   std::shared_ptr<mppi::Optimizer> optimizer = std::make_shared<mppi::Optimizer>();
   nav2::LifecycleNode::WeakPtr weak_ptr_node{node};
 
-  optimizer->initialize(weak_ptr_node, node->get_name(), costmap_ros, params_handler);
+  optimizer->initialize(weak_ptr_node, node->get_name(), costmap_ros, tf_buffer, params_handler);
 
   return optimizer;
 }

--- a/nav2_mppi_controller/trajectory_validators.xml
+++ b/nav2_mppi_controller/trajectory_validators.xml
@@ -1,0 +1,7 @@
+<class_libraries>
+  <library path="mppi_trajectory_validators">
+    <class name="mppi::DefaultOptimalTrajectoryValidator" type="mppi::OptimalTrajectoryValidator" base_class_type="mppi::OptimalTrajectoryValidator">
+      <description>Default trajectory validator for MPPI controller</description>
+    </class>
+  </library>
+</class_libraries>


### PR DESCRIPTION
This creates a new plugin interface to MPPI which takes in the control request, optimal trajectory, and outputs if this is valid. 

This is performed after the optimization process is completed to receive a final trajectory for smoothing - so we should already be applying kinematic and dynamic constraints to the output to make sure its valid in that regard. It should also be known collision free since that would trigger a soft and then hard reset if no trajectories are valid. 

This can be used to validate the trajectory based on application specific constraints, constraints on control due to standards or multi-robot coordination, via point achievement, and so forth. 

TODO
- [x] Add docs for this new plugin + migration guide
- [x] Provide a non-trivial implementation for users


On implementation, we could add in:
- Parameter for max deviation from a path
- Additional non-collision margin from obstacles
- That this trajectory makes some non-trivial progress and doesn't sit idle due to a local minimum 