### PR TITLE
make Blackboard IDs private to the navigators

### DIFF
--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -31,11 +31,11 @@ NavigateThroughPosesNavigator::configure(
   auto node = parent_node.lock();
 
   goals_blackboard_id_ =
-    node->declare_or_get_parameter("goals_blackboard_id", std::string("goals"));
+    node->declare_or_get_parameter(getName() + ".goals_blackboard_id", std::string("goals"));
   path_blackboard_id_ =
-    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+    node->declare_or_get_parameter(getName() + ".path_blackboard_id", std::string("path"));
   waypoint_statuses_blackboard_id_ =
-    node->declare_or_get_parameter("waypoint_statuses_blackboard_id",
+    node->declare_or_get_parameter(getName() + ".waypoint_statuses_blackboard_id",
       std::string("waypoint_statuses"));
 
   // Odometry smoother object for getting current speed

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -29,10 +29,10 @@ NavigateToPoseNavigator::configure(
   start_time_ = rclcpp::Time(0);
   auto node = parent_node.lock();
 
-  goal_blackboard_id_ =
-    node->declare_or_get_parameter("goal_blackboard_id", std::string("goal"));
-  path_blackboard_id_ =
-    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+  goal_blackboard_id_ = node->declare_or_get_parameter(getName() + ".goal_blackboard_id",
+      std::string("goal"));
+  path_blackboard_id_ = node->declare_or_get_parameter(getName() + ".path_blackboard_id",
+      std::string("path"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | -|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of Tally |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Move the `xx_blackboard_id` parameters to each navigator's namespace. This avoids clashes with other navigators which have the same parameter, but uses a different ID -> Not all navigators must use the same blackboard ID.

## Description of documentation updates required from your changes

Yes, need to update the bt_navigator configuration page

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested
- use `ros2 param dump /bt_navigator` to check the params have moved inside the navigators' namespace
- try to use different values (need to adapt in the BT xml) and see if feedback works correctly

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
