### PR TITLE
Revert double spin

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "std_msgs/msg/string.hpp"
 
@@ -102,6 +103,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
 
   std::string topic_name_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "std_msgs/msg/string.hpp"
 
@@ -102,6 +103,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
 
   std::string topic_name_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "std_msgs/msg/string.hpp"
 
@@ -103,6 +104,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
 
   std::string topic_name_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "std_msgs/msg/string.hpp"
 
@@ -101,6 +102,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
 
   std::string topic_name_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "std_msgs/msg/string.hpp"
 
@@ -102,6 +103,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
 
   std::string topic_name_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <memory>
 #include <mutex>
+#include <chrono>
 
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "sensor_msgs/msg/battery_state.hpp"
@@ -85,6 +86,7 @@ private:
   nav2::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr battery_sub_;
   std::string battery_topic_;
   bool is_battery_charging_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <memory>
 #include <mutex>
+#include <chrono>
 
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "sensor_msgs/msg/battery_state.hpp"
@@ -93,6 +94,7 @@ private:
   double min_battery_;
   bool is_voltage_;
   bool is_battery_low_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
 
 #include "behaviortree_cpp/decorator_node.h"
 #include "behaviortree_cpp/json_export.h"
@@ -110,6 +111,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
   std::string goal_updater_topic_;
   std::string goals_updater_topic_;
+  std::chrono::milliseconds bt_loop_duration_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
@@ -33,6 +33,8 @@ ControllerSelector::ControllerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void ControllerSelector::initialize()
@@ -66,7 +68,7 @@ BT::NodeStatus ControllerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   // This behavior always use the last selected controller received from the topic input.
   // When no input is specified it uses the default controller.

--- a/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
@@ -66,7 +66,7 @@ BT::NodeStatus ControllerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   // This behavior always use the last selected controller received from the topic input.
   // When no input is specified it uses the default controller.

--- a/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
@@ -33,9 +33,6 @@ ControllerSelector::ControllerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
-
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_some(std::chrono::nanoseconds(1));
 }
 
 void ControllerSelector::initialize()

--- a/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
@@ -33,6 +33,8 @@ GoalCheckerSelector::GoalCheckerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void GoalCheckerSelector::initialize()
@@ -66,7 +68,7 @@ BT::NodeStatus GoalCheckerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   // This behavior always use the last selected goal checker received from the topic input.
   // When no input is specified it uses the default goal checker.

--- a/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
@@ -66,7 +66,7 @@ BT::NodeStatus GoalCheckerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   // This behavior always use the last selected goal checker received from the topic input.
   // When no input is specified it uses the default goal checker.

--- a/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
@@ -33,9 +33,6 @@ PlannerSelector::PlannerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
-
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_some(std::chrono::nanoseconds(1));
 }
 
 void PlannerSelector::initialize()

--- a/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
@@ -66,7 +66,7 @@ BT::NodeStatus PlannerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   // This behavior always use the last selected planner received from the topic input.
   // When no input is specified it uses the default planner.

--- a/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
@@ -33,6 +33,8 @@ PlannerSelector::PlannerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void PlannerSelector::initialize()
@@ -66,7 +68,7 @@ BT::NodeStatus PlannerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   // This behavior always use the last selected planner received from the topic input.
   // When no input is specified it uses the default planner.

--- a/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
@@ -32,6 +32,8 @@ ProgressCheckerSelector::ProgressCheckerSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void ProgressCheckerSelector::initialize()
@@ -65,7 +67,7 @@ BT::NodeStatus ProgressCheckerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   // This behavior always use the last selected progress checker received from the topic input.
   // When no input is specified it uses the default goaprogressl checker.

--- a/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
@@ -65,7 +65,7 @@ BT::NodeStatus ProgressCheckerSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   // This behavior always use the last selected progress checker received from the topic input.
   // When no input is specified it uses the default goaprogressl checker.

--- a/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
@@ -34,9 +34,6 @@ SmootherSelector::SmootherSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
-
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_some(std::chrono::nanoseconds(1));
 }
 
 void SmootherSelector::initialize()

--- a/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
@@ -34,6 +34,8 @@ SmootherSelector::SmootherSelector(
 : BT::SyncActionNode(name, conf)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void SmootherSelector::initialize()
@@ -67,7 +69,7 @@ BT::NodeStatus SmootherSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   // This behavior always use the last selected smoother received from the topic input.
   // When no input is specified it uses the default smoother.

--- a/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
@@ -67,7 +67,7 @@ BT::NodeStatus SmootherSelector::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   // This behavior always use the last selected smoother received from the topic input.
   // When no input is specified it uses the default smoother.

--- a/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
@@ -62,7 +62,7 @@ BT::NodeStatus IsBatteryChargingCondition::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
   if (is_battery_charging_) {
     return BT::NodeStatus::SUCCESS;
   }

--- a/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
@@ -27,9 +27,6 @@ IsBatteryChargingCondition::IsBatteryChargingCondition(
   is_battery_charging_(false)
 {
   initialize();
-
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_some(std::chrono::nanoseconds(1));
 }
 
 void IsBatteryChargingCondition::initialize()

--- a/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
@@ -27,6 +27,8 @@ IsBatteryChargingCondition::IsBatteryChargingCondition(
   is_battery_charging_(false)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void IsBatteryChargingCondition::initialize()
@@ -62,7 +64,7 @@ BT::NodeStatus IsBatteryChargingCondition::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
   if (is_battery_charging_) {
     return BT::NodeStatus::SUCCESS;
   }

--- a/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
@@ -68,7 +68,7 @@ BT::NodeStatus IsBatteryLowCondition::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_some();
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
   if (is_battery_low_) {
     return BT::NodeStatus::SUCCESS;
   }

--- a/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
@@ -30,9 +30,6 @@ IsBatteryLowCondition::IsBatteryLowCondition(
   is_battery_low_(false)
 {
   initialize();
-
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_some(std::chrono::nanoseconds(1));
 }
 
 void IsBatteryLowCondition::initialize()

--- a/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
@@ -30,6 +30,8 @@ IsBatteryLowCondition::IsBatteryLowCondition(
   is_battery_low_(false)
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void IsBatteryLowCondition::initialize()
@@ -68,7 +70,7 @@ BT::NodeStatus IsBatteryLowCondition::tick()
     initialize();
   }
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
   if (is_battery_low_) {
     return BT::NodeStatus::SUCCESS;
   }

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -88,9 +88,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   getInput("input_goal", goal);
   getInput("input_goals", goals);
 
-  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_all(std::chrono::milliseconds(1));
-  callback_group_executor_.spin_all(std::chrono::milliseconds(49));
+  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
 
   if (last_goal_received_set_) {
     if (last_goal_received_.header.stamp == rclcpp::Time(0)) {

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -36,9 +36,6 @@ GoalUpdater::GoalUpdater(
   goals_updater_topic_("goals_update")
 {
   initialize();
-
-    // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
-  callback_group_executor_.spin_all(std::chrono::milliseconds(1));
 }
 
 void GoalUpdater::initialize()
@@ -91,6 +88,8 @@ inline BT::NodeStatus GoalUpdater::tick()
   getInput("input_goal", goal);
   getInput("input_goals", goals);
 
+  // Spin multiple times due to rclcpp regression in Jazzy requiring a 'warm up' spin
+  callback_group_executor_.spin_all(std::chrono::milliseconds(1));
   callback_group_executor_.spin_all(std::chrono::milliseconds(49));
 
   if (last_goal_received_set_) {

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -36,6 +36,8 @@ GoalUpdater::GoalUpdater(
   goals_updater_topic_("goals_update")
 {
   initialize();
+  bt_loop_duration_ =
+    config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
 }
 
 void GoalUpdater::initialize()
@@ -88,7 +90,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   getInput("input_goal", goal);
   getInput("input_goals", goals);
 
-  callback_group_executor_.spin_all(std::chrono::milliseconds(50));
+  callback_group_executor_.spin_all(bt_loop_duration_);
 
   if (last_goal_received_set_) {
     if (last_goal_received_.header.stamp == rclcpp::Time(0)) {

--- a/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
@@ -44,6 +44,9 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::ControllerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
@@ -44,6 +44,9 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::GoalCheckerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
@@ -44,6 +44,9 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::PlannerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
@@ -43,6 +43,9 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::ProgressCheckerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
@@ -44,6 +44,9 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::SmootherSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
@@ -39,6 +39,9 @@ public:
     config_->blackboard->set(
       "node",
       node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     factory_->registerNodeType<nav2_behavior_tree::IsBatteryChargingCondition>("IsBatteryCharging");
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
@@ -40,6 +40,9 @@ public:
     config_->blackboard->set(
       "node",
       node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     factory_->registerNodeType<nav2_behavior_tree::IsBatteryLowCondition>("IsBatteryLow");
 

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
@@ -43,6 +43,9 @@ public:
     config_->blackboard->set(
       "node",
       node_);
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration",
+      std::chrono::milliseconds(10));
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_route/test/test_graph_loader.cpp
+++ b/nav2_route/test/test_graph_loader.cpp
@@ -107,7 +107,6 @@ TEST(GraphLoader, test_transformation_api)
   tf_broadcaster->sendTransform(transform);
   rclcpp::Rate(1).sleep();
   tf_broadcaster->sendTransform(transform);
-  rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(1));
   rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(50));
 
   graph[0].coords.frame_id = "map_test";

--- a/nav2_route/test/test_graph_saver.cpp
+++ b/nav2_route/test/test_graph_saver.cpp
@@ -143,7 +143,6 @@ TEST(GraphSaver, test_transformation_api)
   tf_broadcaster->sendTransform(transform);
   rclcpp::Rate(1).sleep();
   tf_broadcaster->sendTransform(transform);
-  rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(1));
   rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(50));
 
   GraphSaver graph_saver(node, tf, frame);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/4567 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

- Revert double spin, this has been solved in the latest release
- Change spin some to spin all, to make sure the node has the latest message update

## Description of documentation updates required from your changes

None

## Description of how this change was tested

Tested in different node's unit tests

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
