### PR TITLE
Parallel configure/activate in lifecycle manager

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -259,6 +259,7 @@ protected:
   // Whether to automatically start up the system
   bool autostart_;
   bool attempt_respawn_reconnection_;
+  bool parallel_state_transitions_;
 
   NodeState managed_nodes_state_{NodeState::UNCONFIGURED};
   diagnostic_updater::Updater diagnostics_updater_;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -16,6 +16,7 @@
 #include "nav2_lifecycle_manager/lifecycle_manager.hpp"
 
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -45,6 +46,7 @@ LifecycleManager::LifecycleManager(const rclcpp::NodeOptions & options)
   declare_parameter("service_timeout", 5.0);
   declare_parameter("bond_respawn_max_duration", 10.0);
   declare_parameter("attempt_respawn_reconnection", true);
+  declare_parameter("parallel_state_transitions", rclcpp::ParameterValue(true));
 
   registerRclPreshutdownCallback();
 
@@ -65,6 +67,7 @@ LifecycleManager::LifecycleManager(const rclcpp::NodeOptions & options)
   bond_respawn_max_duration_ = rclcpp::Duration::from_seconds(respawn_timeout_s);
 
   get_parameter("attempt_respawn_reconnection", attempt_respawn_reconnection_);
+  get_parameter("parallel_state_transitions", parallel_state_transitions_);
 
   callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
 
@@ -281,34 +284,104 @@ LifecycleManager::changeStateForNode(const std::string & node_name, std::uint8_t
 bool
 LifecycleManager::changeStateForAllNodes(std::uint8_t transition, bool hard_change)
 {
-  // Hard change will continue even if a node fails
-  if (transition == Transition::TRANSITION_CONFIGURE ||
-    transition == Transition::TRANSITION_ACTIVATE)
-  {
-    for (auto & node_name : node_names_) {
-      try {
-        if (!changeStateForNode(node_name, transition) && !hard_change) {
-          return false;
-        }
-      } catch (const std::runtime_error & e) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Failed to change state for node: %s. Exception: %s.", node_name.c_str(), e.what());
-        return false;
+  /* Function partially created using claude */
+  size_t active_nodes_count = 0;
+  std::string nodes_in_error_state = "";
+  std::string unconfigured_nodes = "";
+  std::string inactive_nodes = "";
+  std::string delimiter(", ");
+
+  if (parallel_state_transitions_) {
+    // Parallel execution
+    std::vector<std::future<bool>> futures;
+    std::vector<std::string> processing_nodes;
+
+    // Hard change will continue even if a node fails
+    if (transition == Transition::TRANSITION_CONFIGURE ||
+      transition == Transition::TRANSITION_ACTIVATE)
+    {
+      // Launch all state changes in parallel
+      for (auto & node_name : node_names_) {
+        futures.emplace_back(std::async(std::launch::async, [this, node_name, transition]() {
+            try {
+              return changeStateForNode(node_name, transition);
+            } catch (const std::runtime_error & e) {
+              RCLCPP_ERROR(
+              get_logger(),
+              "Failed to change state for node: %s. Exception: %s.", node_name.c_str(), e.what());
+              return false;
+            }
+        }));
+        processing_nodes.push_back(node_name);
+      }
+    } else {
+      // For deactivation/cleanup, process in reverse order but still in parallel
+      std::vector<std::string> reverse_nodes(node_names_.rbegin(), node_names_.rend());
+      for (auto & node_name : reverse_nodes) {
+        futures.emplace_back(std::async(std::launch::async, [this, node_name, transition]() {
+            try {
+              return changeStateForNode(node_name, transition);
+            } catch (const std::runtime_error & e) {
+              RCLCPP_ERROR(
+              get_logger(),
+              "Failed to change state for node: %s. Exception: %s.", node_name.c_str(), e.what());
+              return false;
+            }
+        }));
+        processing_nodes.push_back(node_name);
       }
     }
+
+    // Wait for all futures and collect results
+    for (size_t i = 0; i < futures.size(); ++i) {
+      bool success = futures[i].get();
+      const std::string & node_name = processing_nodes[i];
+
+      if (!success && !hard_change) {
+        uint8_t state = node_map_[node_name]->get_state();
+        if (!strcmp(reinterpret_cast<char *>(&state), "Inactive")) {
+          inactive_nodes += node_name + delimiter;
+        } else {
+          unconfigured_nodes += node_name + delimiter;
+        }
+      } else if (success) {
+        ++active_nodes_count;
+      }
+    }
+    if (active_nodes_count != node_names_.size()) {
+      return false;
+    }
+
   } else {
-    std::vector<std::string>::reverse_iterator rit;
-    for (rit = node_names_.rbegin(); rit != node_names_.rend(); ++rit) {
-      try {
-        if (!changeStateForNode(*rit, transition) && !hard_change) {
+    // Sequential execution (original behavior)
+    if (transition == Transition::TRANSITION_CONFIGURE ||
+      transition == Transition::TRANSITION_ACTIVATE)
+    {
+      for (auto & node_name : node_names_) {
+        try {
+          if (!changeStateForNode(node_name, transition) && !hard_change) {
+            return false;
+          }
+        } catch (const std::runtime_error & e) {
+          RCLCPP_ERROR(
+          get_logger(),
+          "Failed to change state for node: %s. Exception: %s.", node_name.c_str(), e.what());
           return false;
         }
-      } catch (const std::runtime_error & e) {
-        RCLCPP_ERROR(
+      }
+    } else {
+      std::vector<std::string>::reverse_iterator rit;
+      for (rit = node_names_.rbegin(); rit != node_names_.rend(); ++rit) {
+        try {
+          if (!changeStateForNode(*rit, transition) && !hard_change) {
+            return false;
+          }
+        } catch (const std::runtime_error & e) {
+          RCLCPP_ERROR(
           get_logger(),
           "Failed to change state for node: %s. Exception: %s.", (*rit).c_str(), e.what());
-        return false;
+          return false;
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Pixel PT |
| Does this PR contain AI generated software? | yes  |
| Was this PR description generated by AI software? | no |

---

## Description of contribution in a few bullet points
we noticed that our lifecycle nodes don't depend being configured/activated in sequence, so we can speed up robot launch by activating everything at once. For us, on the robot it reduces launch speed (until "all managed nodes are active") from 51 seconds to 35 seconds. 

I tried with the simulation from this repo by running some system test:
`colcon test --packages-select nav2_system_tests --event-handler=console_direct+ --ctest-args --output-on-failure -R _error_msg$`

and after I removed some arbitrary long sleeps from the tester node I got
with this PR: 6 seconds for configure+activate; overall test 50 seconds
without this PR: 7 seconds for configure+activate; overall test 52 seconds (as deactivate is also faster)

so, not that much, but the realworld benefit at least for us is significant. Let me know if that is something you want to add, then we can polish this PR.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested
Tested on our robot and in the nav2 simulation.
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
is running on productive robots since a couple weeks, but as this only concerns launching that doesn't mean so much
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
