### PR TITLE
Fix missing dependency

### DIFF
--- a/nav2_loopback_sim/package.xml
+++ b/nav2_loopback_sim/package.xml
@@ -7,12 +7,13 @@
   <maintainer email="steve@opennav.org">steve macenski</maintainer>
   <license>Apache-2.0</license>
 
-  <exec_depend>rclpy</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav2_simple_commander</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>tf_transformations</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>python3-transforms3d</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf_transformations</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
No AI
Obvious fix.

nav2_simple_commander was missing but used in the python file.

My pre-commit hooks took the liberty of sorting the list as well. If this is undesired I can undo this.