### PR TITLE
Humble backport fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "../Dockerfile",
         "context": "..",
         "target": "visualizer",
-        "cacheFrom": "ghcr.io/ros-planning/navigation2:humble"
+        "cacheFrom": "ghcr.io/ros-navigation/navigation2:humble"
     },
     "runArgs": [
         // "--cap-add=SYS_PTRACE", // enable debugging, e.g. gdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,7 +219,7 @@ COPY --from=caddyer /usr/bin/caddy /usr/bin/caddy
 
 # download media files
 RUN mkdir -p $ROOT_SRV/media && cd /tmp && \
-    export ICONS="icons.tar.gz" && wget https://github.com/ros-planning/navigation2/files/11506823/$ICONS && \
+    export ICONS="icons.tar.gz" && wget https://github.com/ros-navigation/navigation2/files/11506823/$ICONS && \
     echo "cae5e2a5230f87b004c8232b579781edb4a72a7431405381403c6f9e9f5f7d41 $ICONS" | sha256sum -c && \
     tar xvz -C $ROOT_SRV/media -f $ICONS && rm $ICONS
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -55,7 +55,8 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<geometry_msgs::msg::PoseStamped>("goals", "Destinations to plan through"),
+        BT::InputPort<std::vector<geometry_msgs::msg::PoseStamped>>(
+          "goals", "Destinations to plan through"),
         BT::InputPort<std::string>("behavior_tree", "Behavior tree to run"),
       });
   }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -16,6 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__NAVIGATE_THROUGH_POSES_ACTION_HPP_
 
 #include <string>
+#include <vector>
 
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"

--- a/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
@@ -24,13 +24,25 @@
 using namespace std::chrono;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 
+// Shim BT node to access protected resetStatus method
+class ShimNode : public nav2_behavior_tree::SingleTrigger
+{
+public:
+  ShimNode(
+    const std::string & name,
+    const BT::NodeConfiguration & confi)
+  : SingleTrigger(name, confi)
+  {}
+  ~ShimNode() {}
+  void changeStatus() {resetStatus();}
+};
+
 class SingleTriggerTestFixture : public nav2_behavior_tree::BehaviorTreeTestFixture
 {
 public:
   void SetUp()
   {
-    bt_node_ = std::make_shared<nav2_behavior_tree::SingleTrigger>(
-      "single_trigger", *config_);
+    bt_node_ = std::make_shared<ShimNode>("single_trigger", *config_);
     dummy_node_ = std::make_shared<nav2_behavior_tree::DummyNode>();
     bt_node_->setChild(dummy_node_.get());
   }
@@ -42,11 +54,11 @@ public:
   }
 
 protected:
-  static std::shared_ptr<nav2_behavior_tree::SingleTrigger> bt_node_;
+  static std::shared_ptr<ShimNode> bt_node_;
   static std::shared_ptr<nav2_behavior_tree::DummyNode> dummy_node_;
 };
 
-std::shared_ptr<nav2_behavior_tree::SingleTrigger>
+std::shared_ptr<ShimNode>
 SingleTriggerTestFixture::bt_node_ = nullptr;
 std::shared_ptr<nav2_behavior_tree::DummyNode>
 SingleTriggerTestFixture::dummy_node_ = nullptr;
@@ -71,6 +83,7 @@ TEST_F(SingleTriggerTestFixture, test_behavior)
   // halt BT for a new execution run, should work when dummy node is running
   // and once when dummy node returns success and then fail
   bt_node_->halt();
+  bt_node_->changeStatus();  // BTv3.8+ doesn't reset root node automatically
   dummy_node_->changeStatus(BT::NodeStatus::RUNNING);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
   dummy_node_->changeStatus(BT::NodeStatus::SUCCESS);

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -368,7 +368,7 @@ TEST(UtilsTests, SmootherTest)
 
   // Check that path is smoother
   float smoothed_val{0}, original_val{0};
-  for (unsigned int i = 0; i != noisey_sequence.vx.shape(0); i++) {
+  for (unsigned int i = 1; i != noisey_sequence.vx.shape(0) - 1; i++) {
     smoothed_val += fabs(noisey_sequence.vx(i) - 0.2);
     smoothed_val += fabs(noisey_sequence.vy(i) - 0.0);
     smoothed_val += fabs(noisey_sequence.wz(i) - 0.3);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #5230) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Backports bug fixes from main to humble:
- https://github.com/ros-navigation/navigation2/pull/3674/commits/1de4cd21bcd1552ff8450c005c4a3382df6d031c
- https://github.com/ros-navigation/navigation2/pull/3605/commits/7d5e93c5704647055ef8a14636373b4f997de76b

Also fixes the devcontainer setup for humble (as I used it for testing and ran into those issues).

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

Ran `colcon test`, which fixes the some of the test issues reported above, however there are still other unrelated tests failing:
```log
build/dwb_plugins/Testing/20250719-1448/Test.xml: 9 tests, 0 errors, 1 failure, 0 skipped
build/dwb_plugins/test_results/dwb_plugins/twist_gen_test.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_behavior_tree/Testing/20250719-1447/Test.xml: 58 tests, 0 errors, 4 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/copyright.xunit.xml: 194 tests, 0 errors, 28 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/cpplint.xunit.xml: 186 tests, 0 errors, 21 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/lint_cmake.xunit.xml: 685 tests, 0 errors, 675 failures, 0 skipped
build/nav2_behavior_tree/test_results/nav2_behavior_tree/uncrustify.xunit.xml: 168 tests, 0 errors, 2 failures, 0 skipped
build/nav2_collision_monitor/Testing/20250719-1448/Test.xml: 10 tests, 0 errors, 1 failure, 0 skipped
build/nav2_collision_monitor/test_results/nav2_collision_monitor/collision_monitor_node_test.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_controller/Testing/20250719-1448/Test.xml: 8 tests, 0 errors, 1 failure, 0 skipped
build/nav2_controller/test_results/nav2_controller/uncrustify.xunit.xml: 16 tests, 0 errors, 1 failure, 0 skipped
build/nav2_mppi_controller/Testing/20250719-1448/Test.xml: 17 tests, 0 errors, 3 failures, 0 skipped
build/nav2_mppi_controller/test_results/nav2_mppi_controller/cpplint.xunit.xml: 85 tests, 0 errors, 20 failures, 0 skipped
build/nav2_mppi_controller/test_results/nav2_mppi_controller/lint_cmake.xunit.xml: 134 tests, 0 errors, 126 failures, 0 skipped
build/nav2_mppi_controller/test_results/nav2_mppi_controller/uncrustify.xunit.xml: 67 tests, 0 errors, 2 failures, 0 skipped
build/nav2_system_tests/Testing/20250719-1448/Test.xml: 31 tests, 0 errors, 6 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_dynamic_obstacle.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_keepout_filter.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_nav_through_poses.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_speed_filter_local.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_spin_behavior.xml: 1 test, 1 error, 0 failures, 0 skipped
build/nav2_system_tests/test_results/nav2_system_tests/test_spin_behavior_fake.xml: 1 test, 1 error, 0 failures, 0 skipped
```

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
