### PR TITLE
outputting tracker feedback on ComputeAndTrack BT node

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
@@ -99,12 +99,31 @@ public:
           "Whether to use the start pose or the robot's current pose"),
         BT::InputPort<bool>(
           "use_poses", false, "Whether to use poses or IDs for start and goal"),
-        BT::OutputPort<builtin_interfaces::msg::Duration>("execution_duration",
+        BT::OutputPort<builtin_interfaces::msg::Duration>(
+          "execution_duration",
           "Time taken to compute and track route"),
         BT::OutputPort<ActionResult::_error_code_type>(
           "error_code_id", "The compute route error code"),
         BT::OutputPort<std::string>(
           "error_msg", "The compute route error msg"),
+        BT::OutputPort<uint16_t>(
+          "last_node_id",
+          "ID of the previous node"),
+        BT::OutputPort<uint16_t>(
+          "next_node_id",
+          "ID of the next node"),
+        BT::OutputPort<uint16_t>(
+          "current_edge_id",
+          "ID of current edge"),
+        BT::OutputPort<nav2_msgs::msg::Route>(
+          "route",
+          "List of RouteNodes to go from start to end"),
+        BT::OutputPort<nav_msgs::msg::Path>(
+          "path",
+          "Path created by ComputeAndTrackRoute node"),
+        BT::OutputPort<bool>(
+          "rerouted",
+          "Whether the plan has rerouted"),
       });
   }
 };

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -135,6 +135,12 @@
       <output_port name="execution_time">Duration to compute route</output_port>
       <output_port name="error_code_id">"Compute route to pose error code"</output_port>
       <output_port name="error_msg">"Compute route to pose error message"</output_port>
+      <output_port name="last_node_id">"ID of the previous node"</output_port>
+      <output_port name="next_node_id">"ID of the next node"</output_port>
+      <output_port name="current_edge_id">"e"</output_port>
+      <output_port name="route">"List of RouteNodes to go from start to end"</output_port>
+      <output_port name="path">"Path created by ComputeAndTrackRoute node"</output_port>
+      <output_port name="rerouted">"Whether the plan has rerouted"</output_port>
     </Action>
 
     <Action ID="RemovePassedGoals">

--- a/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
@@ -82,7 +82,7 @@ void ComputeAndTrackRouteAction::on_timeout()
 }
 
 void ComputeAndTrackRouteAction::on_wait_for_result(
-  std::shared_ptr<const Action::Feedback>/*feedback*/)
+  std::shared_ptr<const Action::Feedback> feedback)
 {
   // Check for request updates to the goal
   bool use_poses = false, use_start = false;
@@ -128,6 +128,15 @@ void ComputeAndTrackRouteAction::on_wait_for_result(
   // Easier to call on_tick() again than to duplicate the code
   if (goal_updated_) {
     on_tick();
+  }
+
+  if (feedback) {
+    setOutput("last_node_id", feedback->last_node_id);
+    setOutput("next_node_id", feedback->next_node_id);
+    setOutput("current_edge_id", feedback->current_edge_id);
+    setOutput("route", feedback->route);
+    setOutput("path", feedback->path);
+    setOutput("rerouted", feedback->rerouted);
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

*Modified the `ComputeAndTrackRoute` BT Action node to also receive feedback and output the feedback on the black board during `on_wait_for_result` 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

* Add routing actions to https://docs.nav2.org/behavior_trees/overview/nav2_specific_nodes.html
* Add new outputs to https://docs.nav2.org/configuration/packages/bt-plugins/actions/ComputeAndTrackRoute.html

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

* This change was tested with the change in https://github.com/ros-navigation/navigation2/pull/5325 in simulation. A route was generated and `FollowPath` was used to navigate the path

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
