### PR TITLE
Use declare_or_get_param API

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -27,6 +27,8 @@
 
 #include "nav2_behavior_tree/plugins_list.hpp"
 
+using nav2::declare_parameter_if_not_declared;
+
 namespace nav2_bt_navigator
 {
 
@@ -95,9 +97,9 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & state)
   navigator_ids = this->declare_or_get_parameter("navigators", default_navigator_ids);
   if (navigator_ids == default_navigator_ids) {
     for (size_t i = 0; i < default_navigator_ids.size(); ++i) {
-      this->declare_or_get_parameter(
-        default_navigator_ids[i] + ".plugin",
-        default_navigator_types[i]);
+      declare_parameter_if_not_declared(
+        node, default_navigator_ids[i] + ".plugin",
+        rclcpp::ParameterValue(default_navigator_types[i]));
     }
   }
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -27,8 +27,6 @@
 
 #include "nav2_behavior_tree/plugins_list.hpp"
 
-using nav2::declare_parameter_if_not_declared;
-
 namespace nav2_bt_navigator
 {
 
@@ -38,19 +36,6 @@ BtNavigator::BtNavigator(rclcpp::NodeOptions options)
   class_loader_("nav2_core", "nav2_core::NavigatorBase")
 {
   RCLCPP_INFO(get_logger(), "Creating");
-
-  declare_parameter_if_not_declared(
-    this, "plugin_lib_names", rclcpp::ParameterValue(std::vector<std::string>{}));
-  declare_parameter_if_not_declared(
-    this, "transform_tolerance", rclcpp::ParameterValue(0.1));
-  declare_parameter_if_not_declared(
-    this, "global_frame", rclcpp::ParameterValue(std::string("map")));
-  declare_parameter_if_not_declared(
-    this, "robot_base_frame", rclcpp::ParameterValue(std::string("base_link")));
-  declare_parameter_if_not_declared(
-    this, "odom_topic", rclcpp::ParameterValue(std::string("odom")));
-  declare_parameter_if_not_declared(
-    this, "filter_duration", rclcpp::ParameterValue(0.3));
 }
 
 BtNavigator::~BtNavigator()
@@ -69,17 +54,18 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & state)
   tf_->setUsingDedicatedThread(true);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, false);
 
-  global_frame_ = get_parameter("global_frame").as_string();
-  robot_frame_ = get_parameter("robot_base_frame").as_string();
-  transform_tolerance_ = get_parameter("transform_tolerance").as_double();
-  odom_topic_ = get_parameter("odom_topic").as_string();
-  filter_duration_ = get_parameter("filter_duration").as_double();
+  global_frame_ = this->declare_or_get_parameter("global_frame", std::string("map"));
+  robot_frame_ = this->declare_or_get_parameter("robot_base_frame", std::string("base_link"));
+  transform_tolerance_ = this->declare_or_get_parameter("transform_tolerance", 0.1);
+  odom_topic_ = this->declare_or_get_parameter("odom_topic", std::string("odom"));
+  filter_duration_ = this->declare_or_get_parameter("filter_duration", 0.3);
 
   // Libraries to pull plugins (BT Nodes) from
   std::vector<std::string> plugin_lib_names;
   plugin_lib_names = nav2_util::split(nav2::details::BT_BUILTIN_PLUGINS, ';');
 
-  auto user_defined_plugins = get_parameter("plugin_lib_names").as_string_array();
+  auto user_defined_plugins =
+    this->declare_or_get_parameter("plugin_lib_names", std::vector<std::string>{});
   // append user_defined_plugins to plugin_lib_names
   plugin_lib_names.insert(
     plugin_lib_names.end(), user_defined_plugins.begin(),
@@ -106,15 +92,12 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & state)
   };
 
   std::vector<std::string> navigator_ids;
-  declare_parameter_if_not_declared(
-    node, "navigators",
-    rclcpp::ParameterValue(default_navigator_ids));
-  get_parameter("navigators", navigator_ids);
+  navigator_ids = this->declare_or_get_parameter("navigators", default_navigator_ids);
   if (navigator_ids == default_navigator_ids) {
     for (size_t i = 0; i < default_navigator_ids.size(); ++i) {
-      declare_parameter_if_not_declared(
-        node, default_navigator_ids[i] + ".plugin",
-        rclcpp::ParameterValue(default_navigator_types[i]));
+      this->declare_or_get_parameter(
+        default_navigator_ids[i] + ".plugin",
+        default_navigator_types[i]);
     }
   }
 

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -31,20 +31,20 @@ NavigateThroughPosesNavigator::configure(
   auto node = parent_node.lock();
 
   goals_blackboard_id_ =
-    nav2::declare_or_get_parameter(node, "goals_blackboard_id", std::string("goals"));
+    node->declare_or_get_parameter("goals_blackboard_id", std::string("goals"));
   path_blackboard_id_ =
-    nav2::declare_or_get_parameter(node, "path_blackboard_id", std::string("path"));
+    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
   waypoint_statuses_blackboard_id_ =
-    nav2::declare_or_get_parameter(node, "waypoint_statuses_blackboard_id",
+    node->declare_or_get_parameter("waypoint_statuses_blackboard_id",
       std::string("waypoint_statuses"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;
 
   bool enable_groot_monitoring =
-    nav2::declare_or_get_parameter(node, getName() + ".enable_groot_monitoring", false);
+    node->declare_or_get_parameter(getName() + ".enable_groot_monitoring", false);
   int groot_server_port =
-    nav2::declare_or_get_parameter(node, getName() + ".groot_server_port", 1669);
+    node->declare_or_get_parameter(getName() + ".groot_server_port", 1669);
 
   bt_action_server_->setGrootMonitoring(
       enable_groot_monitoring,
@@ -61,8 +61,8 @@ NavigateThroughPosesNavigator::getDefaultBTFilepath(
   std::string pkg_share_dir =
     ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
 
-  auto default_bt_xml_filename = nav2::declare_or_get_parameter<std::string>(
-    node, "default_nav_through_poses_bt_xml",
+  auto default_bt_xml_filename = node->declare_or_get_parameter(
+    "default_nav_through_poses_bt_xml",
     pkg_share_dir +
     "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml");
 

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -28,41 +28,26 @@ NavigateThroughPosesNavigator::configure(
   std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
 {
   start_time_ = rclcpp::Time(0);
-  auto node = parent_node.lock();
 
-  if (!node->has_parameter("goals_blackboard_id")) {
-    node->declare_parameter("goals_blackboard_id", std::string("goals"));
-  }
-
-  goals_blackboard_id_ = node->get_parameter("goals_blackboard_id").as_string();
-
-  if (!node->has_parameter("path_blackboard_id")) {
-    node->declare_parameter("path_blackboard_id", std::string("path"));
-  }
-
-  path_blackboard_id_ = node->get_parameter("path_blackboard_id").as_string();
-
-  if (!node->has_parameter("waypoint_statuses_blackboard_id")) {
-    node->declare_parameter("waypoint_statuses_blackboard_id", std::string("waypoint_statuses"));
-  }
-
+  goals_blackboard_id_ =
+    this->declare_or_get_parameter("goals_blackboard_id", std::string("goals"));
+  path_blackboard_id_ =
+    this->declare_or_get_parameter("path_blackboard_id", std::string("path"));
   waypoint_statuses_blackboard_id_ =
-    node->get_parameter("waypoint_statuses_blackboard_id").as_string();
+    this->declare_or_get_parameter("waypoint_statuses_blackboard_id",
+      std::string("waypoint_statuses"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;
 
-  if (!node->has_parameter(getName() + ".enable_groot_monitoring")) {
-    node->declare_parameter(getName() + ".enable_groot_monitoring", false);
-  }
-
-  if (!node->has_parameter(getName() + ".groot_server_port")) {
-    node->declare_parameter(getName() + ".groot_server_port", 1669);
-  }
+  bool enable_groot_monitoring =
+    this->declare_or_get_parameter(getName() + ".enable_groot_monitoring", false);
+  int groot_server_port =
+    this->declare_or_get_parameter(getName() + ".groot_server_port", 1669);
 
   bt_action_server_->setGrootMonitoring(
-      node->get_parameter(getName() + ".enable_groot_monitoring").as_bool(),
-      node->get_parameter(getName() + ".groot_server_port").as_int());
+      enable_groot_monitoring,
+      groot_server_port);
 
   return true;
 }
@@ -71,19 +56,13 @@ std::string
 NavigateThroughPosesNavigator::getDefaultBTFilepath(
   nav2::LifecycleNode::WeakPtr parent_node)
 {
-  std::string default_bt_xml_filename;
-  auto node = parent_node.lock();
+  std::string pkg_share_dir =
+    ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
 
-  if (!node->has_parameter("default_nav_through_poses_bt_xml")) {
-    std::string pkg_share_dir =
-      ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
-    node->declare_parameter<std::string>(
-      "default_nav_through_poses_bt_xml",
+  auto default_bt_xml_filename = this->declare_or_get_parameter<std::string>(
+    "default_nav_through_poses_bt_xml",
       pkg_share_dir +
       "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml");
-  }
-
-  node->get_parameter("default_nav_through_poses_bt_xml", default_bt_xml_filename);
 
   return default_bt_xml_filename;
 }

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -28,22 +28,23 @@ NavigateThroughPosesNavigator::configure(
   std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
 {
   start_time_ = rclcpp::Time(0);
+  auto node = parent_node.lock();
 
   goals_blackboard_id_ =
-    this->declare_or_get_parameter("goals_blackboard_id", std::string("goals"));
+    nav2::declare_or_get_parameter(node, "goals_blackboard_id", std::string("goals"));
   path_blackboard_id_ =
-    this->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+    nav2::declare_or_get_parameter(node, "path_blackboard_id", std::string("path"));
   waypoint_statuses_blackboard_id_ =
-    this->declare_or_get_parameter("waypoint_statuses_blackboard_id",
+    nav2::declare_or_get_parameter(node, "waypoint_statuses_blackboard_id",
       std::string("waypoint_statuses"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;
 
   bool enable_groot_monitoring =
-    this->declare_or_get_parameter(getName() + ".enable_groot_monitoring", false);
+    nav2::declare_or_get_parameter(node, getName() + ".enable_groot_monitoring", false);
   int groot_server_port =
-    this->declare_or_get_parameter(getName() + ".groot_server_port", 1669);
+    nav2::declare_or_get_parameter(node, getName() + ".groot_server_port", 1669);
 
   bt_action_server_->setGrootMonitoring(
       enable_groot_monitoring,
@@ -56,13 +57,14 @@ std::string
 NavigateThroughPosesNavigator::getDefaultBTFilepath(
   nav2::LifecycleNode::WeakPtr parent_node)
 {
+  auto node = parent_node.lock();
   std::string pkg_share_dir =
     ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
 
-  auto default_bt_xml_filename = this->declare_or_get_parameter<std::string>(
-    "default_nav_through_poses_bt_xml",
-      pkg_share_dir +
-      "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml");
+  auto default_bt_xml_filename = nav2::declare_or_get_parameter<std::string>(
+    node, "default_nav_through_poses_bt_xml",
+    pkg_share_dir +
+    "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml");
 
   return default_bt_xml_filename;
 }

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -30,9 +30,9 @@ NavigateToPoseNavigator::configure(
   auto node = parent_node.lock();
 
   goal_blackboard_id_ =
-    nav2::declare_or_get_parameter(node, "goal_blackboard_id", std::string("goal"));
+    node->declare_or_get_parameter("goal_blackboard_id", std::string("goal"));
   path_blackboard_id_ =
-    nav2::declare_or_get_parameter(node, "path_blackboard_id", std::string("path"));
+    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;
@@ -44,9 +44,9 @@ NavigateToPoseNavigator::configure(
     std::bind(&NavigateToPoseNavigator::onGoalPoseReceived, this, std::placeholders::_1));
 
   bool enable_groot_monitoring =
-    nav2::declare_or_get_parameter(node, getName() + ".enable_groot_monitoring", false);
+    node->declare_or_get_parameter(getName() + ".enable_groot_monitoring", false);
   int groot_server_port =
-    nav2::declare_or_get_parameter(node, getName() + ".groot_server_port", 1669);
+    node->declare_or_get_parameter(getName() + ".groot_server_port", 1669);
 
   bt_action_server_->setGrootMonitoring(
       enable_groot_monitoring,
@@ -63,8 +63,8 @@ NavigateToPoseNavigator::getDefaultBTFilepath(
   std::string pkg_share_dir =
     ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
 
-  auto default_bt_xml_filename = this->declare_or_get_parameter<std::string>(
-    node, "default_nav_to_pose_bt_xml",
+  auto default_bt_xml_filename = node->declare_or_get_parameter(
+    "default_nav_to_pose_bt_xml",
     pkg_share_dir +
     "/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml");
 

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -27,9 +27,12 @@ NavigateToPoseNavigator::configure(
   std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
 {
   start_time_ = rclcpp::Time(0);
+  auto node = parent_node.lock();
 
-  goal_blackboard_id_ = this->declare_or_get_parameter("goal_blackboard_id", std::string("goal"));
-  path_blackboard_id_ = this->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+  goal_blackboard_id_ =
+    nav2::declare_or_get_parameter(node, "goal_blackboard_id", std::string("goal"));
+  path_blackboard_id_ =
+    nav2::declare_or_get_parameter(node, "path_blackboard_id", std::string("path"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;
@@ -41,9 +44,9 @@ NavigateToPoseNavigator::configure(
     std::bind(&NavigateToPoseNavigator::onGoalPoseReceived, this, std::placeholders::_1));
 
   bool enable_groot_monitoring =
-    this->declare_or_get_parameter(getName() + ".enable_groot_monitoring", false);
+    nav2::declare_or_get_parameter(node, getName() + ".enable_groot_monitoring", false);
   int groot_server_port =
-    this->declare_or_get_parameter(getName() + ".groot_server_port", 1669);
+    nav2::declare_or_get_parameter(node, getName() + ".groot_server_port", 1669);
 
   bt_action_server_->setGrootMonitoring(
       enable_groot_monitoring,
@@ -56,13 +59,14 @@ std::string
 NavigateToPoseNavigator::getDefaultBTFilepath(
   nav2::LifecycleNode::WeakPtr parent_node)
 {
+  auto node = parent_node.lock();
   std::string pkg_share_dir =
     ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
 
   auto default_bt_xml_filename = this->declare_or_get_parameter<std::string>(
-    "default_nav_to_pose_bt_xml",
-      pkg_share_dir +
-      "/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml");
+    node, "default_nav_to_pose_bt_xml",
+    pkg_share_dir +
+    "/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml");
 
   return default_bt_xml_filename;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5299 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
Addresses #5299
Use `declare_or_get_param` API instead of  `declare_parameter` - `get_parameter`
### Target packages:
- nav2_bt_navigator
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes
Nothing
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested
- Unit tests
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work
- [ ] Add `declare_parameter_if_not_declared` to `nav2::LifecycleNode` so that  we could do `node->declare_parameter_if_not_declared`
<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
--> 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
