### PR TITLE
Fix duplicate poses with computePlanThroughPoses

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -428,9 +428,19 @@ void PlannerServer::computePlanThroughPoses()
         throw nav2_core::NoValidPathCouldBeFound(goal->planner_id + " generated a empty path");
       }
 
-      // Concatenate paths together
-      concat_path.poses.insert(
-        concat_path.poses.end(), curr_path.poses.begin(), curr_path.poses.end());
+      // Concatenate paths together, but skip the first pose of subsequent paths
+      // to avoid duplicating the connection point
+      if (i == 0) {
+        // First path: add all poses
+        concat_path.poses.insert(
+          concat_path.poses.end(), curr_path.poses.begin(), curr_path.poses.end());
+      } else {
+        // Subsequent paths: skip the first pose to avoid duplication
+        if (curr_path.poses.size() > 1) {
+          concat_path.poses.insert(
+            concat_path.poses.end(), curr_path.poses.begin() + 1, curr_path.poses.end());
+        }
+      }
       concat_path.header = curr_path.header;
     }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |


Story:

1- I turned on MPPI's enforce_path_inversion and noticed that the pruned path was flake-ly being cut short to one of the poses that were used to generate the global plan with computePlanThroughPoses
2- I put my investigation hat and found out that in MPPI's `findFirstPathInversion`, the `dot_product` was sometimes -0.0000000-peanuts -> negative -> path inversion. Turns out points in points OAB, B was sometimes very slightly before A so the vector was pointing in the other direction. 
3- Looking into the planner server, `computePlanThroughPoses` does start the concatenated path exactly where the first one ends and thus this PR.

I think I experienced a similar issue in the past with RPP but can't find the conversation

---

## Description of contribution in a few bullet points

* Change computePlanThroughPoses to skip the first pose of the paths to concatenate


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
