### PR TITLE
feat(smoother):Add footprint collision checking to SimpleSmoother

### DIFF
--- a/nav2_smoother/include/nav2_smoother/simple_smoother.hpp
+++ b/nav2_smoother/include/nav2_smoother/simple_smoother.hpp
@@ -27,6 +27,7 @@
 #include "nav2_smoother/smoother_utils.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/collision_checker.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_ros_common/node_utils.hpp"
 #include "nav_msgs/msg/path.hpp"
@@ -94,6 +95,7 @@ protected:
    * @param costmap Pointer to minimal costmap
    * @param max_time Maximum time to compute, stop early if over limit
    */
+
   void smoothImpl(
     nav_msgs::msg::Path & path,
     bool & reversing_segment,
@@ -124,6 +126,9 @@ protected:
   int max_its_, refinement_ctr_, refinement_num_;
   bool do_refinement_, enforce_path_inversion_;
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_sub_;
+  //member variables added to store foorprint sub and collision checker
+  std::shared_ptr<nav2_costmap_2d::FootprintSubscriber> footprint_sub_;
+  std::shared_ptr<nav2_costmap_2d::CollisionChecker> collision_checker_;
   rclcpp::Logger logger_{rclcpp::get_logger("SimpleSmoother")};
 };
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses    | Fixes #5330 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Added full footprint collision checking to the `SimpleSmoother`.
* The smoother now correctly uses the robot's orientation to validate poses.
* If a smoothed path is found to be in collision, the smoother safely reverts to the original, valid path segment.

## Description of documentation updates required from your changes

No documentation changes are required. This PR is a bug fix that improves the safety and correctness of the smoother without adding new user-facing parameters or behaviors that need configuration.

## Description of how this change was tested

* A new unit test was added to verify that the smoother correctly identifies and rejects paths that are in footprint collision but would have previously been considered valid.
* Successfully ran all existing unit tests for the `nav2_smoother` package.
* Performed linting validation using `colcon test`.

---

## Future work that may be required in bullet points

* The current implementation reverts the entire path segment on any detected collision. A more advanced approach could potentially be developed to only partially revert or re-smooth from the last valid point.

---

#### For Maintainers: - [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.