### PR TITLE
Return early from edge interpolation for zero-length edges

### DIFF
--- a/nav2_route/src/path_converter.cpp
+++ b/nav2_route/src/path_converter.cpp
@@ -151,6 +151,10 @@ void PathConverter::interpolateEdge(
   float x = x0;
   float y = y0;
   poses.push_back(utils::toMsg(x, y));
+  // For zero-length edges, we can just push the start point and return
+  if (num_pts < 1) {
+    return;
+  }
 
   unsigned int pt_ctr = 0;
   while (pt_ctr < num_pts - 1) {

--- a/nav2_route/src/path_converter.cpp
+++ b/nav2_route/src/path_converter.cpp
@@ -141,6 +141,11 @@ void PathConverter::interpolateEdge(
   // Find number of points to populate by given density
   const float mag = hypotf(x1 - x0, y1 - y0);
   const unsigned int num_pts = ceil(mag / density_);
+  // For zero-length edges, we can just push the start point and return
+  if (num_pts < 1) {
+    return;
+  }
+
   const float iterpolated_dist = mag / num_pts;
 
   // Find unit vector direction
@@ -151,10 +156,6 @@ void PathConverter::interpolateEdge(
   float x = x0;
   float y = y0;
   poses.push_back(utils::toMsg(x, y));
-  // For zero-length edges, we can just push the start point and return
-  if (num_pts < 1) {
-    return;
-  }
 
   unsigned int pt_ctr = 0;
   while (pt_ctr < num_pts - 1) {

--- a/nav2_route/test/test_path_converter.cpp
+++ b/nav2_route/test/test_path_converter.cpp
@@ -163,3 +163,15 @@ TEST(PathConverterTest, test_path_converter_interpolation)
         poses[i].pose.position.y - poses[i + 1].pose.position.y), 0.05);
   }
 }
+
+TEST(PathConverterTest, test_path_converter_zero_length_edge)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("edge_scorer_test");
+  PathConverter converter;
+  converter.configure(node);
+
+  float x0 = 10.0, y0 = 10.0, x1 = 10.0, y1 = 10.0;
+  std::vector<geometry_msgs::msg::PoseStamped> poses;
+  converter.interpolateEdge(x0, y0, x1, y1, poses);
+  ASSERT_TRUE(poses.empty());
+}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Polymath Autonomy System |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

When a zero-length edge in a route graph is in a calculated route, the `densify` function for the resulting path would go into an infinite loop pushing points to a vector until running out of memory and crashing.

## Description of documentation updates required from your changes

None

## Description of how this change was tested

Added a unit test that definitely fails before adding the fix.

I've been running it on simulation examples with a route graph that has zero length edges.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
