### PR TITLE
fix(nav2_theta_star_planner): Correct typo in CMakeLists ament_export_dependencies

### DIFF
--- a/nav2_theta_star_planner/CMakeLists.txt
+++ b/nav2_theta_star_planner/CMakeLists.txt
@@ -87,7 +87,8 @@ ament_export_libraries(${library_name})
 ament_export_dependencies(
   geometry_msgs
   nav2_core
-  nav2_costmap_2dnav2_util
+  nav2_costmap_2d
+  nav2_util
   nav_msgs
   rclcpp
   rclcpp_lifecycle


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 22.04 LTS |
| Robotic platform tested on | N/A (build fix) |
| Does this PR contain AI generated software? | (No, just a newline really) |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* I fixed a typo in the CMakeLists.txt file from the `nav2_theta_star_planner` package where the `nav2_costmap_2d` and `nav2_util` were written together (without a newline).

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

* Performed a clean build using colcon build --symlink-install.
---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
