### PR TITLE
fix: add missing keepout and speed zone substitutions for non-composed nodes

### DIFF
--- a/nav2_bringup/launch/bringup_launch.py
+++ b/nav2_bringup/launch/bringup_launch.py
@@ -235,6 +235,8 @@ def generate_launch_description() -> LaunchDescription:
                     'params_file': params_file,
                     'use_composition': use_composition,
                     'use_respawn': use_respawn,
+                    'use_keepout_zones': use_keepout_zones,
+                    'use_speed_zones': use_speed_zones,
                     'container_name': 'nav2_container',
                 }.items(),
             ),

--- a/nav2_bringup/launch/navigation_launch.py
+++ b/nav2_bringup/launch/navigation_launch.py
@@ -38,6 +38,8 @@ def generate_launch_description() -> LaunchDescription:
     container_name_full = (namespace, '/', container_name)
     use_respawn = LaunchConfigAsBool('use_respawn')
     log_level = LaunchConfiguration('log_level')
+    use_keepout_zones = LaunchConfigAsBool('use_keepout_zones')
+    use_speed_zones = LaunchConfigAsBool('use_speed_zones')
 
     lifecycle_nodes = [
         'controller_server',
@@ -58,11 +60,17 @@ def generate_launch_description() -> LaunchDescription:
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {'autostart': autostart}
 
+    yaml_substitutions = {
+        'KEEPOUT_ZONE_ENABLED': use_keepout_zones,
+        'SPEED_ZONE_ENABLED': use_speed_zones,
+    }
+
     configured_params = ParameterFile(
         RewrittenYaml(
             source_file=params_file,
             root_key=namespace,
             param_rewrites=param_substitutions,
+            value_rewrites=yaml_substitutions,
             convert_types=True,
         ),
         allow_substs=True,
@@ -119,6 +127,16 @@ def generate_launch_description() -> LaunchDescription:
 
     declare_log_level_cmd = DeclareLaunchArgument(
         'log_level', default_value='info', description='log level'
+    )
+
+    declare_use_keepout_zones_cmd = DeclareLaunchArgument(
+        'use_keepout_zones', default_value='True',
+        description='Whether to enable keepout zones or not'
+    )
+
+    declare_use_speed_zones_cmd = DeclareLaunchArgument(
+        'use_speed_zones', default_value='True',
+        description='Whether to enable speed zones or not'
     )
 
     load_nodes = GroupAction(
@@ -351,6 +369,8 @@ def generate_launch_description() -> LaunchDescription:
     ld.add_action(declare_container_name_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
+    ld.add_action(declare_use_keepout_zones_cmd)
+    ld.add_action(declare_use_speed_zones_cmd)
     # Add the actions to launch all of the navigation nodes
     ld.add_action(load_nodes)
     ld.add_action(load_composable_nodes)


### PR DESCRIPTION
Non-composed nodes were missing the yaml substitutions for keepout and speed zones that are present in the component container launch. This was causing parameter type errors when the substitution values weren't being replaced.

Added:
- use_keepout_zones and use_speed_zones launch arguments
- yaml_substitutions dictionary with KEEPOUT_ZONE_ENABLED and SPEED_ZONE_ENABLED
- value_rewrites parameter to RewrittenYaml to apply the substitutions

Fixes #5356

Generated with [Claude Code](https://claude.ai/code)