### PR TITLE
Add support for dynamically changing keepout zone

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
@@ -69,6 +69,20 @@ public:
     const std::string & filter_info_topic);
 
   /**
+   * @brief Update the bounds of the master costmap by this layer's update dimensions
+   * @param robot_x X pose of robot
+   * @param robot_y Y pose of robot
+   * @param robot_yaw Robot orientation
+   * @param min_x X min map coord of the window to update
+   * @param min_y Y min map coord of the window to update
+   * @param max_x X max map coord of the window to update
+   * @param max_y Y max map coord of the window to update
+   */
+  void updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y) override;
+
+  /**
    * @brief Process the keepout layer at the current pose / bounds / grid
    */
   void process(

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
@@ -79,8 +79,8 @@ public:
    * @param max_y Y max map coord of the window to update
    */
   void updateBounds(
-  double robot_x, double robot_y, double robot_yaw,
-  double * min_x, double * min_y, double * max_x, double * max_y) override;
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
 
   /**
    * @brief Process the keepout layer at the current pose / bounds / grid

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/costmap_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/costmap_filter.hpp
@@ -99,7 +99,7 @@ public:
    */
   void updateBounds(
     double robot_x, double robot_y, double robot_yaw,
-    double * min_x, double * min_y, double * max_x, double * max_y) final;
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
 
   /**
    * @brief Update the costs in the master costmap in the window

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
@@ -69,6 +69,20 @@ public:
     const std::string & filter_info_topic);
 
   /**
+   * @brief Update the bounds of the master costmap by this layer's update dimensions
+   * @param robot_x X pose of robot
+   * @param robot_y Y pose of robot
+   * @param robot_yaw Robot orientation
+   * @param min_x X min map coord of the window to update
+   * @param min_y Y min map coord of the window to update
+   * @param max_x X max map coord of the window to update
+   * @param max_y Y max map coord of the window to update
+   */
+  void updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y) override;
+
+  /**
    * @brief Process the keepout layer at the current pose / bounds / grid
    */
   void process(
@@ -108,6 +122,12 @@ private:
   bool last_pose_lethal_{false};  // If true, last pose was lethal
   unsigned int lethal_state_update_min_x_{999999u}, lethal_state_update_min_y_{999999u};
   unsigned int lethal_state_update_max_x_{0u}, lethal_state_update_max_y_{0u};
+
+  unsigned int x_{0};
+  unsigned int y_{0};
+  unsigned int width_{0};
+  unsigned int height_{0};
+  bool has_updated_data_{false};
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/keepout_filter.hpp
@@ -79,8 +79,8 @@ public:
    * @param max_y Y max map coord of the window to update
    */
   void updateBounds(
-  double robot_x, double robot_y, double robot_yaw,
-  double * min_x, double * min_y, double * max_x, double * max_y) override;
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
 
   /**
    * @brief Process the keepout layer at the current pose / bounds / grid

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -69,6 +69,20 @@ public:
     const std::string & filter_info_topic);
 
   /**
+   * @brief Update the bounds of the master costmap by this layer's update dimensions
+   * @param robot_x X pose of robot
+   * @param robot_y Y pose of robot
+   * @param robot_yaw Robot orientation
+   * @param min_x X min map coord of the window to update
+   * @param min_y Y min map coord of the window to update
+   * @param max_x X max map coord of the window to update
+   * @param max_y Y max map coord of the window to update
+   */
+  void updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y) override;
+
+  /**
    * @brief Process the keepout layer at the current pose / bounds / grid
    */
   void process(

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -79,8 +79,8 @@ public:
    * @param max_y Y max map coord of the window to update
    */
   void updateBounds(
-  double robot_x, double robot_y, double robot_yaw,
-  double * min_x, double * min_y, double * max_x, double * max_y) override;
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
 
   /**
    * @brief Process the keepout layer at the current pose / bounds / grid

--- a/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
@@ -101,6 +101,15 @@ void BinaryFilter::initializeFilter(
   changeState(binary_state_);
 }
 
+void BinaryFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  if (!enabled_) {
+    return;
+  }
+  CostmapFilter::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
+}
+
 void BinaryFilter::filterInfoCallback(
   const nav2_msgs::msg::CostmapFilterInfo::SharedPtr msg)
 {

--- a/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
@@ -101,7 +101,8 @@ void BinaryFilter::initializeFilter(
   changeState(binary_state_);
 }
 
-void BinaryFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+void BinaryFilter::updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
   double * min_x, double * min_y, double * max_x, double * max_y)
 {
   if (!enabled_) {

--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -114,10 +114,6 @@ void CostmapFilter::updateBounds(
   double robot_x, double robot_y, double robot_yaw,
   double * /*min_x*/, double * /*min_y*/, double * /*max_x*/, double * /*max_y*/)
 {
-  if (!enabled_) {
-    return;
-  }
-
   latest_pose_.position.x = robot_x;
   latest_pose_.position.y = robot_y;
   latest_pose_.position.z = 0.0;

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -155,6 +155,35 @@ void KeepoutFilter::maskCallback(
 
   // Store filter_mask_
   filter_mask_ = msg;
+  has_updated_data_ = true;
+  x_ = y_ = 0;
+  width_ = msg->info.width;
+  height_ = msg->info.height;
+}
+
+void KeepoutFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  CostmapFilter::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
+
+  if(!has_updated_data_)
+    return;
+
+  double wx, wy;
+
+  layered_costmap_->getCostmap()->mapToWorld(x_, y_, wx, wy);
+  *min_x = std::min(wx, *min_x);
+  *min_y = std::min(wy, *min_y);
+
+  layered_costmap_->getCostmap()->mapToWorld(x_ + width_, y_ + height_, wx, wy);
+  *max_x = std::max(wx, *max_x);
+  *max_y = std::max(wy, *max_y);
+
+  has_updated_data_ = false;
 }
 
 void KeepoutFilter::process(

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -161,7 +161,8 @@ void KeepoutFilter::maskCallback(
   height_ = msg->info.height;
 }
 
-void KeepoutFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+void KeepoutFilter::updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
   double * min_x, double * min_y, double * max_x, double * max_y)
 {
   if (!enabled_) {
@@ -170,8 +171,9 @@ void KeepoutFilter::updateBounds(double robot_x, double robot_y, double robot_ya
 
   CostmapFilter::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
 
-  if(!has_updated_data_)
+  if(!has_updated_data_) {
     return;
+  }
 
   double wx, wy;
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -95,7 +95,8 @@ void SpeedFilter::initializeFilter(
   percentage_ = false;
 }
 
-void SpeedFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+void SpeedFilter::updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
   double * min_x, double * min_y, double * max_x, double * max_y)
 {
   if (!enabled_) {

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -95,6 +95,15 @@ void SpeedFilter::initializeFilter(
   percentage_ = false;
 }
 
+void SpeedFilter::updateBounds(double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  if (!enabled_) {
+    return;
+  }
+  CostmapFilter::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
+}
+
 void SpeedFilter::filterInfoCallback(
   const nav2_msgs::msg::CostmapFilterInfo::SharedPtr msg)
 {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5410  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | tb4 sim, as mentioned in the issue |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
