### PR TITLE
[Graceful Controller] Add deceleration limit

### DIFF
--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -226,6 +226,7 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.v_linear_max | Maximum linear velocity (m/s) | double | 0.25    |
 | controller.v_angular_max | Maximum angular velocity (rad/s) produced by the control law | double | 0.75    |
 | controller.slowdown_radius | Radius (m) around the goal pose in which the robot will start to slow down | double | 0.25     |
+| controller.deceleration_max | Maximum deceleration (m/s²) used to compute a velocity limit based on distance to the goal: `v = sqrt(2 * dist * deceleration_max)` | double | 2.5     |
 | controller.rotate_to_heading_angular_vel | Angular velocity (rad/s) to rotate to the goal heading when rotate_to_dock is enabled | double | 1.0    |
 | controller.rotate_to_heading_max_angular_accel | Maximum angular acceleration (rad/s^2) to rotate to the goal heading when rotate_to_dock is enabled | double | 3.2    |
 | controller.use_collision_detection | Whether to use collision detection to avoid obstacles | bool | true     |

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
@@ -133,7 +133,7 @@ protected:
   // Smooth control law
   std::unique_ptr<nav2_graceful_controller::SmoothControlLaw> control_law_;
   double k_phi_, k_delta_, beta_, lambda_;
-  double slowdown_radius_, v_linear_min_, v_linear_max_, v_angular_max_;
+  double slowdown_radius_, deceleration_max_, v_linear_min_, v_linear_max_, v_angular_max_;
   double rotate_to_heading_angular_vel_, rotate_to_heading_max_angular_accel_;
 
   // The trajectory of the robot while dock / undock for visualization / debug purposes

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -43,7 +43,7 @@ Controller::Controller(
   v_linear_max_ = node->declare_or_get_parameter("controller.v_linear_max", 0.25);
   v_angular_max_ = node->declare_or_get_parameter("controller.v_angular_max", 0.75);
   slowdown_radius_ = node->declare_or_get_parameter("controller.slowdown_radius", 0.25);
-  deceleration_max_ = node->declare_or_get_parameter("controller.deceleration_max", 0.5);
+  deceleration_max_ = node->declare_or_get_parameter("controller.deceleration_max", 2.5);
   rotate_to_heading_angular_vel_ = node->declare_or_get_parameter(
     "controller.rotate_to_heading_angular_vel", 1.0);
   rotate_to_heading_max_angular_accel_ = node->declare_or_get_parameter(

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -43,6 +43,7 @@ Controller::Controller(
   v_linear_max_ = node->declare_or_get_parameter("controller.v_linear_max", 0.25);
   v_angular_max_ = node->declare_or_get_parameter("controller.v_angular_max", 0.75);
   slowdown_radius_ = node->declare_or_get_parameter("controller.slowdown_radius", 0.25);
+  deceleration_max_ = node->declare_or_get_parameter("controller.deceleration_max", 0.5);
   rotate_to_heading_angular_vel_ = node->declare_or_get_parameter(
     "controller.rotate_to_heading_angular_vel", 1.0);
   rotate_to_heading_max_angular_accel_ = node->declare_or_get_parameter(
@@ -63,8 +64,8 @@ Controller::Controller(
     "controller.dock_collision_threshold", 0.3);
 
   control_law_ = std::make_unique<nav2_graceful_controller::SmoothControlLaw>(
-    k_phi_, k_delta_, beta_, lambda_, slowdown_radius_, v_linear_min_, v_linear_max_,
-    v_angular_max_);
+    k_phi_, k_delta_, beta_, lambda_, slowdown_radius_, deceleration_max_,
+    v_linear_min_, v_linear_max_, v_angular_max_);
 
   // Add callback for dynamic parameters
   post_set_params_handler_ = node->add_post_set_parameters_callback(
@@ -263,6 +264,8 @@ Controller::updateParametersCallback(const std::vector<rclcpp::Parameter> & para
         v_angular_max_ = parameter.as_double();
       } else if (param_name == "controller.slowdown_radius") {
         slowdown_radius_ = parameter.as_double();
+      } else if (param_name == "controller.deceleration_max") {
+        deceleration_max_ = parameter.as_double();
       } else if (param_name == "controller.rotate_to_heading_angular_vel") {
         rotate_to_heading_angular_vel_ = parameter.as_double();
       } else if (param_name == "controller.rotate_to_heading_max_angular_accel") {
@@ -278,6 +281,7 @@ Controller::updateParametersCallback(const std::vector<rclcpp::Parameter> & para
       // Update the smooth control law with the new params
       control_law_->setCurvatureConstants(k_phi_, k_delta_, beta_, lambda_);
       control_law_->setSlowdownRadius(slowdown_radius_);
+      control_law_->setMaxDeceleration(deceleration_max_);
       control_law_->setSpeedLimit(v_linear_min_, v_linear_max_, v_angular_max_);
     }
   }

--- a/nav2_docking/opennav_docking/test/test_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_controller.cpp
@@ -229,6 +229,7 @@ TEST(ControllerTests, DynamicParameters) {
       rclcpp::Parameter("controller.v_linear_max", 6.0),
       rclcpp::Parameter("controller.v_angular_max", 7.0),
       rclcpp::Parameter("controller.slowdown_radius", 8.0),
+      rclcpp::Parameter("controller.deceleration_max", 14.0),
       rclcpp::Parameter("controller.projection_time", 9.0),
       rclcpp::Parameter("controller.simulation_time_step", 10.0),
       rclcpp::Parameter("controller.dock_collision_threshold", 11.0),
@@ -247,6 +248,7 @@ TEST(ControllerTests, DynamicParameters) {
   EXPECT_EQ(node->get_parameter("controller.v_linear_max").as_double(), 6.0);
   EXPECT_EQ(node->get_parameter("controller.v_angular_max").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("controller.slowdown_radius").as_double(), 8.0);
+  EXPECT_EQ(node->get_parameter("controller.deceleration_max").as_double(), 14.0);
   EXPECT_EQ(node->get_parameter("controller.projection_time").as_double(), 9.0);
   EXPECT_EQ(node->get_parameter("controller.simulation_time_step").as_double(), 10.0);
   EXPECT_EQ(node->get_parameter("controller.dock_collision_threshold").as_double(), 11.0);

--- a/nav2_graceful_controller/README.md
+++ b/nav2_graceful_controller/README.md
@@ -24,6 +24,7 @@ The smooth control law is a pose-following kinematic control law that generates 
 | `v_linear_max` | Maximum linear velocity. Units: meters/sec. |
 | `v_angular_max` | Maximum angular velocity produced by the control law. Units: radians/sec. |
 | `slowdown_radius` | Radius around the goal pose in which the robot will start to slow down. Units: meters. |
+| `deceleration_max` | Maximum deceleration (m/s²) used to compute a velocity limit based on distance to the goal: `v = sqrt(2 * dist * deceleration_max)`. Units: m/s². |
 | `initial_rotation` | Enable a rotation in place to the goal before starting the path. The control law may generate large sweeping arcs to the goal pose, depending on the initial robot orientation and k_phi, k_delta. |
 | `initial_rotation_min_angle` | The difference in the path orientation and the starting robot orientation to trigger a rotate in place, if `initial_rotation` is enabled. |
 | `final_rotation` | Similar to `initial_rotation`, the control law can generate large arcs when the goal orientation is not aligned with the path. If this is enabled, the final pose will be ignored and the robot will follow the orientation of he path and will make a final rotation in place to the goal orientation. |

--- a/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/parameter_handler.hpp
@@ -43,6 +43,7 @@ struct Parameters
   double v_angular_max_initial;
   double v_angular_min_in_place;
   double slowdown_radius;
+  double deceleration_max;
   bool initial_rotation;
   double initial_rotation_tolerance;
   bool prefer_final_rotation;

--- a/nav2_graceful_controller/include/nav2_graceful_controller/smooth_control_law.hpp
+++ b/nav2_graceful_controller/include/nav2_graceful_controller/smooth_control_law.hpp
@@ -40,12 +40,14 @@ public:
    * @param beta Constant factor applied to the path curvature: dropping velocity.
    * @param lambda Constant factor applied to the path curvature for sharpness.
    * @param slowdown_radius Radial threshold applied to the slowdown rule.
+   * @param deceleration_max Maximum deceleration.
    * @param v_linear_min Minimum linear velocity.
    * @param v_linear_max Maximum linear velocity.
    * @param v_angular_max Maximum angular velocity.
    */
   SmoothControlLaw(
-    double k_phi, double k_delta, double beta, double lambda, double slowdown_radius,
+    double k_phi, double k_delta, double beta, double lambda,
+    double slowdown_radius, double deceleration_max,
     double v_linear_min, double v_linear_max, double v_angular_max);
 
   /**
@@ -70,6 +72,13 @@ public:
    * @param slowdown_radius Radial threshold applied to the slowdown rule.
    */
   void setSlowdownRadius(const double slowdown_radius);
+
+  /**
+   * @brief Set the maximum deceleration
+   *
+   * @param deceleration_max Maximum deceleration possible.
+   */
+  void setMaxDeceleration(const double deceleration_max);
 
   /**
    * @brief Update the velocity limits.
@@ -169,6 +178,11 @@ protected:
    * @brief Radial threshold applied to the slowdown rule.
    */
   double slowdown_radius_;
+
+  /**
+   * @brief Maximum deceleration.
+   */
+  double deceleration_max_;
 
   /**
    * @brief Minimum linear velocity.

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -49,7 +49,8 @@ void GracefulController::configure(
 
   // Handles the control law to generate the velocity commands
   control_law_ = std::make_unique<SmoothControlLaw>(
-    params_->k_phi, params_->k_delta, params_->beta, params_->lambda, params_->slowdown_radius,
+    params_->k_phi, params_->k_delta, params_->beta, params_->lambda,
+    params_->slowdown_radius, params_->deceleration_max,
     params_->v_linear_min, params_->v_linear_max, params_->v_angular_max);
 
   // Initialize footprint collision checker
@@ -149,6 +150,7 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
   control_law_->setCurvatureConstants(
     params_->k_phi, params_->k_delta, params_->beta, params_->lambda);
   control_law_->setSlowdownRadius(params_->slowdown_radius);
+  control_law_->setMaxDeceleration(params_->deceleration_max);
   control_law_->setSpeedLimit(params_->v_linear_min, params_->v_linear_max, params_->v_angular_max);
   // Add proper orientations to plan, if needed
   validateOrientations(transformed_plan.poses);

--- a/nav2_graceful_controller/src/parameter_handler.cpp
+++ b/nav2_graceful_controller/src/parameter_handler.cpp
@@ -56,6 +56,8 @@ ParameterHandler::ParameterHandler(
     plugin_name_ + ".v_angular_min_in_place", 0.25);
   params_.slowdown_radius = node->declare_or_get_parameter(
     plugin_name_ + ".slowdown_radius", 1.5);
+  params_.deceleration_max = node->declare_or_get_parameter(
+    plugin_name_ + ".deceleration_max", 2.5);
   params_.initial_rotation = node->declare_or_get_parameter(
     plugin_name_ + ".initial_rotation", true);
   params_.initial_rotation_tolerance = node->declare_or_get_parameter(
@@ -164,6 +166,8 @@ ParameterHandler::updateParametersCallback(
         params_.v_angular_min_in_place = parameter.as_double();
       } else if (param_name == plugin_name_ + ".slowdown_radius") {
         params_.slowdown_radius = parameter.as_double();
+      } else if (param_name == plugin_name_ + ".deceleration_max") {
+        params_.deceleration_max = parameter.as_double();
       } else if (param_name == plugin_name_ + ".initial_rotation_tolerance") {
         params_.initial_rotation_tolerance = parameter.as_double();
       } else if (param_name == plugin_name_ + ".rotation_scaling_factor") {

--- a/nav2_graceful_controller/src/smooth_control_law.cpp
+++ b/nav2_graceful_controller/src/smooth_control_law.cpp
@@ -21,9 +21,11 @@ namespace nav2_graceful_controller
 {
 
 SmoothControlLaw::SmoothControlLaw(
-  double k_phi, double k_delta, double beta, double lambda, double slowdown_radius,
+  double k_phi, double k_delta, double beta, double lambda,
+  double slowdown_radius, double deceleration_max,
   double v_linear_min, double v_linear_max, double v_angular_max)
-: k_phi_(k_phi), k_delta_(k_delta), beta_(beta), lambda_(lambda), slowdown_radius_(slowdown_radius),
+: k_phi_(k_phi), k_delta_(k_delta), beta_(beta), lambda_(lambda),
+  slowdown_radius_(slowdown_radius), deceleration_max_(deceleration_max),
   v_linear_min_(v_linear_min), v_linear_max_(v_linear_max), v_angular_max_(v_angular_max)
 {
 }
@@ -40,6 +42,11 @@ void SmoothControlLaw::setCurvatureConstants(
 void SmoothControlLaw::setSlowdownRadius(double slowdown_radius)
 {
   slowdown_radius_ = slowdown_radius;
+}
+
+void SmoothControlLaw::setMaxDeceleration(double deceleration_max)
+{
+  deceleration_max_ = deceleration_max;
 }
 
 void SmoothControlLaw::setSpeedLimit(
@@ -67,6 +74,9 @@ geometry_msgs::msg::Twist SmoothControlLaw::calculateRegularVelocity(
 
   // Slowdown when the robot is near the target to remove singularity
   v = std::min(v_linear_max_ * (ego_coords.r / slowdown_radius_), v);
+
+  // Constraint robot velocity within deceleration limits
+  v = std::min(sqrt(2 * ego_coords.r * deceleration_max_), v);
 
   // Set some small v_min when far away from origin to promote faster
   // turning motion when the curvature is very high

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -29,15 +29,17 @@ class SCLFixture : public nav2_graceful_controller::SmoothControlLaw
 public:
   SCLFixture(
     double k_phi, double k_delta, double beta, double lambda,
-    double slowdown_radius, double v_linear_min, double v_linear_max, double v_angular_max)
+    double slowdown_radius, double deceleration_max,
+    double v_linear_min, double v_linear_max, double v_angular_max)
   : nav2_graceful_controller::SmoothControlLaw(k_phi, k_delta, beta, lambda,
-      slowdown_radius, v_linear_min, v_linear_max, v_angular_max) {}
+      slowdown_radius, deceleration_max, v_linear_min, v_linear_max, v_angular_max) {}
 
   double getCurvatureKPhi() {return k_phi_;}
   double getCurvatureKDelta() {return k_delta_;}
   double getCurvatureBeta() {return beta_;}
   double getCurvatureLambda() {return lambda_;}
   double getSlowdownRadius() {return slowdown_radius_;}
+  double getDecelMax() {return deceleration_max_;}
   double getSpeedLinearMin() {return v_linear_min_;}
   double getSpeedLinearMax() {return v_linear_max_;}
   double getSpeedAngularMax() {return v_angular_max_;}
@@ -78,7 +80,7 @@ public:
 
 TEST(SmoothControlLawTest, setCurvatureConstants) {
   // Initialize SmoothControlLaw
-  SCLFixture scl(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0);
+  SCLFixture scl(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0);
 
   // Set curvature constants
   scl.setCurvatureConstants(1.0, 2.0, 3.0, 4.0);
@@ -86,17 +88,21 @@ TEST(SmoothControlLawTest, setCurvatureConstants) {
   // Set slowdown radius
   scl.setSlowdownRadius(5.0);
 
+  // Set max deceleration
+  scl.setMaxDeceleration(6.0);
+
   // Check results
   EXPECT_EQ(scl.getCurvatureKPhi(), 1.0);
   EXPECT_EQ(scl.getCurvatureKDelta(), 2.0);
   EXPECT_EQ(scl.getCurvatureBeta(), 3.0);
   EXPECT_EQ(scl.getCurvatureLambda(), 4.0);
   EXPECT_EQ(scl.getSlowdownRadius(), 5.0);
+  EXPECT_EQ(scl.getDecelMax(), 6.0);
 }
 
 TEST(SmoothControlLawTest, setSpeedLimits) {
   // Initialize SmoothControlLaw
-  SCLFixture scl(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  SCLFixture scl(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
 
   // Set speed limits
   scl.setSpeedLimit(1.0, 2.0, 3.0);
@@ -109,7 +115,7 @@ TEST(SmoothControlLawTest, setSpeedLimits) {
 
 TEST(SmoothControlLawTest, calculateCurvature) {
   // Initialize SmoothControlLaw
-  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 0.0, 1.0, 1.0);
+  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 2.5, 0.0, 1.0, 1.0);
 
   // Initialize target
   geometry_msgs::msg::Pose target;
@@ -144,7 +150,7 @@ TEST(SmoothControlLawTest, calculateCurvature) {
 
 TEST(SmoothControlLawTest, calculateRegularVelocity) {
   // Initialize SmoothControlLaw
-  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 0.0, 1.0, 1.0);
+  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 2.5, 0.0, 1.0, 1.0);
 
   // Initialize target
   geometry_msgs::msg::Pose target;
@@ -181,7 +187,7 @@ TEST(SmoothControlLawTest, calculateRegularVelocity) {
 
 TEST(SmoothControlLawTest, calculateNextPose) {
   // Initialize SmoothControlLaw
-  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 0.0, 1.0, 1.0);
+  SCLFixture scl(1.0, 10.0, 0.2, 2.0, 0.1, 2.5, 0.0, 1.0, 1.0);
 
   // Initialize target
   geometry_msgs::msg::Pose target;
@@ -243,6 +249,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
       rclcpp::Parameter("test.v_angular_max", 10.0),
       rclcpp::Parameter("test.v_angular_min_in_place", 14.0),
       rclcpp::Parameter("test.slowdown_radius", 11.0),
+      rclcpp::Parameter("test.deceleration_max", 21.0),
       rclcpp::Parameter("test.initial_rotation", false),
       rclcpp::Parameter("test.initial_rotation_tolerance", 12.0),
       rclcpp::Parameter("test.prefer_final_rotation", false),
@@ -271,6 +278,7 @@ TEST(GracefulControllerTest, dynamicParameters) {
   EXPECT_EQ(node->get_parameter("test.v_angular_max").as_double(), 10.0);
   EXPECT_EQ(node->get_parameter("test.v_angular_min_in_place").as_double(), 14.0);
   EXPECT_EQ(node->get_parameter("test.slowdown_radius").as_double(), 11.0);
+  EXPECT_EQ(node->get_parameter("test.deceleration_max").as_double(), 21.0);
   EXPECT_EQ(node->get_parameter("test.initial_rotation").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.initial_rotation_tolerance").as_double(), 12.0);
   EXPECT_EQ(node->get_parameter("test.prefer_final_rotation").as_bool(), false);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4865 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot3 Gazebo Simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Graceful Controller makes use of a slowdown radius to stop at the target. This PR additionally applies deceleration limit while the robot is stopping.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

* Added new parameter, `deceleration_max` to Graceful Controller.
* Supporting a new behavior for stopping.

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

Tested in simulation.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
