### PR TITLE
fix: correct ThroughActionResult type alias in would_a_planner_recovery_help_condition

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
@@ -29,7 +29,7 @@ class WouldAPlannerRecoveryHelp : public AreErrorCodesPresent
   using Action = nav2_msgs::action::ComputePathToPose;
   using ActionResult = Action::Result;
   using ThroughAction = nav2_msgs::action::ComputePathThroughPoses;
-  using ThroughActionResult = Action::Result;
+  using ThroughActionResult = ThroughAction::Result;
 
 public:
   WouldAPlannerRecoveryHelp(


### PR DESCRIPTION
Fixes a typo in the `ThroughActionResult` type alias that was causing the `Would_a_planner_recovery_help_condition` BT node to not work properly for `ComputePathThroughPoses` actions.

The issue was on line 32 where `ThroughActionResult` was incorrectly defined as `Action::Result` instead of `ThroughAction::Result`.

Fixes #5324

Generated with [Claude Code](https://claude.ai/code)