### PR TITLE
Fix dynamic param SmacPlannerLattice 

### DIFF
--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -51,21 +51,19 @@ void LatticeMotionTable::initMotionModel(
   SearchInfo & search_info)
 {
   size_x = size_x_in;
-
-  if (current_lattice_filepath == search_info.lattice_filepath) {
-    return;
-  }
-
-  size_x = size_x_in;
   change_penalty = search_info.change_penalty;
   non_straight_penalty = search_info.non_straight_penalty;
   cost_penalty = search_info.cost_penalty;
   reverse_penalty = search_info.reverse_penalty;
   travel_distance_reward = 1.0f - search_info.retrospective_penalty;
-  current_lattice_filepath = search_info.lattice_filepath;
   allow_reverse_expansion = search_info.allow_reverse_expansion;
   rotation_penalty = search_info.rotation_penalty;
   min_turning_radius = search_info.minimum_turning_radius;
+
+  if (current_lattice_filepath == search_info.lattice_filepath) {
+    return;
+  }
+  current_lattice_filepath = search_info.lattice_filepath;
 
   // Get the metadata about this minimum control set
   lattice_metadata = getLatticeMetadata(current_lattice_filepath);
@@ -310,6 +308,7 @@ float NodeLattice::getTraversalCost(const NodePtr & child)
   if (prim == nullptr) {
     return prim_length;
   }
+  //print cost penalty
 
   // Pure rotation in place 1 angular bin in either direction
   if (transition_prim->trajectory_length < 1e-4) {

--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -308,7 +308,6 @@ float NodeLattice::getTraversalCost(const NodePtr & child)
   if (prim == nullptr) {
     return prim_length;
   }
-  //print cost penalty
 
   // Pure rotation in place 1 angular bin in either direction
   if (transition_prim->trajectory_length < 1e-4) {


### PR DESCRIPTION
I noticed that some parameters from SmacPlannerLattice were only being dynamically set successfully once, more attempts wouldn't change anything. The issue to my understanding is that it was exiting early because the `lattice_filepath` hadn't changed.

To be honest I didn't look for side-effects but looks relatively safe. Any risks you see of updating the parameters without  re-populating the primitives?

