### PR TITLE
Moving Nav2 behaviors to the system build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,7 +532,7 @@ jobs:
 
 _parameters:
   release_parameters: &release_parameters
-    packages_skip_regex: "'(nav2_system_tests|nav2_smac_planner|nav2_mppi_controller|nav2_route|nav2_rviz_plugins|nav2_bringup|navigation2)'"
+    packages_skip_regex: "'(nav2_system_tests|nav2_smac_planner|nav2_mppi_controller|nav2_route|nav2_rviz_plugins|nav2_behaviors|nav2_bringup|navigation2)'"
 
 workflows:
   version: 2


### PR DESCRIPTION
Another package to move to the other build job to keep under the 1 hour context window for clean rebuilds 