### PR TITLE
Add "plugins" Parameter to BT XML for Selective Clearing of Costmap Layers

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
@@ -16,6 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__CLEAR_COSTMAP_SERVICE_HPP_
 
 #include <string>
+#include <vector>
 
 #include "nav2_behavior_tree/bt_service_node.hpp"
 #include "nav2_msgs/srv/clear_entire_costmap.hpp"
@@ -49,6 +50,18 @@ public:
    * @return BT::NodeStatus Status of tick execution
    */
   void on_tick() override;
+
+  /**
+   * @brief Creates list of BT ports
+   * @return BT::PortsList Containing basic ports along with node-specific ports
+   */
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts(
+      {
+        BT::InputPort<std::vector<std::string>>("plugins", "List of costmap layer names to clear. If empty, all layers will be cleared")
+      });
+  }
 };
 
 /**
@@ -86,7 +99,8 @@ public:
       {
         BT::InputPort<double>(
           "reset_distance", 1,
-          "Distance from the robot above which obstacles are cleared")
+          "Distance from the robot above which obstacles are cleared"),
+        BT::InputPort<std::vector<std::string>>("plugins", "List of costmap layer names to clear. If empty, all layers will be cleared")
       });
   }
 };
@@ -125,7 +139,8 @@ public:
       {
         BT::InputPort<double>(
           "reset_distance", 1,
-          "Distance from the robot under which obstacles are cleared")
+          "Distance from the robot under which obstacles are cleared"),
+        BT::InputPort<std::vector<std::string>>("plugins", "List of costmap layer names to clear. If empty, all layers will be cleared")
       });
   }
 };
@@ -166,7 +181,8 @@ public:
           "pose", "Pose around which to clear the costmap"),
         BT::InputPort<double>(
           "reset_distance", 1.0,
-          "Distance from the pose under which obstacles are cleared")
+          "Distance from the pose under which obstacles are cleared"),
+        BT::InputPort<std::vector<std::string>>("plugins", "List of costmap layer names to clear. If empty, all layers will be cleared")
       });
   }
 };

--- a/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
+++ b/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "nav2_behavior_tree/plugins/action/clear_costmap_service.hpp"
 
@@ -29,6 +30,10 @@ ClearEntireCostmapService::ClearEntireCostmapService(
 
 void ClearEntireCostmapService::on_tick()
 {
+  std::vector<std::string> plugins;
+  if (getInput("plugins", plugins)) {
+    request_->plugins = plugins;
+  }
   increment_recovery_count();
 }
 
@@ -42,6 +47,11 @@ ClearCostmapExceptRegionService::ClearCostmapExceptRegionService(
 void ClearCostmapExceptRegionService::on_tick()
 {
   getInput("reset_distance", request_->reset_distance);
+  std::vector<std::string> plugins;
+  if (getInput("plugins", plugins)) {
+    request_->plugins = plugins;
+  }
+  
   increment_recovery_count();
 }
 
@@ -55,6 +65,12 @@ ClearCostmapAroundRobotService::ClearCostmapAroundRobotService(
 void ClearCostmapAroundRobotService::on_tick()
 {
   getInput("reset_distance", request_->reset_distance);
+  
+  std::vector<std::string> plugins;
+  if (getInput("plugins", plugins)) {
+    request_->plugins = plugins;
+  }
+  
   increment_recovery_count();
 }
 
@@ -69,6 +85,12 @@ void ClearCostmapAroundPoseService::on_tick()
 {
   getInput("pose", request_->pose);
   getInput("reset_distance", request_->reset_distance);
+  
+  std::vector<std::string> plugins;
+  if (getInput("plugins", plugins)) {
+    request_->plugins = plugins;
+  }
+  
   increment_recovery_count();
 }
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -59,17 +59,17 @@ public:
   /**
    * @brief Clears the region outside of a user-specified area reverting to the static map
    */
-  void clearRegion(double reset_distance, bool invert);
+  void clearRegion(double reset_distance, bool invert, const std::vector<std::string> & plugins);
 
   /**
    * @brief Clears the region around a specific pose
    */
-  void clearAroundPose(const geometry_msgs::msg::PoseStamped & pose, double reset_distance);
+  void clearAroundPose(const geometry_msgs::msg::PoseStamped & pose, double reset_distance, const std::vector<std::string> & plugins);
 
   /**
    * @brief Clears all layers
    */
-  void clearEntirely();
+  void clearEntirely(const std::vector<std::string> & plugins);
 
 private:
   // The Logger object for logging
@@ -126,13 +126,17 @@ private:
    * @brief  Function used to clear a given costmap layer
    */
   void clearLayerRegion(
-    std::shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance,
-    bool invert);
+    std::shared_ptr<CostmapLayer> & costmap,
+    double pose_x, double pose_y, double reset_distance, bool invert);
 
   /**
    * @brief Get the robot's position in the costmap using the master costmap
    */
   bool getPosition(double & x, double & y) const;
+
+  bool shouldClearLayer(
+    const std::shared_ptr<Layer> & layer,
+    const std::vector<std::string> & plugins) const;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_msgs/srv/ClearCostmapAroundPose.srv
+++ b/nav2_msgs/srv/ClearCostmapAroundPose.srv
@@ -2,5 +2,6 @@
 
 geometry_msgs/PoseStamped pose
 float64 reset_distance
+string[] plugins
 ---
 std_msgs/Empty response

--- a/nav2_msgs/srv/ClearCostmapAroundRobot.srv
+++ b/nav2_msgs/srv/ClearCostmapAroundRobot.srv
@@ -1,5 +1,6 @@
 # Clears the costmap within a distance
 
 float32 reset_distance
+string[] plugins
 ---
 std_msgs/Empty response

--- a/nav2_msgs/srv/ClearCostmapExceptRegion.srv
+++ b/nav2_msgs/srv/ClearCostmapExceptRegion.srv
@@ -1,5 +1,6 @@
 # Clears the costmap except a rectangular region specified by reset_distance
 
 float32 reset_distance
+string[] plugins
 ---
 std_msgs/Empty response

--- a/nav2_msgs/srv/ClearEntireCostmap.srv
+++ b/nav2_msgs/srv/ClearEntireCostmap.srv
@@ -1,5 +1,6 @@
 # Clears all layers on the costmap
 
 std_msgs/Empty request
+string[] plugins
 ---
 std_msgs/Empty response


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#4963) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
