### PR TITLE
add route planning BT nodes to nav2_tree_nodes.xml

### DIFF
--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -311,6 +311,18 @@
       <output_port name="pose">Stamped extracted pose</output_port>
     </Action>
 
+    <Action ID="GetCurrentPose">
+      <input_port name="global_frame">Global reference frame</input_port>
+      <input_port name="robot_base_frame">robot base frame</input_port>
+      <output_port name="current_pose">Current pose output</output_port>
+    </Action>
+
+    <Action ID="ConcatenatePaths">
+      <input_port name="input_path1">Input Path 1 to cancatenate</input_port>
+      <input_port name="input_path2">Input Path 2 to cancatenate</input_port>
+      <output_port name="output_path">Paths concatenated</output_port>
+    </Action>
+
     <!-- ############################### CONDITION NODES ############################## -->
     <Condition ID="GoalReached">
       <input_port name="goal">Destination</input_port>
@@ -388,11 +400,21 @@
       <input_port name="error_code">Error code</input_port>
     </Condition>
 
+    <Condition ID="WouldARouteRecoveryHelp">
+      <input_port name="error_code">Error code</input_port>
+    </Condition>
+
     <Condition ID="AreErrorCodesPresent">
       <input_port name="error_code">Error code</input_port>
       <input_port name="error_codes_to_check">Error codes to check, user defined</input_port>
     </Condition>
 
+    <Condition ID="ArePosesNear">
+      <input_port name="ref_pose">Destination</input_port>
+      <input_port name="target_pose">Destination</input_port>
+      <input_port name="global_frame">Global frame</input_port>
+      <input_port name="tolerance">Tolerance</input_port>
+    </Condition>
 
     <!-- ############################### CONTROL NODES ################################ -->
     <Control ID="PipelineSequence"/>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | not applicable, groot2 1.6.1 |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
* add bt nodes GetCurrentPose, ConcatenatePaths, WouldARouteRecoveryHelp, ArePosesNear to nav2_tree_nodes.xml, descriptions taken from corresponding C++ classes

## Description of documentation updates required from your changes

none

## Description of how this change was tested

opened `navigate_on_route_graph_w_recovery.xml` in groot2, no warnings of undefined BT nodes are observed anymore

---

## Future work that may be required in bullet points

* Some autogeneration of this description from the C++ classes would be nice, i guess

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
