### PR TITLE
Removing openMP dep on MPPI

### DIFF
--- a/nav2_mppi_controller/package.xml
+++ b/nav2_mppi_controller/package.xml
@@ -14,7 +14,6 @@
   <depend>angles</depend>
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
-  <depend>libomp-dev</depend>
   <depend>nav2_common</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>


### PR DESCRIPTION
Remove an unused dependency