### PR TITLE
Reverting ad2f9602f03ba688c34df7f903a118b6898ef0ce on Humble

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
@@ -32,15 +32,14 @@ namespace mppi
 
 /**
  * @struct mppi::CriticData
- * @brief Data to pass to critics for scoring, including state, trajectories,
- * pruned path, global goal, costs, and important parameters to share
+ * @brief Data to pass to critics for scoring, including state, trajectories, path, costs, and
+ * important parameters to share
  */
 struct CriticData
 {
   const models::State & state;
   const models::Trajectories & trajectories;
   const models::Path & path;
-  const geometry_msgs::msg::Pose & goal;
 
   xt::xtensor<float, 1> & costs;
   float & model_dt;

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -90,7 +90,7 @@ public:
   geometry_msgs::msg::TwistStamped evalControl(
     const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::Twist & robot_speed, const nav_msgs::msg::Path & plan,
-    const geometry_msgs::msg::Pose & goal, nav2_core::GoalChecker * goal_checker);
+    nav2_core::GoalChecker * goal_checker);
 
   /**
    * @brief Get the trajectories generated in a cycle for visualization
@@ -132,8 +132,7 @@ protected:
   void prepare(
     const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::Twist & robot_speed,
-    const nav_msgs::msg::Path & plan,
-    const geometry_msgs::msg::Pose & goal, nav2_core::GoalChecker * goal_checker);
+    const nav_msgs::msg::Path & plan, nav2_core::GoalChecker * goal_checker);
 
   /**
    * @brief Obtain the main controller's parameters
@@ -251,12 +250,10 @@ protected:
   std::array<mppi::models::Control, 4> control_history_;
   models::Trajectories generated_trajectories_;
   models::Path path_;
-  geometry_msgs::msg::Pose goal_;
   xt::xtensor<float, 1> costs_;
 
-  CriticData critics_data_ = {
-    state_, generated_trajectories_, path_, goal_,
-    costs_, settings_.model_dt, false, nullptr, nullptr,
+  CriticData critics_data_ =
+  {state_, generated_trajectories_, path_, costs_, settings_.model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
@@ -89,13 +89,6 @@ public:
    */
   nav_msgs::msg::Path transformPath(const geometry_msgs::msg::PoseStamped & robot_pose);
 
-  /**
-   * @brief Get the global goal pose transformed to the local frame
-   * @param stamp Time to get the goal pose at
-   * @return Transformed goal pose
-   */
-  geometry_msgs::msg::PoseStamped getTransformedGoal(const builtin_interfaces::msg::Time & stamp);
-
 protected:
   /**
     * @brief Transform a pose to another frame

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -195,14 +195,18 @@ inline models::Path toTensor(const nav_msgs::msg::Path & path)
  * @brief Check if the robot pose is within the Goal Checker's tolerances to goal
  * @param global_checker Pointer to the goal checker
  * @param robot Pose of robot
- * @param goal Goal pose
+ * @param path Path to retreive goal pose from
  * @return bool If robot is within goal checker tolerances to the goal
  */
 inline bool withinPositionGoalTolerance(
   nav2_core::GoalChecker * goal_checker,
   const geometry_msgs::msg::Pose & robot,
-  const geometry_msgs::msg::Pose & goal)
+  const models::Path & path)
 {
+  const auto goal_idx = path.x.shape(0) - 1;
+  const auto goal_x = path.x(goal_idx);
+  const auto goal_y = path.y(goal_idx);
+
   if (goal_checker) {
     geometry_msgs::msg::Pose pose_tolerance;
     geometry_msgs::msg::Twist velocity_tolerance;
@@ -210,8 +214,8 @@ inline bool withinPositionGoalTolerance(
 
     const auto pose_tolerance_sq = pose_tolerance.position.x * pose_tolerance.position.x;
 
-    auto dx = robot.position.x - goal.position.x;
-    auto dy = robot.position.y - goal.position.y;
+    auto dx = robot.position.x - goal_x;
+    auto dy = robot.position.y - goal_y;
 
     auto dist_sq = dx * dx + dy * dy;
 
@@ -227,19 +231,24 @@ inline bool withinPositionGoalTolerance(
  * @brief Check if the robot pose is within tolerance to the goal
  * @param pose_tolerance Pose tolerance to use
  * @param robot Pose of robot
- * @param goal Goal pose
+ * @param path Path to retreive goal pose from
  * @return bool If robot is within tolerance to the goal
  */
 inline bool withinPositionGoalTolerance(
   float pose_tolerance,
   const geometry_msgs::msg::Pose & robot,
-  const geometry_msgs::msg::Pose & goal)
+  const models::Path & path)
 {
-  const double & dist_sq =
-    std::pow(goal.position.x - robot.position.x, 2) +
-    std::pow(goal.position.y - robot.position.y, 2);
+  const auto goal_idx = path.x.shape(0) - 1;
+  const auto goal_x = path.x(goal_idx);
+  const auto goal_y = path.y(goal_idx);
 
-  const float pose_tolerance_sq = pose_tolerance * pose_tolerance;
+  const auto pose_tolerance_sq = pose_tolerance * pose_tolerance;
+
+  auto dx = robot.position.x - goal_x;
+  auto dy = robot.position.y - goal_y;
+
+  auto dist_sq = dx * dx + dy * dy;
 
   if (dist_sq < pose_tolerance_sq) {
     return true;

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -92,15 +92,13 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
   last_time_called_ = clock_->now();
 
   std::lock_guard<std::mutex> param_lock(*parameters_handler_->getLock());
-  geometry_msgs::msg::Pose goal = path_handler_.getTransformedGoal(robot_pose.header.stamp).pose;
-
   nav_msgs::msg::Path transformed_plan = path_handler_.transformPath(robot_pose);
 
   nav2_costmap_2d::Costmap2D * costmap = costmap_ros_->getCostmap();
   std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> costmap_lock(*(costmap->getMutex()));
 
   geometry_msgs::msg::TwistStamped cmd =
-    optimizer_.evalControl(robot_pose, robot_speed, transformed_plan, goal, goal_checker);
+    optimizer_.evalControl(robot_pose, robot_speed, transformed_plan, goal_checker);
 
 #ifdef BENCHMARK_TESTING
   auto end = std::chrono::system_clock::now();

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -132,7 +132,7 @@ void CostCritic::score(CriticData & data)
 
   // If near the goal, don't apply the preferential term since the goal is near obstacles
   bool near_goal = false;
-  if (utils::withinPositionGoalTolerance(near_goal_distance_, data.state.pose.pose, data.goal)) {
+  if (utils::withinPositionGoalTolerance(near_goal_distance_, data.state.pose.pose, data.path)) {
     near_goal = true;
   }
 

--- a/nav2_mppi_controller/src/critics/goal_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/goal_angle_critic.cpp
@@ -36,7 +36,7 @@ void GoalAngleCritic::initialize()
 void GoalAngleCritic::score(CriticData & data)
 {
   if (!enabled_ || !utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
+      threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/critics/goal_critic.cpp
+++ b/nav2_mppi_controller/src/critics/goal_critic.cpp
@@ -36,13 +36,15 @@ void GoalCritic::initialize()
 void GoalCritic::score(CriticData & data)
 {
   if (!enabled_ || !utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
+      threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }
 
-  const auto & goal_x = data.goal.position.x;
-  const auto & goal_y = data.goal.position.y;
+  const auto goal_idx = data.path.x.shape(0) - 1;
+
+  const auto goal_x = data.path.x(goal_idx);
+  const auto goal_y = data.path.y(goal_idx);
 
   const auto traj_x = xt::view(data.trajectories.x, xt::all(), xt::all());
   const auto traj_y = xt::view(data.trajectories.y, xt::all(), xt::all());

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -138,7 +138,7 @@ void ObstaclesCritic::score(CriticData & data)
 
   // If near the goal, don't apply the preferential term since the goal is near obstacles
   bool near_goal = false;
-  if (utils::withinPositionGoalTolerance(near_goal_distance_, data.state.pose.pose, data.goal)) {
+  if (utils::withinPositionGoalTolerance(near_goal_distance_, data.state.pose.pose, data.path)) {
     near_goal = true;
   }
 

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -46,8 +46,8 @@ void PathAlignCritic::initialize()
 void PathAlignCritic::score(CriticData & data)
 {
   // Don't apply close to goal, let the goal critics take over
-  if (!enabled_ || utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
+  if (!enabled_ ||
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/critics/path_align_legacy_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_legacy_critic.cpp
@@ -46,8 +46,8 @@ void PathAlignLegacyCritic::initialize()
 void PathAlignLegacyCritic::score(CriticData & data)
 {
   // Don't apply close to goal, let the goal critics take over
-  if (!enabled_ || utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
+  if (!enabled_ ||
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -62,9 +62,7 @@ void PathAngleCritic::score(CriticData & data)
     return;
   }
 
-  if (utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
-  {
+  if (utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path)) {
     return;
   }
 

--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -35,7 +35,7 @@ void PathFollowCritic::initialize()
 void PathFollowCritic::score(CriticData & data)
 {
   if (!enabled_ || data.path.x.shape(0) < 2 ||
-    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.goal))
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/critics/prefer_forward_critic.cpp
+++ b/nav2_mppi_controller/src/critics/prefer_forward_critic.cpp
@@ -33,8 +33,8 @@ void PreferForwardCritic::initialize()
 void PreferForwardCritic::score(CriticData & data)
 {
   using xt::evaluation_strategy::immediate;
-  if (!enabled_ || utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, data.goal))
+  if (!enabled_ ||
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/critics/twirling_critic.cpp
+++ b/nav2_mppi_controller/src/critics/twirling_critic.cpp
@@ -32,7 +32,7 @@ void TwirlingCritic::score(CriticData & data)
 {
   using xt::evaluation_strategy::immediate;
   if (!enabled_ ||
-    utils::withinPositionGoalTolerance(data.goal_checker, data.state.pose.pose, data.goal))
+    utils::withinPositionGoalTolerance(data.goal_checker, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -134,11 +134,9 @@ void Optimizer::reset()
 geometry_msgs::msg::TwistStamped Optimizer::evalControl(
   const geometry_msgs::msg::PoseStamped & robot_pose,
   const geometry_msgs::msg::Twist & robot_speed,
-  const nav_msgs::msg::Path & plan,
-  const geometry_msgs::msg::Pose & goal,
-  nav2_core::GoalChecker * goal_checker)
+  const nav_msgs::msg::Path & plan, nav2_core::GoalChecker * goal_checker)
 {
-  prepare(robot_pose, robot_speed, plan, goal, goal_checker);
+  prepare(robot_pose, robot_speed, plan, goal_checker);
 
   do {
     optimize();
@@ -185,15 +183,11 @@ bool Optimizer::fallback(bool fail)
 void Optimizer::prepare(
   const geometry_msgs::msg::PoseStamped & robot_pose,
   const geometry_msgs::msg::Twist & robot_speed,
-  const nav_msgs::msg::Path & plan,
-  const geometry_msgs::msg::Pose & goal,
-  nav2_core::GoalChecker * goal_checker)
+  const nav_msgs::msg::Path & plan, nav2_core::GoalChecker * goal_checker)
 {
   state_.pose = robot_pose;
   state_.speed = robot_speed;
   path_ = utils::toTensor(plan);
-  goal_ = goal;
-
   costs_.fill(0);
 
   critics_data_.fail_flag = false;

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -186,22 +186,6 @@ void PathHandler::prunePlan(nav_msgs::msg::Path & plan, const PathIterator end)
   plan.poses.erase(plan.poses.begin(), end);
 }
 
-geometry_msgs::msg::PoseStamped PathHandler::getTransformedGoal(
-  const builtin_interfaces::msg::Time & stamp)
-{
-  auto goal = global_plan_.poses.back();
-  goal.header.frame_id = global_plan_.header.frame_id;
-  goal.header.stamp = stamp;
-  if (goal.header.frame_id.empty()) {
-    throw std::runtime_error("Goal pose has an empty frame_id");
-  }
-  geometry_msgs::msg::PoseStamped transformed_goal;
-  if (!transformPose(costmap_->getGlobalFrameID(), goal, transformed_goal)) {
-    throw std::runtime_error("Unable to transform goal pose into costmap frame");
-  }
-  return transformed_goal;
-}
-
 bool PathHandler::isWithinInversionTolerances(const geometry_msgs::msg::PoseStamped & robot_pose)
 {
   // Keep full path if we are within tolerance of the inversion pose

--- a/nav2_mppi_controller/test/controller_state_transition_test.cpp
+++ b/nav2_mppi_controller/test/controller_state_transition_test.cpp
@@ -60,8 +60,6 @@ TEST(ControllerStateTransitionTest, ControllerNotFail)
   auto pose = getDummyPointStamped(node, start_pose);
   auto velocity = getDummyTwist();
   auto path = getIncrementalDummyPath(node, path_settings);
-  path.header.frame_id = costmap_ros->getGlobalFrameID();
-  pose.header.frame_id = costmap_ros->getGlobalFrameID();
 
   controller->setPlan(path);
 

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -103,11 +103,10 @@ TEST(CriticManagerTests, BasicCriticOperations)
   models::ControlSequence control_sequence;
   models::Trajectories generated_trajectories;
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs;
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};
 
   data.fail_flag = true;

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -57,12 +57,11 @@ TEST(CriticTests, ConstraintsCritic)
   models::ControlSequence control_sequence;
   models::Trajectories generated_trajectories;
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
   // Initialization testing
@@ -206,12 +205,11 @@ TEST(CriticTests, GoalAngleCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
   // Initialization testing
@@ -229,7 +227,6 @@ TEST(CriticTests, GoalAngleCritic)
   path.x(9) = 10.0;
   path.y(9) = 0.0;
   path.yaws(9) = 3.14;
-  goal.position.x = 10.0;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0, 1e-6);
 
@@ -260,12 +257,11 @@ TEST(CriticTests, GoalCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
   // Initialization testing
@@ -282,7 +278,6 @@ TEST(CriticTests, GoalCritic)
   path.reset(10);
   path.x(9) = 10.0;
   path.y(9) = 0.0;
-  goal.position.x = 10.0;
   critic.score(data);
   EXPECT_NEAR(costs(2), 0.0, 1e-6);  // (0 * 5.0 weight
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);  // Should all be 0 * 1000
@@ -291,7 +286,6 @@ TEST(CriticTests, GoalCritic)
   // provide state pose and path close
   path.x(9) = 0.5;
   path.y(9) = 0.0;
-  goal.position.x = 0.5;
   critic.score(data);
   EXPECT_NEAR(costs(2), 2.5, 1e-6);  // (sqrt(10.0 * 10.0) * 5.0 weight
   EXPECT_NEAR(xt::sum(costs, immediate)(), 2500.0, 1e-6);  // should be 2.5 * 1000
@@ -313,12 +307,11 @@ TEST(CriticTests, PathAngleCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
 
@@ -336,13 +329,11 @@ TEST(CriticTests, PathAngleCritic)
   state.pose.pose.position.y = 0.0;
   path.reset(10);
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
   // provide state pose and path close but outside of tol. with less than PI/2 angular diff.
   path.x(9) = 0.95;
-  goal.position.x = 0.95;
   data.furthest_reached_path_point = 2;  // So it grabs the 2 + offset_from_furthest_ = 6th point
   path.x(6) = 1.0;  // angle between path point and pose = 0 < max_angle_to_furthest_
   path.y(6) = 0.0;
@@ -373,12 +364,11 @@ TEST(CriticTests, PreferForwardCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
 
@@ -395,13 +385,11 @@ TEST(CriticTests, PreferForwardCritic)
   state.pose.pose.position.x = 1.0;
   path.reset(10);
   path.x(9) = 10.0;
-  goal.position.x = 10.0;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0f, 1e-6f);
 
   // provide state pose and path close to trigger behavior but with all forward motion
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   state.vx = xt::ones<float>({1000, 30});
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0f, 1e-6f);
@@ -429,12 +417,11 @@ TEST(CriticTests, TwirlingCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
   data.goal_checker = &goal_checker;
@@ -452,13 +439,11 @@ TEST(CriticTests, TwirlingCritic)
   state.pose.pose.position.x = 1.0;
   path.reset(10);
   path.x(9) = 10.0;
-  goal.position.x = 10.0;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
   // provide state pose and path close to trigger behavior but with no angular variation
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   state.wz = xt::zeros<float>({1000, 30});
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
@@ -492,12 +477,11 @@ TEST(CriticTests, PathFollowCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
   data.goal_checker = &goal_checker;
@@ -511,18 +495,16 @@ TEST(CriticTests, PathFollowCritic)
 
   // Scoring testing
 
-  // provide state poses and goal close within positional tolerances
+  // provide state poses and path close within positional tolerances
   state.pose.pose.position.x = 2.0;
   path.reset(6);
-  path.x(5) = 1.8;
-  goal.position.x = 1.8;
+  path.x(5) = 1.7;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
   // provide state pose and path far enough to enable
   // pose differential is (0, 0) and (0.15, 0)
   path.x(5) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 750.0, 1e-2);  // 0.15 * 5 weight * 1000
 }
@@ -543,12 +525,11 @@ TEST(CriticTests, PathAlignCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
   data.goal_checker = &goal_checker;
@@ -566,14 +547,12 @@ TEST(CriticTests, PathAlignCritic)
   state.pose.pose.position.x = 1.0;
   path.reset(10);
   path.x(9) = 0.85;
-  goal.position.x = 0.85;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
   // provide state pose and path far enough to enable
   // but data furthest point reached is 0 and offset default is 20, so returns
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
@@ -581,7 +560,6 @@ TEST(CriticTests, PathAlignCritic)
   // but with empty trajectories and paths, should still be zero
   *data.furthest_reached_path_point = 21;
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
@@ -612,7 +590,6 @@ TEST(CriticTests, PathAlignCritic)
   path.x(19) = 0.9;
   path.x(20) = 0.9;
   path.x(21) = 0.9;
-  goal.position.x = 0.9;
   generated_trajectories.x = 0.66 * xt::ones<float>({1000, 30});
   critic.score(data);
   // 0.66 * 1000 * 10 weight * 6 num pts eval / 6 normalization term
@@ -632,7 +609,6 @@ TEST(CriticTests, PathAlignCritic)
   costs = xt::zeros<float>({1000});
   path.x = 1.5 * xt::ones<float>({22});
   path.y = 1.5 * xt::ones<float>({22});
-  goal.position.x = 1.5;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 }
@@ -653,12 +629,11 @@ TEST(CriticTests, PathAlignLegacyCritic)
   models::Trajectories generated_trajectories;
   generated_trajectories.reset(1000, 30);
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
   data.goal_checker = &goal_checker;
@@ -676,14 +651,12 @@ TEST(CriticTests, PathAlignLegacyCritic)
   state.pose.pose.position.x = 1.0;
   path.reset(10);
   path.x(9) = 0.85;
-  goal.position.x = 0.85;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
   // provide state pose and path far enough to enable
   // but data furthest point reached is 0 and offset default is 20, so returns
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
@@ -691,7 +664,6 @@ TEST(CriticTests, PathAlignLegacyCritic)
   // but with empty trajectories and paths, should still be zero
   *data.furthest_reached_path_point = 21;
   path.x(9) = 0.15;
-  goal.position.x = 0.15;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 
@@ -722,7 +694,6 @@ TEST(CriticTests, PathAlignLegacyCritic)
   path.x(19) = 0.9;
   path.x(20) = 0.9;
   path.x(21) = 0.9;
-  goal.position.x = 0.9;
   generated_trajectories.x = 0.66 * xt::ones<float>({1000, 30});
   critic.score(data);
   // 0.04 * 1000 * 10 weight * 6 num pts eval / 6 normalization term
@@ -742,7 +713,6 @@ TEST(CriticTests, PathAlignLegacyCritic)
   costs = xt::zeros<float>({1000});
   path.x = 1.5 * xt::ones<float>({22});
   path.y = 1.5 * xt::ones<float>({22});
-  goal.position.x = 1.5;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 }
@@ -764,12 +734,11 @@ TEST(CriticTests, VelocityDeadbandCritic)
   models::ControlSequence control_sequence;
   models::Trajectories generated_trajectories;
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt};
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
   data.motion_model = std::make_shared<OmniMotionModel>();
 
   // Initialization testing

--- a/nav2_mppi_controller/test/optimizer_smoke_test.cpp
+++ b/nav2_mppi_controller/test/optimizer_smoke_test.cpp
@@ -85,10 +85,9 @@ TEST_P(OptimizerSuite, OptimizerTest) {
   auto pose = getDummyPointStamped(node, start_pose);
   auto velocity = getDummyTwist();
   auto path = getIncrementalDummyPath(node, path_settings);
-  auto goal = path.poses.back().pose;
   nav2_core::GoalChecker * dummy_goal_checker{nullptr};
 
-  EXPECT_NO_THROW(optimizer->evalControl(pose, velocity, path, goal, dummy_goal_checker));
+  EXPECT_NO_THROW(optimizer->evalControl(pose, velocity, path, dummy_goal_checker));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -123,11 +123,9 @@ public:
   void testPrepare(
     const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::Twist & robot_speed,
-    const nav_msgs::msg::Path & plan,
-    const geometry_msgs::msg::Pose & goal,
-    nav2_core::GoalChecker * goal_checker)
+    const nav_msgs::msg::Path & plan, nav2_core::GoalChecker * goal_checker)
   {
-    prepare(robot_pose, robot_speed, plan, goal, goal_checker);
+    prepare(robot_pose, robot_speed, plan, goal_checker);
 
     EXPECT_EQ(critics_data_.goal_checker, nullptr);
     EXPECT_NEAR(xt::sum(costs_, immediate)(), 0, 1e-6);  // should be reset
@@ -369,10 +367,9 @@ TEST(OptimizerTests, PrepareTests)
   geometry_msgs::msg::Twist speed;
   speed.linear.y = 4.0;
   nav_msgs::msg::Path path;
-  geometry_msgs::msg::Pose goal;
   path.poses.resize(17);
 
-  optimizer_tester.testPrepare(pose, speed, path, goal, nullptr);
+  optimizer_tester.testPrepare(pose, speed, path, nullptr);
 }
 
 TEST(OptimizerTests, shiftControlSequenceTests)

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -132,46 +132,37 @@ TEST(UtilsTests, WithTolTests)
 
   nav2_core::GoalChecker * goal_checker = new TestGoalChecker;
 
+  // Test not in tolerance
   nav_msgs::msg::Path path;
   path.poses.resize(2);
-  geometry_msgs::msg::Pose & goal = path.poses.back().pose;
-
-  // Create CriticData with state and goal initialized
-  models::State state;
-  state.pose.pose = pose;
-  models::Trajectories generated_trajectories;
-  models::Path path_critic;
-  xt::xtensor<float, 1> costs;
-  float model_dt;
-  CriticData data = {
-    state, generated_trajectories, path_critic, goal,
-    costs, model_dt, false, nullptr, nullptr, std::nullopt, std::nullopt};
-
-  // Test not in tolerance
-  goal.position.x = 0.0;
-  goal.position.y = 0.0;
-  EXPECT_FALSE(withinPositionGoalTolerance(goal_checker, pose, goal));
-  EXPECT_FALSE(withinPositionGoalTolerance(0.25, pose, goal));
+  path.poses[1].pose.position.x = 0.0;
+  path.poses[1].pose.position.y = 0.0;
+  models::Path path_t = toTensor(path);
+  EXPECT_FALSE(withinPositionGoalTolerance(goal_checker, pose, path_t));
+  EXPECT_FALSE(withinPositionGoalTolerance(0.25, pose, path_t));
 
   // Test in tolerance
-  goal.position.x = 9.8;
-  goal.position.y = 0.95;
-  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, goal));
-  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, goal));
+  path.poses[1].pose.position.x = 9.8;
+  path.poses[1].pose.position.y = 0.95;
+  path_t = toTensor(path);
+  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, path_t));
+  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, path_t));
 
-  goal.position.x = 10.0;
-  goal.position.y = 0.76;
-  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, goal));
-  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, goal));
+  path.poses[1].pose.position.x = 10.0;
+  path.poses[1].pose.position.y = 0.76;
+  path_t = toTensor(path);
+  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, path_t));
+  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, path_t));
 
-  goal.position.x = 9.76;
-  goal.position.y = 1.0;
-  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, goal));
-  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, goal));
+  path.poses[1].pose.position.x = 9.76;
+  path.poses[1].pose.position.y = 1.0;
+  path_t = toTensor(path);
+  EXPECT_TRUE(withinPositionGoalTolerance(goal_checker, pose, path_t));
+  EXPECT_TRUE(withinPositionGoalTolerance(0.25, pose, path_t));
 
   delete goal_checker;
   goal_checker = nullptr;
-  EXPECT_FALSE(withinPositionGoalTolerance(goal_checker, pose, goal));
+  EXPECT_FALSE(withinPositionGoalTolerance(goal_checker, pose, path_t));
 }
 
 TEST(UtilsTests, AnglesTests)
@@ -219,12 +210,11 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
   models::State state;
   models::Trajectories generated_trajectories;
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs;
   float model_dt = 0.1;
 
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   // Attempt to set furthest point if notionally set, should not change
@@ -234,7 +224,7 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
 
   // Attempt to set if not set already with no other information, should fail
   CriticData data2 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
   setPathFurthestPointIfNotSet(data2);
   EXPECT_EQ(data2.furthest_reached_path_point, 0);
@@ -253,7 +243,7 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
   path = toTensor(plan);
 
   CriticData data3 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
   EXPECT_EQ(findPathFurthestReachedPoint(data3), 5u);
   EXPECT_EQ(findPathTrajectoryInitialPoint(data3), 5u);
@@ -264,12 +254,11 @@ TEST(UtilsTests, findPathCosts)
   models::State state;
   models::Trajectories generated_trajectories;
   models::Path path;
-  geometry_msgs::msg::Pose goal;
   xt::xtensor<float, 1> costs;
   float model_dt = 0.1;
 
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   // Test not set if already set, should not change
@@ -282,7 +271,7 @@ TEST(UtilsTests, findPathCosts)
   EXPECT_EQ(data.path_pts_valid->size(), 10u);
 
   CriticData data3 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(


### PR DESCRIPTION
Reverting https://github.com/ros-navigation/navigation2/commit/ad2f9602f03ba688c34df7f903a118b6898ef0ce on Humble due to bug that was fixed on Main but is not backward compatible with Humble, so the entire feature should be removed. 

FYI @redvinaa

Closes https://github.com/ros-navigation/navigation2/issues/5503