### PR TITLE
Support stamped footprints in costmap_2d

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -313,7 +313,7 @@ public:
    * layered_costmap_->setFootprint().  Also saves the unpadded
    * footprint, which is available from
    * getUnpaddedRobotFootprint(). */
-  void setRobotFootprintPolygon(const geometry_msgs::msg::Polygon::SharedPtr footprint);
+  void setRobotFootprintPolygon(const geometry_msgs::msg::Polygon & footprint);
 
   std::shared_ptr<tf2_ros::Buffer> getTfBuffer() {return tf_buffer_;}
 
@@ -351,6 +351,7 @@ protected:
   std::vector<std::unique_ptr<Costmap2DPublisher>> layer_publishers_;
 
   nav2::Subscription<geometry_msgs::msg::Polygon>::SharedPtr footprint_sub_;
+  nav2::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr footprint_stamped_sub_;
   nav2::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_sub_;
 
   // Dedicated callback group and executor for tf timer_interface and message filter
@@ -407,6 +408,8 @@ protected:
   double transform_tolerance_{0};           ///< The timeout before transform errors
   double initial_transform_timeout_{0};   ///< The timeout before activation of the node errors
   double map_vis_z_{0};                 ///< The height of map, allows to avoid flickering at -0.008
+  /// If true, the footprint subscriber expects a PolygonStamped msg
+  bool subscribe_to_stamped_footprint_{false};
 
   bool is_lifecycle_follower_{true};   ///< whether is a child-LifecycleNode or an independent node
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint.hpp
@@ -65,23 +65,23 @@ std::pair<double, double> calculateMinAndMaxDistances(
 /**
  * @brief Convert Point32 to Point
  */
-geometry_msgs::msg::Point toPoint(geometry_msgs::msg::Point32 pt);
+geometry_msgs::msg::Point toPoint(const geometry_msgs::msg::Point32 & pt);
 
 /**
  * @brief Convert Point to Point32
  */
-geometry_msgs::msg::Point32 toPoint32(geometry_msgs::msg::Point pt);
+geometry_msgs::msg::Point32 toPoint32(const geometry_msgs::msg::Point & pt);
 
 /**
  * @brief Convert vector of Points to Polygon msg
  */
-geometry_msgs::msg::Polygon toPolygon(std::vector<geometry_msgs::msg::Point> pts);
+geometry_msgs::msg::Polygon toPolygon(const std::vector<geometry_msgs::msg::Point> & pts);
 
 /**
  * @brief Convert Polygon msg to vector of Points.
  */
 std::vector<geometry_msgs::msg::Point> toPointVector(
-  geometry_msgs::msg::Polygon::SharedPtr polygon);
+  const geometry_msgs::msg::Polygon & polygon);
 
 /**
  * @brief  Given a pose and base footprint, build the oriented footprint of the robot (list of Points)

--- a/nav2_costmap_2d/src/footprint.cpp
+++ b/nav2_costmap_2d/src/footprint.cpp
@@ -71,7 +71,7 @@ std::pair<double, double> calculateMinAndMaxDistances(
   return std::pair<double, double>(min_dist, max_dist);
 }
 
-geometry_msgs::msg::Point32 toPoint32(geometry_msgs::msg::Point pt)
+geometry_msgs::msg::Point32 toPoint32(const geometry_msgs::msg::Point & pt)
 {
   geometry_msgs::msg::Point32 point32;
   point32.x = pt.x;
@@ -80,7 +80,7 @@ geometry_msgs::msg::Point32 toPoint32(geometry_msgs::msg::Point pt)
   return point32;
 }
 
-geometry_msgs::msg::Point toPoint(geometry_msgs::msg::Point32 pt)
+geometry_msgs::msg::Point toPoint(const geometry_msgs::msg::Point32 & pt)
 {
   geometry_msgs::msg::Point point;
   point.x = pt.x;
@@ -89,20 +89,22 @@ geometry_msgs::msg::Point toPoint(geometry_msgs::msg::Point32 pt)
   return point;
 }
 
-geometry_msgs::msg::Polygon toPolygon(std::vector<geometry_msgs::msg::Point> pts)
+geometry_msgs::msg::Polygon toPolygon(const std::vector<geometry_msgs::msg::Point> & pts)
 {
   geometry_msgs::msg::Polygon polygon;
-  for (unsigned int i = 0; i < pts.size(); i++) {
-    polygon.points.push_back(toPoint32(pts[i]));
+  polygon.points.reserve(pts.size());
+  for (const auto & pt : pts) {
+    polygon.points.push_back(toPoint32(pt));
   }
   return polygon;
 }
 
-std::vector<geometry_msgs::msg::Point> toPointVector(geometry_msgs::msg::Polygon::SharedPtr polygon)
+std::vector<geometry_msgs::msg::Point> toPointVector(const geometry_msgs::msg::Polygon & polygon)
 {
   std::vector<geometry_msgs::msg::Point> pts;
-  for (unsigned int i = 0; i < polygon->points.size(); i++) {
-    pts.push_back(toPoint(polygon->points[i]));
+  pts.reserve(polygon.points.size());
+  for (const auto & point : polygon.points) {
+    pts.push_back(toPoint(point));
   }
   return pts;
 }

--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -35,8 +35,7 @@ FootprintSubscriber::getFootprintRaw(
   }
 
   auto current_footprint = std::atomic_load(&footprint_);
-  footprint = toPointVector(
-    std::make_shared<geometry_msgs::msg::Polygon>(current_footprint->polygon));
+  footprint = toPointVector(current_footprint->polygon);
   footprint_header = current_footprint->header;
 
   return true;


### PR DESCRIPTION


---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Propreitary |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* This PR adds a parameter to choose between `Polygon`/`PolygonStamped` subscriber for receiving the footprint in the `Costmap2DROS`.
* By default `Costmap2DROS` subscribes to `Polygon` footprints
* `PolygonStamped` footprints can be subscribed to by setting the `subscribe_to_stamped_footprint` parameter to True
* Also includes some cleanup, tiny optimizations, and minor refactoring to parts of code in the vicinity of the above changes

## Description of documentation updates required from your changes

None

## Description of how this change was tested

Tested that the `Costmap2DROS` can receive and properly process `PolygonStamped` footprint messages on a proprietary robot

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
