### PR TITLE
Replace rclcpp::spin_some and rclcpp::spin_all

### DIFF
--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -202,8 +202,10 @@ public:
     action_server_ = std::make_shared<FibonacciActionServer>();
     server_thread_ = std::make_shared<std::thread>(
       []() {
+        rclcpp::executors::SingleThreadedExecutor executor;
+        executor.add_node(action_server_);
         while (rclcpp::ok() && BTActionNodeTestFixture::action_server_ != nullptr) {
-          rclcpp::spin_some(BTActionNodeTestFixture::action_server_);
+          executor.spin_some();
           std::this_thread::sleep_for(100ns);
         }
       });
@@ -211,6 +213,8 @@ public:
 
   void TearDown() override
   {
+    // Sleep for some time to avoid race condition
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
     action_server_.reset();
     tree_.reset();
     server_thread_->join();

--- a/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
@@ -31,6 +31,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("controller_selector_test_fixture");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
 
     // Configure and activate the lifecycle node
     node_->configure();
@@ -67,6 +69,7 @@ public:
     config_ = nullptr;
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
   void TearDown() override
@@ -76,12 +79,15 @@ public:
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 nav2::LifecycleNode::SharedPtr ControllerSelectorTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr ControllerSelectorTestFixture::executor_ =
+  nullptr;
 
 BT::NodeConfiguration * ControllerSelectorTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> ControllerSelectorTestFixture::factory_ = nullptr;
@@ -126,7 +132,7 @@ TEST_F(ControllerSelectorTestFixture, test_custom_topic)
     tree_->rootNode()->executeTick();
     controller_selector_pub->publish(selected_controller_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check controller updated
@@ -173,7 +179,7 @@ TEST_F(ControllerSelectorTestFixture, test_default_topic)
     tree_->rootNode()->executeTick();
     controller_selector_pub->publish(selected_controller_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check controller updated

--- a/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
@@ -31,6 +31,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("goal_checker_selector_test_fixture");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
 
     // Configure and activate the lifecycle node
     node_->configure();
@@ -67,6 +69,7 @@ public:
     config_ = nullptr;
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
   void TearDown() override
@@ -76,12 +79,15 @@ public:
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 nav2::LifecycleNode::SharedPtr GoalCheckerSelectorTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr GoalCheckerSelectorTestFixture::executor_ =
+  nullptr;
 
 BT::NodeConfiguration * GoalCheckerSelectorTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> GoalCheckerSelectorTestFixture::factory_ = nullptr;
@@ -127,7 +133,7 @@ TEST_F(GoalCheckerSelectorTestFixture, test_custom_topic)
     tree_->rootNode()->executeTick();
     goal_checker_selector_pub->publish(selected_goal_checker_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check goal_checker updated
@@ -175,7 +181,7 @@ TEST_F(GoalCheckerSelectorTestFixture, test_default_topic)
     tree_->rootNode()->executeTick();
     goal_checker_selector_pub->publish(selected_goal_checker_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check goal_checker updated

--- a/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
@@ -31,6 +31,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("planner_selector_test_fixture");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
 
     // Configure and activate the lifecycle node
     node_->configure();
@@ -65,6 +67,7 @@ public:
     config_ = nullptr;
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
   void TearDown() override
@@ -74,12 +77,15 @@ public:
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 nav2::LifecycleNode::SharedPtr PlannerSelectorTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr PlannerSelectorTestFixture::executor_ =
+  nullptr;
 
 BT::NodeConfiguration * PlannerSelectorTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> PlannerSelectorTestFixture::factory_ = nullptr;
@@ -125,7 +131,7 @@ TEST_F(PlannerSelectorTestFixture, test_custom_topic)
     tree_->rootNode()->executeTick();
     planner_selector_pub->publish(selected_planner_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check planner updated
@@ -173,7 +179,7 @@ TEST_F(PlannerSelectorTestFixture, test_default_topic)
     tree_->rootNode()->executeTick();
     planner_selector_pub->publish(selected_planner_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check planner updated

--- a/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
@@ -30,6 +30,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("progress_checker_selector_test_fixture");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
 
     // Configure and activate the lifecycle node
     node_->configure();
@@ -66,6 +68,7 @@ public:
     config_ = nullptr;
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
   void TearDown() override
@@ -75,12 +78,15 @@ public:
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 nav2::LifecycleNode::SharedPtr ProgressCheckerSelectorTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr ProgressCheckerSelectorTestFixture::
+executor_ = nullptr;
 
 BT::NodeConfiguration * ProgressCheckerSelectorTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> ProgressCheckerSelectorTestFixture::factory_ = nullptr;
@@ -129,7 +135,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_custom_topic)
     tree_->rootNode()->executeTick();
     progress_checker_selector_pub->publish(selected_progress_checker_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check progress_checker updated
@@ -179,7 +185,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_default_topic)
     tree_->rootNode()->executeTick();
     progress_checker_selector_pub->publish(selected_progress_checker_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check goal_checker updated

--- a/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
@@ -31,6 +31,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("smoother_selector_test_fixture");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
 
     // Configure and activate the lifecycle node
     node_->configure();
@@ -67,6 +69,7 @@ public:
     config_ = nullptr;
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
   void TearDown() override
@@ -76,12 +79,15 @@ public:
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 nav2::LifecycleNode::SharedPtr SmootherSelectorTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr SmootherSelectorTestFixture::executor_ =
+  nullptr;
 
 BT::NodeConfiguration * SmootherSelectorTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> SmootherSelectorTestFixture::factory_ = nullptr;
@@ -127,7 +133,7 @@ TEST_F(SmootherSelectorTestFixture, test_custom_topic)
     tree_->rootNode()->executeTick();
     smoother_selector_pub->publish(selected_smoother_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check smoother updated
@@ -175,7 +181,7 @@ TEST_F(SmootherSelectorTestFixture, test_default_topic)
     tree_->rootNode()->executeTick();
     smoother_selector_pub->publish(selected_smoother_cmd);
 
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor_->spin_some();
   }
 
   // check smoother updated

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
@@ -30,6 +30,8 @@ public:
   static void SetUpTestCase()
   {
     node_ = std::make_shared<nav2::LifecycleNode>("test_is_battery_low");
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
     factory_ = std::make_shared<BT::BehaviorTreeFactory>();
 
     config_ = new BT::NodeConfiguration();
@@ -59,10 +61,12 @@ public:
     battery_pub_.reset();
     node_.reset();
     factory_.reset();
+    executor_.reset();
   }
 
 protected:
   static nav2::LifecycleNode::SharedPtr node_;
+  static rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   static BT::NodeConfiguration * config_;
   static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
   static nav2::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr
@@ -70,6 +74,8 @@ protected:
 };
 
 nav2::LifecycleNode::SharedPtr IsBatteryLowConditionTestFixture::node_ = nullptr;
+rclcpp::executors::SingleThreadedExecutor::SharedPtr IsBatteryLowConditionTestFixture::
+executor_ = nullptr;
 BT::NodeConfiguration * IsBatteryLowConditionTestFixture::config_ = nullptr;
 std::shared_ptr<BT::BehaviorTreeFactory> IsBatteryLowConditionTestFixture::factory_ = nullptr;
 nav2::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr
@@ -91,25 +97,25 @@ TEST_F(IsBatteryLowConditionTestFixture, test_behavior_percentage)
   battery_msg.percentage = 1.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.percentage = 0.49;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 
   battery_msg.percentage = 0.51;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.percentage = 0.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 }
 
@@ -129,25 +135,25 @@ TEST_F(IsBatteryLowConditionTestFixture, test_behavior_voltage)
   battery_msg.voltage = 10.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.voltage = 4.9;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 
   battery_msg.voltage = 5.1;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.voltage = 0.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  rclcpp::spin_some(node_->get_node_base_interface());
+  executor_->spin_some();
   EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 }
 

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -188,6 +188,7 @@ protected:
 
   // CollisionMonitor node
   std::shared_ptr<CollisionMonitorWrapper> cm_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
 
   // Footprint publisher
   nav2::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr
@@ -222,6 +223,8 @@ protected:
 Tester::Tester()
 {
   cm_ = std::make_shared<CollisionMonitorWrapper>();
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  executor_->add_node(cm_->get_node_base_interface());
   cm_->declare_parameter("enable_stamped_cmd_vel", rclcpp::ParameterValue(false));
 
   footprint_pub_ = cm_->create_publisher<geometry_msgs::msg::PolygonStamped>(
@@ -281,6 +284,7 @@ Tester::~Tester()
   collision_points_marker_sub_.reset();
 
   cm_.reset();
+  executor_.reset();
 }
 
 void Tester::setCommonParameters()
@@ -724,7 +728,7 @@ bool Tester::waitData(
     if (cm_->correctDataReceived(expected_dist, stamp)) {
       return true;
     }
-    rclcpp::spin_some(cm_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -737,7 +741,7 @@ bool Tester::waitCmdVel(const std::chrono::nanoseconds & timeout)
     if (cmd_vel_out_) {
       return true;
     }
-    rclcpp::spin_some(cm_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -753,7 +757,7 @@ bool Tester::waitFuture(
     if (status == std::future_status::ready) {
       return true;
     }
-    rclcpp::spin_some(cm_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -766,7 +770,7 @@ bool Tester::waitActionState(const std::chrono::nanoseconds & timeout)
     if (action_state_) {
       return true;
     }
-    rclcpp::spin_some(cm_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -779,7 +783,7 @@ bool Tester::waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout)
     if (collision_points_marker_msg_) {
       return true;
     }
-    rclcpp::spin_some(cm_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;

--- a/nav2_collision_monitor/test/sources_test.cpp
+++ b/nav2_collision_monitor/test/sources_test.cpp
@@ -375,6 +375,7 @@ protected:
   void checkPolygon(const std::vector<nav2_collision_monitor::Point> & data);
 
   std::shared_ptr<TestNode> test_node_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   std::shared_ptr<ScanWrapper> scan_;
   std::shared_ptr<PointCloudWrapper> pointcloud_;
   std::shared_ptr<RangeWrapper> range_;
@@ -384,6 +385,8 @@ protected:
 Tester::Tester()
 {
   test_node_ = std::make_shared<TestNode>();
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  executor_->add_node(test_node_->get_node_base_interface());
 
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(test_node_->get_clock());
   tf_buffer_->setUsingDedicatedThread(true);  // One-thread broadcasting-listening model
@@ -506,7 +509,7 @@ bool Tester::waitScan(const std::chrono::nanoseconds & timeout)
     if (scan_->dataReceived()) {
       return true;
     }
-    rclcpp::spin_some(test_node_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -519,7 +522,7 @@ bool Tester::waitPointCloud(const std::chrono::nanoseconds & timeout)
     if (pointcloud_->dataReceived()) {
       return true;
     }
-    rclcpp::spin_some(test_node_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -532,7 +535,7 @@ bool Tester::waitRange(const std::chrono::nanoseconds & timeout)
     if (range_->dataReceived()) {
       return true;
     }
-    rclcpp::spin_some(test_node_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;
@@ -545,7 +548,7 @@ bool Tester::waitPolygon(const std::chrono::nanoseconds & timeout)
     if (polygon_->dataReceived()) {
       return true;
     }
-    rclcpp::spin_some(test_node_->get_node_base_interface());
+    executor_->spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;

--- a/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
+++ b/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
@@ -32,6 +32,10 @@ TEST(DynParamTestNode, testDynParamsSet)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("dyn_param_tester");
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
+  rclcpp::executors::SingleThreadedExecutor node_executor;
+  node_executor.add_node(node->get_node_base_interface());
+  rclcpp::executors::SingleThreadedExecutor costmap_executor;
+  costmap_executor.add_node(costmap->get_node_base_interface());
   costmap->on_configure(rclcpp_lifecycle::State());
 
   // Set tf between default global_frame and robot_base_frame in order not to block in on_activate
@@ -76,8 +80,8 @@ TEST(DynParamTestNode, testDynParamsSet)
     rclcpp::Parameter("robot_base_frame", "wrong_test_frame"),
   });
 
-  rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(50));
-  rclcpp::spin_all(costmap->get_node_base_interface(), std::chrono::milliseconds(50));
+  node_executor.spin_all(std::chrono::milliseconds(50));
+  costmap_executor.spin_all(std::chrono::milliseconds(50));
 
   EXPECT_EQ(costmap->get_parameter("robot_radius").as_double(), 1.234);
   EXPECT_EQ(costmap->get_parameter("footprint_padding").as_double(), 2.345);

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -102,8 +102,10 @@ std::vector<Point> TestNode::setRadii(
 
 void TestNode::waitForMap(std::shared_ptr<nav2_costmap_2d::StaticLayer> & slayer)
 {
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_->get_node_base_interface());
   while (!slayer->isCurrent()) {
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor.spin_some();
   }
 }
 

--- a/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
+++ b/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
@@ -93,8 +93,10 @@ public:
 
   void waitForMap(std::shared_ptr<nav2_costmap_2d::StaticLayer> & slayer)
   {
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(node_->get_node_base_interface());
     while (!slayer->isCurrent()) {
-      rclcpp::spin_some(node_->get_node_base_interface());
+      executor.spin_some();
     }
   }
 

--- a/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
@@ -205,6 +205,8 @@ TEST_F(TestCostmapSubscriberShould, handleFullCostmapMsgs)
   auto costmapPublisher = std::make_shared<nav2_costmap_2d::Costmap2DPublisher>(
     node, costmapToSend.get(), "", topicName, always_send_full_costmap);
   costmapPublisher->on_activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   for (const auto & mapChange : mapChanges) {
     for (const auto & observation : mapChange.observations) {
@@ -220,7 +222,7 @@ TEST_F(TestCostmapSubscriberShould, handleFullCostmapMsgs)
     expectedGrids.emplace_back(grid);
     costmapPublisher->updateBounds(mapChange.x0, mapChange.xn, mapChange.y0, mapChange.yn);
     costmapPublisher->publishCostmap();
-    rclcpp::spin_some(node->get_node_base_interface());
+    executor.spin_some();
     receivedCostmaps.emplace_back(getCurrentCharMapFromSubscriber());
   }
 
@@ -252,6 +254,9 @@ TEST_F(TestCostmapSubscriberShould, handleCostmapUpdateMsgs)
   std::uint32_t yn = costmapToSend->getSizeInCellsY();
   bool first_iteration = true;
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
   for (const auto & mapChange : mapChanges) {
     for (const auto & observation : mapChange.observations) {
       costmapToSend->setCost(observation.x, observation.y, observation.cost);
@@ -272,7 +277,7 @@ TEST_F(TestCostmapSubscriberShould, handleCostmapUpdateMsgs)
     expectedGrids.emplace_back(grid);
     costmapPublisher->updateBounds(mapChange.x0, mapChange.xn, mapChange.y0, mapChange.yn);
     costmapPublisher->publishCostmap();
-    rclcpp::spin_some(node->get_node_base_interface());
+    executor.spin_some();
     receivedCostmaps.emplace_back(getUpdatedCharMapFromSubscriber(x0, xn, y0, yn));
     first_iteration = false;
   }

--- a/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
@@ -133,9 +133,10 @@ public:
     // Add Static Layer
     std::shared_ptr<nav2_costmap_2d::StaticLayer> slayer = nullptr;
     addStaticLayer(*layers_, *tf_buffer_, shared_from_this(), slayer, callback_group_);
-
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(this->get_node_base_interface());
     while (!slayer->isCurrent()) {
-      rclcpp::spin_some(this->get_node_base_interface());
+      executor.spin_some();
     }
     // Add Inflation Layer
     std::shared_ptr<nav2_costmap_2d::InflationLayer> ilayer = nullptr;

--- a/nav2_costmap_2d/test/unit/keepout_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/keepout_filter_test.cpp
@@ -200,8 +200,10 @@ void TestNode::rePublishMask()
 void TestNode::waitSome(const std::chrono::nanoseconds & duration)
 {
   rclcpp::Time start_time = node_->now();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_->get_node_base_interface());
   while (rclcpp::ok() && node_->now() - start_time <= rclcpp::Duration(duration)) {
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
 }
@@ -229,8 +231,10 @@ void TestNode::createKeepoutFilter(const std::string & global_frame)
   keepout_filter_->initializeFilter(INFO_TOPIC);
 
   // Wait until mask will be received by KeepoutFilter
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_->get_node_base_interface());
   while (!keepout_filter_->isActive()) {
-    rclcpp::spin_some(node_->get_node_base_interface());
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
 }

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -244,6 +244,7 @@ private:
   const double resolution_ = 1.0;
 
   nav2::LifecycleNode::SharedPtr node_;
+  rclcpp::executors::SingleThreadedExecutor node_executor_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
@@ -255,6 +256,8 @@ private:
   std::shared_ptr<InfoPublisher> info_publisher_;
   std::shared_ptr<MaskPublisher> mask_publisher_;
   std::shared_ptr<SpeedLimitSubscriber> speed_limit_subscriber_;
+  rclcpp::executors::SingleThreadedExecutor speed_limit_subscriber_executor_;
+
 };
 
 void TestNode::createMaps(const std::string & mask_frame)
@@ -308,7 +311,7 @@ void TestNode::rePublishMask()
 nav2_msgs::msg::SpeedLimit::SharedPtr TestNode::getSpeedLimit()
 {
   std::this_thread::sleep_for(100ms);
-  rclcpp::spin_some(speed_limit_subscriber_);
+  speed_limit_subscriber_executor_.spin_some();
   return speed_limit_subscriber_->getSpeedLimit();
 }
 
@@ -323,7 +326,7 @@ nav2_msgs::msg::SpeedLimit::SharedPtr TestNode::waitSpeedLimit()
       speed_limit_subscriber_->resetSpeedLimitIndicator();
       return speed_limit_subscriber_->getSpeedLimit();
     }
-    rclcpp::spin_some(speed_limit_subscriber_);
+    speed_limit_subscriber_executor_.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return nullptr;
@@ -333,8 +336,8 @@ void TestNode::waitSome(const std::chrono::nanoseconds & duration)
 {
   rclcpp::Time start_time = node_->now();
   while (rclcpp::ok() && node_->now() - start_time <= rclcpp::Duration(duration)) {
-    rclcpp::spin_some(node_->get_node_base_interface());
-    rclcpp::spin_some(speed_limit_subscriber_);
+    node_executor_.spin_some();
+    speed_limit_subscriber_executor_.spin_some();
     std::this_thread::sleep_for(10ms);
   }
 }
@@ -366,6 +369,8 @@ bool TestNode::createSpeedFilter(const std::string & global_frame)
   speed_filter_->initializeFilter(INFO_TOPIC);
 
   speed_limit_subscriber_ = std::make_shared<SpeedLimitSubscriber>(SPEED_LIMIT_TOPIC);
+  speed_limit_subscriber_executor_.add_node(speed_limit_subscriber_);
+  node_executor_.add_node(node_->get_node_base_interface());
 
   // Wait until mask will be received by SpeedFilter
   const std::chrono::nanoseconds timeout = 500ms;
@@ -374,7 +379,7 @@ bool TestNode::createSpeedFilter(const std::string & global_frame)
     if (node_->now() - start_time > rclcpp::Duration(timeout)) {
       return false;
     }
-    rclcpp::spin_some(node_->get_node_base_interface());
+    node_executor_.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return true;

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -257,7 +257,6 @@ private:
   std::shared_ptr<MaskPublisher> mask_publisher_;
   std::shared_ptr<SpeedLimitSubscriber> speed_limit_subscriber_;
   rclcpp::executors::SingleThreadedExecutor speed_limit_subscriber_executor_;
-
 };
 
 void TestNode::createMaps(const std::string & mask_frame)

--- a/nav2_docking/opennav_docking/test/test_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_controller.cpp
@@ -291,6 +291,8 @@ TEST(ControllerTests, CollisionCheckerDockForward) {
     node, tf, "test_base_frame", "test_base_frame");
   collision_tester->configure();
   collision_tester->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   // Set the pose of the dock at 1.75m in front of the robot
   auto dock_pose = collision_tester->setPose(1.75, 0.0, 0.0);
@@ -302,7 +304,7 @@ TEST(ControllerTests, CollisionCheckerDockForward) {
   // Publish an empty costmap
   // It should not hit anything in an empty costmap
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(dock_pose, true, false));
 
   // Set a dock in the costmap of 0.2x1.5m at 2m in front of the robot
@@ -310,7 +312,7 @@ TEST(ControllerTests, CollisionCheckerDockForward) {
   // But it does not hit because the collision tolerance is 0.3m
   collision_tester->setRectangle(0.2, 1.5, 2.0, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(dock_pose, true, false));
 
   // Set an object between the robot and the dock
@@ -318,7 +320,7 @@ TEST(ControllerTests, CollisionCheckerDockForward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.2, 1.0, -0.1, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(dock_pose, true, false));
 
   // Set the collision tolerance to 0 to ensure all obstacles in the path are detected
@@ -329,7 +331,7 @@ TEST(ControllerTests, CollisionCheckerDockForward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 1.5, 2.0, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(dock_pose, true, false));
 
   collision_tester->deactivate();
@@ -356,6 +358,8 @@ TEST(ControllerTests, CollisionCheckerDockBackward) {
     node, tf, "test_base_frame", "test_base_frame");
   collision_tester->configure();
   collision_tester->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   // Set the pose of the dock at 1.75m behind the robot
   auto dock_pose = collision_tester->setPose(-1.75, 0.0, 0.0);
@@ -367,7 +371,7 @@ TEST(ControllerTests, CollisionCheckerDockBackward) {
   // Publish an empty costmap
   // It should not hit anything in an empty costmap
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(dock_pose, true, true));
 
   // Set a dock in the costmap of 0.2x1.5m at 2m behind the robot
@@ -375,7 +379,7 @@ TEST(ControllerTests, CollisionCheckerDockBackward) {
   // But it does not hit because the collision tolerance is 0.3m
   collision_tester->setRectangle(0.2, 1.5, -2.1, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(dock_pose, true, true));
 
   // Set an object between the robot and the dock
@@ -383,7 +387,7 @@ TEST(ControllerTests, CollisionCheckerDockBackward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.2, -1.0, 0.0, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(dock_pose, true, true));
 
   // Set the collision tolerance to 0 to ensure all obstacles in the path are detected
@@ -394,7 +398,7 @@ TEST(ControllerTests, CollisionCheckerDockBackward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 1.5, -2.1, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(dock_pose, true, true));
 
   collision_tester->deactivate();
@@ -421,6 +425,8 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
     node, tf, "test_base_frame", "test_base_frame");
   collision_tester->configure();
   collision_tester->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   // Set the staging pose at 1.75m behind the robot
   auto staging_pose = collision_tester->setPose(-1.75, 0.0, 0.0);
@@ -432,7 +438,7 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
   // Publish an empty costmap
   // It should not hit anything in an empty costmap
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(staging_pose, false, true));
 
   // Set a dock in the costmap of 0.2x1.5m in front of the robot. The robot is docked
@@ -440,7 +446,7 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
   // But it does not hit because the collision tolerance is 0.3m
   collision_tester->setRectangle(0.2, 1.5, 0.25, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(staging_pose, false, true));
 
   // Set an object beyond the staging pose
@@ -448,7 +454,7 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.2, -1.75 - 0.5, -0.1, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, true));
 
   // Set an object between the robot and the staging pose
@@ -456,7 +462,7 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.2, -1.0, -0.1, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, true));
 
   // Set the collision tolerance to 0 to ensure all obstacles in the path are detected
@@ -467,7 +473,7 @@ TEST(ControllerTests, CollisionCheckerUndockBackward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 1.5, 0.25, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, true));
 
   collision_tester->deactivate();
@@ -494,6 +500,8 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
     node, tf, "test_base_frame", "test_base_frame");
   collision_tester->configure();
   collision_tester->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   // Set the staging pose at 1.75m in the front of the robot
   auto staging_pose = collision_tester->setPose(1.75, 0.0, 0.0);
@@ -505,14 +513,14 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
   // Publish an empty costmap
   // It should not hit anything in an empty costmap
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(staging_pose, false, false));
 
   // Set a dock in the costmap of 0.2x1.5m at 0.5m behind the robot. The robot is docked
   // It should not hit anything because the robot is docked and the trajectory is backward
   collision_tester->setRectangle(0.2, 1.5, -0.35, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_TRUE(controller->isTrajectoryCollisionFree(staging_pose, false, false));
 
   // Set an object beyond the staging pose
@@ -520,7 +528,7 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.3, 1.75 + 0.5, 0.0, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, false));
 
   // Set an object between the robot and the staging pose
@@ -528,7 +536,7 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 0.2, 1.0, 0.0, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, false));
 
   // Set the collision tolerance to 0 to ensure all obstacles in the path are detected
@@ -539,7 +547,7 @@ TEST(ControllerTests, CollisionCheckerUndockForward) {
   collision_tester->clearCostmap();
   collision_tester->setRectangle(0.2, 1.5, -0.35, -0.75, nav2_costmap_2d::LETHAL_OBSTACLE);
   collision_tester->publishCostmap();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_FALSE(controller->isTrajectoryCollisionFree(staging_pose, false, false));
 
   collision_tester->deactivate();

--- a/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
@@ -71,6 +71,9 @@ TEST(SimpleChargingDockTests, BatteryState)
 
   dock->configure(node, "my_dock", nullptr);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
   geometry_msgs::msg::PoseStamped pose;
   EXPECT_TRUE(dock->getRefinedPose(pose, ""));
 
@@ -80,7 +83,7 @@ TEST(SimpleChargingDockTests, BatteryState)
   pub->publish(msg);
   rclcpp::Rate r(2);
   r.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_FALSE(dock->isCharging());
   EXPECT_TRUE(dock->hasStoppedCharging());
@@ -91,7 +94,7 @@ TEST(SimpleChargingDockTests, BatteryState)
   pub->publish(msg2);
   rclcpp::Rate r1(2);
   r1.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_TRUE(dock->isCharging());
   EXPECT_FALSE(dock->hasStoppedCharging());
@@ -124,6 +127,9 @@ TEST(SimpleChargingDockTests, StallDetection)
     rclcpp::Parameter("my_dock.stall_joint_names", rclcpp::ParameterValue(names)));
   dock->configure(node, "my_dock", nullptr);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
   EXPECT_EQ(dock->getStallJointNames(), names);
 
   // Stopped, but below effort threshold
@@ -134,7 +140,7 @@ TEST(SimpleChargingDockTests, StallDetection)
   pub->publish(msg);
   rclcpp::Rate r(2);
   r.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_FALSE(dock->isDocked());
 
@@ -146,7 +152,7 @@ TEST(SimpleChargingDockTests, StallDetection)
   pub->publish(msg2);
   rclcpp::Rate r1(2);
   r1.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_FALSE(dock->isDocked());
 
@@ -158,7 +164,7 @@ TEST(SimpleChargingDockTests, StallDetection)
   pub->publish(msg3);
   rclcpp::Rate r2(2);
   r2.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_TRUE(dock->isDocked());
 
@@ -229,6 +235,8 @@ TEST(SimpleChargingDockTests, RefinedPoseTest)
 
   dock->configure(node, "my_dock", nullptr);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped pose;
 
@@ -242,7 +250,7 @@ TEST(SimpleChargingDockTests, RefinedPoseTest)
   detected_pose.pose.position.x = 0.1;
   detected_pose.pose.position.y = -0.5;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   pose.header.frame_id = "my_frame";
   EXPECT_TRUE(dock->getRefinedPose(pose, ""));
@@ -269,6 +277,8 @@ TEST(SimpleChargingDockTests, RefinedPoseNotTransform)
 
   dock->configure(node, "my_dock", tf_buffer);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped detected_pose;
   detected_pose.header.stamp = node->now();
@@ -276,7 +286,7 @@ TEST(SimpleChargingDockTests, RefinedPoseNotTransform)
   detected_pose.pose.position.x = 1.0;
   detected_pose.pose.position.y = 1.0;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   // Create a pose with a different frame_id
   geometry_msgs::msg::PoseStamped pose;
@@ -306,6 +316,8 @@ TEST(SimpleChargingDockTests, IsDockedTransformException)
 
   dock->configure(node, "my_dock", tf_buffer);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped detected_pose;
   detected_pose.header.stamp = node->now();
@@ -313,7 +325,7 @@ TEST(SimpleChargingDockTests, IsDockedTransformException)
   detected_pose.pose.position.x = 1.0;
   detected_pose.pose.position.y = 1.0;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   // Create a pose with a different frame_id
   geometry_msgs::msg::PoseStamped pose;

--- a/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_non_charging_dock.cpp
@@ -84,6 +84,9 @@ TEST(SimpleNonChargingDockTests, StallDetection)
   EXPECT_EQ(dock->getStallJointNames(), names);
 
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
   geometry_msgs::msg::PoseStamped pose;
   EXPECT_TRUE(dock->getRefinedPose(pose, ""));
 
@@ -95,7 +98,7 @@ TEST(SimpleNonChargingDockTests, StallDetection)
   pub->publish(msg);
   rclcpp::Rate r(2);
   r.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_FALSE(dock->isDocked());
 
@@ -107,7 +110,7 @@ TEST(SimpleNonChargingDockTests, StallDetection)
   pub->publish(msg2);
   rclcpp::Rate r1(2);
   r1.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_FALSE(dock->isDocked());
 
@@ -119,7 +122,7 @@ TEST(SimpleNonChargingDockTests, StallDetection)
   pub->publish(msg3);
   rclcpp::Rate r2(2);
   r2.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_TRUE(dock->isDocked());
 
@@ -190,6 +193,8 @@ TEST(SimpleNonChargingDockTests, RefinedPoseTest)
 
   dock->configure(node, "my_dock", nullptr);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped pose;
 
@@ -203,7 +208,7 @@ TEST(SimpleNonChargingDockTests, RefinedPoseTest)
   detected_pose.pose.position.x = 0.1;
   detected_pose.pose.position.y = -0.5;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   pose.header.frame_id = "my_frame";
   EXPECT_TRUE(dock->getRefinedPose(pose, ""));
@@ -230,6 +235,8 @@ TEST(SimpleNonChargingDockTests, RefinedPoseNotTransform)
 
   dock->configure(node, "my_dock", tf_buffer);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped detected_pose;
   detected_pose.header.stamp = node->now();
@@ -237,7 +244,7 @@ TEST(SimpleNonChargingDockTests, RefinedPoseNotTransform)
   detected_pose.pose.position.x = 1.0;
   detected_pose.pose.position.y = 1.0;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   // Create a pose with a different frame_id
   geometry_msgs::msg::PoseStamped pose;
@@ -267,6 +274,8 @@ TEST(SimpleNonChargingDockTests, IsDockedTransformException)
 
   dock->configure(node, "my_dock", tf_buffer);
   dock->activate();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
 
   geometry_msgs::msg::PoseStamped detected_pose;
   detected_pose.header.stamp = node->now();
@@ -274,7 +283,7 @@ TEST(SimpleNonChargingDockTests, IsDockedTransformException)
   detected_pose.pose.position.x = 1.0;
   detected_pose.pose.position.y = 1.0;
   pub->publish(detected_pose);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   // Create a pose with a different frame_id
   geometry_msgs::msg::PoseStamped pose;

--- a/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
+++ b/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
@@ -134,8 +134,10 @@ private:
 TEST_F(InfoServerTester, testCostmapFilterInfoPublish)
 {
   rclcpp::Time start_time = info_server_->now();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(info_server_->get_node_base_interface());
   while (!isReceived()) {
-    rclcpp::spin_some(info_server_->get_node_base_interface());
+    executor.spin_some();
     std::this_thread::sleep_for(100ms);
     // Waiting no more than 5 seconds
     ASSERT_TRUE((info_server_->now() - start_time) <= rclcpp::Duration(5000ms));
@@ -155,8 +157,10 @@ TEST_F(InfoServerTester, testCostmapFilterInfoDeactivateActivate)
   info_server_->activate();
 
   rclcpp::Time start_time = info_server_->now();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(info_server_->get_node_base_interface());
   while (!isReceived()) {
-    rclcpp::spin_some(info_server_->get_node_base_interface());
+    executor.spin_some();
     std::this_thread::sleep_for(100ms);
     // Waiting no more than 5 seconds
     ASSERT_TRUE((info_server_->now() - start_time) <= rclcpp::Duration(5000ms));

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -150,6 +150,7 @@ protected:
 
   // Vector Object server node
   std::shared_ptr<VOServerWrapper> vo_server_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
 };  // Tester
 
 Tester::Tester()
@@ -174,6 +175,7 @@ Tester::Tester()
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(vo_server_->get_clock());
   tf_buffer_->setUsingDedicatedThread(true);  // One-thread broadcasting-listening model
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  executor_.add_node(vo_server_->get_node_base_interface());
 }
 
 Tester::~Tester()
@@ -406,7 +408,7 @@ typename T::Response::SharedPtr Tester::sendRequest(
     if (status == std::future_status::ready) {
       return result_future.get();
     }
-    rclcpp::spin_some(vo_server_->get_node_base_interface());
+    executor_.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return nullptr;
@@ -424,7 +426,7 @@ bool Tester::waitMap(const std::chrono::nanoseconds & timeout)
     if (map_) {
       return true;
     }
-    rclcpp::spin_some(vo_server_->get_node_base_interface());
+    executor_.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   return false;

--- a/nav2_mppi_controller/test/utils/utils.hpp
+++ b/nav2_mppi_controller/test/utils/utils.hpp
@@ -35,9 +35,11 @@ using namespace std::chrono_literals;  // NOLINT
 template<typename TNode>
 void waitSome(const std::chrono::nanoseconds & duration, TNode & node)
 {
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
   rclcpp::Time start_time = node->now();
   while (rclcpp::ok() && node->now() - start_time <= rclcpp::Duration(duration)) {
-    rclcpp::spin_some(node->get_node_base_interface());
+    executor.spin_some();
     std::this_thread::sleep_for(3ms);
   }
 }

--- a/nav2_ros_common/test/test_actions.cpp
+++ b/nav2_ros_common/test/test_actions.cpp
@@ -173,8 +173,10 @@ public:
   {
     auto node = std::make_shared<FibonacciServerNode>();
     node->on_init();
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(node->get_node_base_interface());
     while (rclcpp::ok() && !stop_.load()) {
-      rclcpp::spin_some(node->get_node_base_interface());
+      executor.spin_some();
       std::this_thread::sleep_for(10ms);
     }
     node->on_term();

--- a/nav2_ros_common/test/test_service_client.cpp
+++ b/nav2_ros_common/test/test_service_client.cpp
@@ -85,7 +85,9 @@ TEST(ServiceClient, can_ServiceClient_invoke_in_callback)
     });
 
   pub->publish(std_msgs::msg::Empty());
-  rclcpp::spin_some(sub_node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(sub_node->get_node_base_interface());
+  executor.spin_some();
 
   rclcpp::shutdown();
   srv_thread.join();
@@ -98,7 +100,9 @@ TEST(ServiceClient, can_ServiceClient_timeout)
   rclcpp::init(0, nullptr);
   auto node = rclcpp::Node::make_shared("test_node");
   TestServiceClient t("bar", node, true);
-  rclcpp::spin_some(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin_some();
   bool ready = t.wait_for_service(std::chrono::milliseconds(10));
   rclcpp::shutdown();
   ASSERT_EQ(ready, false);
@@ -128,7 +132,9 @@ TEST(ServiceClient, can_ServiceClient_async_call) {
   // Test async_call
   client.async_call(req, callback);
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  rclcpp::spin_some(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin_some();
 
   rclcpp::shutdown();
   srv_thread.join();

--- a/nav2_route/test/test_graph_loader.cpp
+++ b/nav2_route/test/test_graph_loader.cpp
@@ -74,6 +74,8 @@ TEST(GraphLoader, test_api)
 TEST(GraphLoader, test_transformation_api)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("graph_loader_test");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
   tf->setUsingDedicatedThread(true);
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
@@ -107,7 +109,7 @@ TEST(GraphLoader, test_transformation_api)
   tf_broadcaster->sendTransform(transform);
   rclcpp::Rate(1).sleep();
   tf_broadcaster->sendTransform(transform);
-  rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(50));
+  executor.spin_all(std::chrono::milliseconds(50));
 
   graph[0].coords.frame_id = "map_test";
   EXPECT_EQ(graph[0].coords.frame_id, "map_test");

--- a/nav2_route/test/test_graph_saver.cpp
+++ b/nav2_route/test/test_graph_saver.cpp
@@ -110,6 +110,8 @@ TEST(GraphSaver, test_api)
 TEST(GraphSaver, test_transformation_api)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("graph_saver_test");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
   tf->setUsingDedicatedThread(true);
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
@@ -143,7 +145,7 @@ TEST(GraphSaver, test_transformation_api)
   tf_broadcaster->sendTransform(transform);
   rclcpp::Rate(1).sleep();
   tf_broadcaster->sendTransform(transform);
-  rclcpp::spin_all(node->get_node_base_interface(), std::chrono::milliseconds(50));
+  executor.spin_all(std::chrono::milliseconds(50));
 
   GraphSaver graph_saver(node, tf, frame);
   std::string file_path = "test.geojson";

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/docking_panel.hpp
@@ -88,6 +88,7 @@ private:
 
   // The (non-spinning) client node used to invoke the action client
   rclcpp::Node::SharedPtr client_node_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
 
   // The Node pointer that we need to keep alive for the duration of this plugin.
   std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_ptr_;

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -112,7 +112,7 @@ private:
 
   // The (non-spinning) client node used to invoke the action client
   rclcpp::Node::SharedPtr client_node_;
-
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   // Timeout value when waiting for action servers to respond
   std::chrono::milliseconds server_timeout_;
 

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
@@ -33,10 +33,11 @@ namespace nav2_rviz_plugins
    * @param server_name The name of the server to load plugins for
    * @param plugin_type The type of plugin to load
    * @param combo_box The combo box to add the loaded plugins to
+   * @param executor The executor to pass to the SyncParameterClient
    */
 void pluginLoader(
   rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
-  const std::string & plugin_type, QComboBox * combo_box);
+  const std::string & plugin_type, QComboBox * combo_box, rclcpp::Executor::SharedPtr executor = nullptr);
 
 // Create label string from goal status msg
 QString getGoalStatusLabel(

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/utils.hpp
@@ -33,11 +33,12 @@ namespace nav2_rviz_plugins
    * @param server_name The name of the server to load plugins for
    * @param plugin_type The type of plugin to load
    * @param combo_box The combo box to add the loaded plugins to
-   * @param executor The executor to pass to the SyncParameterClient
+   * @param executor The executor to pass to the AsyncParameterClient
    */
 void pluginLoader(
   rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
-  const std::string & plugin_type, QComboBox * combo_box, rclcpp::Executor::SharedPtr executor = nullptr);
+  const std::string & plugin_type, QComboBox * combo_box,
+  rclcpp::Executor::SharedPtr executor = nullptr);
 
 // Create label string from goal status msg
 QString getGoalStatusLabel(

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -52,10 +52,16 @@ void pluginLoader(
   auto parameters = parameter_client->get_parameters({plugin_type});
   if (executor) {
     if (executor->spin_until_future_complete(parameters) != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_ERROR(node->get_logger(),
+      "Failed to get parameter '%s' from server '%s'",
+      plugin_type.c_str(), server_name.c_str());
       return;
     }
   } else {
     if (rclcpp::spin_until_future_complete(node, parameters) != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_ERROR(node->get_logger(),
+      "Failed to get parameter '%s' from server '%s'",
+      plugin_type.c_str(), server_name.c_str());
       return;
     }
   }

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -50,7 +50,7 @@ void pluginLoader(
     return;
   }
   auto parameters = parameter_client->get_parameters({plugin_type});
-  if(executor) {
+  if (executor) {
     if (executor->spin_until_future_complete(parameters) != rclcpp::FutureReturnCode::SUCCESS) {
       return;
     }

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -22,14 +22,14 @@ namespace nav2_rviz_plugins
 
 void pluginLoader(
   rclcpp::Node::SharedPtr node, bool & server_failed, const std::string & server_name,
-  const std::string & plugin_type, QComboBox * combo_box)
+  const std::string & plugin_type, QComboBox * combo_box, rclcpp::Executor::SharedPtr executor)
 {
   // Do not load the plugins if the combo box is already populated
   if (combo_box->count() > 0) {
     return;
   }
 
-  auto parameter_client = std::make_shared<rclcpp::SyncParametersClient>(node, server_name);
+  auto parameter_client = std::make_shared<rclcpp::AsyncParametersClient>(node, server_name);
 
   // Wait for the service to be available before calling it
   bool server_unavailable = false;
@@ -50,7 +50,18 @@ void pluginLoader(
     return;
   }
   auto parameters = parameter_client->get_parameters({plugin_type});
-  auto str_arr = parameters[0].as_string_array();
+  if(executor){
+    if (executor->spin_until_future_complete(parameters) != rclcpp::FutureReturnCode::SUCCESS){
+      return;
+    }
+  }
+  else{
+    if (rclcpp::spin_until_future_complete(node, parameters) != rclcpp::FutureReturnCode::SUCCESS){
+      return;
+    }
+  }
+  
+  auto str_arr = parameters.get()[0].as_string_array();
   combo_box->addItem("Default");
   for (auto str : str_arr) {
     combo_box->addItem(QString::fromStdString(str));

--- a/nav2_rviz_plugins/src/utils.cpp
+++ b/nav2_rviz_plugins/src/utils.cpp
@@ -50,17 +50,16 @@ void pluginLoader(
     return;
   }
   auto parameters = parameter_client->get_parameters({plugin_type});
-  if(executor){
-    if (executor->spin_until_future_complete(parameters) != rclcpp::FutureReturnCode::SUCCESS){
+  if(executor) {
+    if (executor->spin_until_future_complete(parameters) != rclcpp::FutureReturnCode::SUCCESS) {
+      return;
+    }
+  } else {
+    if (rclcpp::spin_until_future_complete(node, parameters) != rclcpp::FutureReturnCode::SUCCESS) {
       return;
     }
   }
-  else{
-    if (rclcpp::spin_until_future_complete(node, parameters) != rclcpp::FutureReturnCode::SUCCESS){
-      return;
-    }
-  }
-  
+
   auto str_arr = parameters.get()[0].as_string_array();
   combo_box->addItem("Default");
   for (auto str : str_arr) {

--- a/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.cpp
+++ b/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.cpp
@@ -83,6 +83,7 @@ AssistedTeleopBehaviorTester::AssistedTeleopBehaviorTester()
   );
 
   stamp_ = node_->now();
+  executor_.add_node(node_);
 }
 
 AssistedTeleopBehaviorTester::~AssistedTeleopBehaviorTester()
@@ -103,7 +104,7 @@ void AssistedTeleopBehaviorTester::activate()
     RCLCPP_WARN(node_->get_logger(), "Initial pose not received");
     sendInitialPose();
     std::this_thread::sleep_for(100ms);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Wait for lifecycle_manager_navigation to activate behavior_server
@@ -146,7 +147,7 @@ bool AssistedTeleopBehaviorTester::defaultAssistedTeleopTest(
 
   auto goal_handle_future = client_ptr_->async_send_goal(nav2_msgs::action::AssistedTeleop::Goal());
 
-  if (rclcpp::spin_until_future_complete(node_, goal_handle_future) !=
+  if (executor_.spin_until_future_complete(goal_handle_future) !=
     rclcpp::FutureReturnCode::SUCCESS)
   {
     RCLCPP_ERROR(node_->get_logger(), "send goal call failed :(");
@@ -182,7 +183,7 @@ bool AssistedTeleopBehaviorTester::defaultAssistedTeleopTest(
       return false;
     }
 
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     r.sleep();
   }
 
@@ -190,7 +191,7 @@ bool AssistedTeleopBehaviorTester::defaultAssistedTeleopTest(
   preempt_pub_->publish(preempt_msg);
 
   RCLCPP_INFO(node_->get_logger(), "Waiting for result");
-  if (rclcpp::spin_until_future_complete(node_, result_future) !=
+  if (executor_.spin_until_future_complete(result_future) !=
     rclcpp::FutureReturnCode::SUCCESS)
   {
     RCLCPP_ERROR(node_->get_logger(), "get result call failed :(");

--- a/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.hpp
+++ b/nav2_system_tests/src/behaviors/assisted_teleop/assisted_teleop_behavior_tester.hpp
@@ -79,6 +79,7 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   rclcpp::Node::SharedPtr node_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
 
   // Publishers
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initial_pose_pub_;

--- a/nav2_system_tests/src/behaviors/wait/wait_behavior_tester.cpp
+++ b/nav2_system_tests/src/behaviors/wait/wait_behavior_tester.cpp
@@ -68,12 +68,13 @@ void WaitBehaviorTester::activate()
     throw std::runtime_error("Trying to activate while already active");
     return;
   }
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_);
   while (!initial_pose_received_) {
     RCLCPP_WARN(node_->get_logger(), "Initial pose not received");
     sendInitialPose();
     std::this_thread::sleep_for(100ms);
-    rclcpp::spin_some(node_);
+    executor.spin_some();
   }
 
   // Wait for lifecycle_manager_navigation to activate behavior_server

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -32,10 +32,11 @@ public:
     tol_ = 0.25;
 
     node = rclcpp::Node::make_shared("localization_test");
+    executor_.add_node(node);
 
     while (node->count_subscribers("scan") < 1) {
       std::this_thread::sleep_for(100ms);
-      rclcpp::spin_some(node);
+      executor_.spin_some();
     }
 
     initial_pose_pub_ = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -50,6 +51,7 @@ public:
 
 protected:
   std::shared_ptr<rclcpp::Node> node;
+  rclcpp::executors::SingleThreadedExecutor executor_;
   void initTestPose();
 
 private:
@@ -76,7 +78,7 @@ bool TestAmclPose::defaultAmclTest()
     // TODO(mhpanah): Initial pose should only be published once.
     initial_pose_pub_->publish(testPose_);
     std::this_thread::sleep_for(1s);
-    rclcpp::spin_some(node);
+    executor_.spin_some();
   }
   if (std::abs(amcl_pose_x - testPose_.pose.pose.position.x) < tol_ &&
     std::abs(amcl_pose_y - testPose_.pose.pose.position.y) < tol_)

--- a/nav2_util/test/test_base_footprint_publisher.cpp
+++ b/nav2_util/test/test_base_footprint_publisher.cpp
@@ -22,7 +22,9 @@
 TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
 {
   auto node = std::make_shared<nav2_util::BaseFootprintPublisher>();
-  rclcpp::spin_some(node->get_node_base_interface());
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin_some();
 
   auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
   auto buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
@@ -41,7 +43,7 @@ TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
   transform.header.frame_id = "test1_1";
   transform.child_frame_id = "test1";
   tf_broadcaster->sendTransform(transform);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   EXPECT_THROW(
     buffer->lookupTransform(base_link, base_footprint, tf2::TimePointZero),
     tf2::TransformException);
@@ -56,7 +58,7 @@ TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
   tf_broadcaster->sendTransform(transform);
   rclcpp::Rate r(1.0);
   r.sleep();
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
   auto t = buffer->lookupTransform(base_link, base_footprint, tf2::TimePointZero);
   EXPECT_EQ(t.transform.translation.x, 1.0);
   EXPECT_EQ(t.transform.translation.y, 1.0);

--- a/nav2_util/test/test_odometry_utils.cpp
+++ b/nav2_util/test/test_odometry_utils.cpp
@@ -66,7 +66,8 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_pub->on_activate();
 
   nav2_util::OdomSmoother odom_smoother(node, 0.3, "odom");
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
   nav_msgs::msg::Odometry odom_msg;
   geometry_msgs::msg::Twist twist_msg;
   geometry_msgs::msg::Twist twist_raw_msg;
@@ -79,7 +80,7 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_msg.twist.twist.angular.z = 1.0;
 
   odom_pub->publish(odom_msg);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   twist_msg = odom_smoother.getTwist();
   EXPECT_EQ(twist_msg.linear.x, 1.0);
@@ -93,7 +94,7 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_pub->publish(odom_msg);
 
   std::this_thread::sleep_for(100ms);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   twist_msg = odom_smoother.getTwist();
   twist_raw_msg = odom_smoother.getRawTwist();
@@ -111,7 +112,7 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_pub->publish(odom_msg);
 
   std::this_thread::sleep_for(100ms);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   twist_msg = odom_smoother.getTwist();
   twist_raw_msg = odom_smoother.getRawTwist();
@@ -129,7 +130,7 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_pub->publish(odom_msg);
 
   std::this_thread::sleep_for(100ms);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   twist_msg = odom_smoother.getTwist();
   twist_raw_msg = odom_smoother.getRawTwist();
@@ -147,7 +148,7 @@ TEST(OdometryUtils, test_smoothed_velocity)
   odom_pub->publish(odom_msg);
 
   std::this_thread::sleep_for(100ms);
-  rclcpp::spin_some(node->get_node_base_interface());
+  executor.spin_some();
 
   twist_msg = odom_smoother.getTwist();
   twist_raw_msg = odom_smoother.getRawTwist();

--- a/nav2_util/test/test_twist_publisher.cpp
+++ b/nav2_util/test/test_twist_publisher.cpp
@@ -47,9 +47,10 @@ TEST(TwistPublisher, Unstamped)
   auto my_sub = sub_node->create_subscription<geometry_msgs::msg::Twist>(
     "cmd_vel",
     [&](const geometry_msgs::msg::Twist msg) {sub_msg = msg;});
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(sub_node->get_node_base_interface());
   vel_publisher->publish(std::move(pub_msg));
-  rclcpp::spin_some(sub_node->get_node_base_interface());
+  executor.spin_some();
 
   EXPECT_EQ(pub_msg_copy.linear.x, sub_msg.linear.x);
   EXPECT_EQ(vel_publisher->get_subscription_count(), 1);
@@ -86,9 +87,10 @@ TEST(TwistPublisher, Stamped)
   auto my_sub = sub_node->create_subscription<geometry_msgs::msg::TwistStamped>(
     "cmd_vel",
     [&](const geometry_msgs::msg::TwistStamped msg) {sub_msg = msg;});
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(sub_node->get_node_base_interface());
   vel_publisher->publish(std::move(pub_msg));
-  rclcpp::spin_some(sub_node->get_node_base_interface());
+  executor.spin_some();
   ASSERT_EQ(vel_publisher->get_subscription_count(), 1);
   EXPECT_EQ(pub_msg_copy, sub_msg);
   pub_node->deactivate();

--- a/nav2_util/test/test_twist_subscriber.cpp
+++ b/nav2_util/test/test_twist_subscriber.cpp
@@ -47,12 +47,13 @@ TEST(TwistSubscriber, Unstamped)
 
   auto vel_pub =
     pub_node->create_publisher<geometry_msgs::msg::Twist>("cmd_vel");
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(sub_node->get_node_base_interface());
   pub_node->activate();
   vel_pub->on_activate();
 
   vel_pub->publish(pub_msg.twist);
-  rclcpp::spin_some(sub_node->get_node_base_interface());
+  executor.spin_some();
   ASSERT_EQ(vel_pub->get_subscription_count(), 1);
   EXPECT_EQ(pub_msg, sub_msg);
 
@@ -87,9 +88,10 @@ TEST(TwistSubscriber, Stamped)
 
   pub_node->activate();
   vel_pub->on_activate();
-
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(sub_node->get_node_base_interface());
   vel_pub->publish(pub_msg);
-  rclcpp::spin_some(sub_node->get_node_base_interface());
+  executor.spin_some();
   ASSERT_EQ(vel_pub->get_subscription_count(), 1);
   EXPECT_EQ(pub_msg, sub_msg);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

- Per https://github.com/ros2/rclcpp/pull/2848, rclcpp::spin_some and spin_all are going to be deprecated in the next release
- Most changes are related to the unit tests except for `nav2_rviz_plugins`

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
