### PR TITLE
Fix bad_weak_ptr in createBond() by using shared_ptr

### DIFF
--- a/nav2_ros_common/include/nav2_ros_common/lifecycle_node.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/lifecycle_node.hpp
@@ -392,7 +392,7 @@ protected:
 
   // Connection to tell that server is still up
   std::unique_ptr<rclcpp::PreShutdownCallbackHandle> rcl_preshutdown_cb_handle_{nullptr};
-  std::unique_ptr<bond::Bond> bond_{nullptr};
+  std::shared_ptr<bond::Bond> bond_{nullptr};
   double bond_heartbeat_period{0.1};
   rclcpp::TimerBase::SharedPtr autostart_timer_;
 

--- a/nav2_ros_common/include/nav2_ros_common/lifecycle_node.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/lifecycle_node.hpp
@@ -312,8 +312,8 @@ public:
   {
     if (bond_heartbeat_period > 0.0) {
       RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
-
-      bond_ = std::make_unique<bond::Bond>(
+      
+      bond_ = std::make_shared<bond::Bond>(
         std::string("bond"),
         this->get_name(),
         shared_from_this());


### PR DESCRIPTION
This PR fixes a bad_weak_ptr error caused by passing a std::unique_ptr to (main)nav2_ros_common::createBond()( and nav2_util::createBond() in humble), which expects a std::shared_ptr. The incorrect ownership type led to invalid weak pointer dereferencing. This change ensures correct usage of shared_ptr to avoid runtime errors during bond creation.

- Replaces unique_ptr with shared_ptr where required
- Resolves bad_weak_ptr error in lifecycle bond handling
- Fixes https://github.com/ros-navigation/navigation2/issues/5335