### PR TITLE
Fix lifecycle manager deadlock during shutdown

### DIFF
--- a/nav2_ros_common/include/nav2_ros_common/service_client.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/service_client.hpp
@@ -218,6 +218,16 @@ public:
     return service_name_;
   }
 
+  /**
+  * @brief Stop any running spin operations on the internal executor
+  */
+  void stop()
+  {
+    if (client_) {
+      callback_group_executor_.cancel();
+    }
+  }
+
 protected:
   std::string service_name_;
   rclcpp::Clock::SharedPtr clock_;

--- a/nav2_util/include/nav2_util/lifecycle_service_client.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_service_client.hpp
@@ -57,6 +57,12 @@ public:
     }
   }
 
+  ~LifecycleServiceClient()
+  {
+    change_state_.stop();
+    get_state_.stop();
+  }
+
   /// Trigger a state change
   /**
    * Throws std::runtime_error on failure


### PR DESCRIPTION
This PR fixes the lifecycle manager deadlock issue described in #5437.

## Changes
- Add `stop()` method to `ServiceClient` that cancels internal executor operations
- Call `stop()` in `LifecycleServiceClient` destructor to prevent deadlock

## Problem Addressed
When CTRL+C is pressed during lifecycle node bringup, a race condition can cause `spin_until_future_complete` to hang indefinitely as bringup and shutdown sequences run concurrently.

## Solution
The `stop()` method cancels any running spin operations on the internal executor, allowing proper shutdown coordination.

Closes #5437

Generated with [Claude Code](https://claude.ai/code)