### PR TITLE
Add a parameter to set initial enabled state for the collision monitor

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -485,7 +485,7 @@ velocity_smoother:
 
 collision_monitor:
   ros__parameters:
-    enabled_at_start: False
+    enabled_at_start: True
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -485,6 +485,7 @@ velocity_smoother:
 
 collision_monitor:
   ros__parameters:
+    enabled_at_start: False
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -485,7 +485,7 @@ velocity_smoother:
 
 collision_monitor:
   ros__parameters:
-    enabled_at_start: True
+    enabled: True
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -1,5 +1,6 @@
 collision_monitor:
   ros__parameters:
+    enabled_at_start: True
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -1,6 +1,6 @@
 collision_monitor:
   ros__parameters:
-    enabled_at_start: True
+    enabled: True
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -106,7 +106,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
   node->get_parameter("enabled_at_start", enabled_);
 
   if (!enabled_) {
-    RCLCPP_WARN(get_logger(), "Collision monitor is disabled!");
+    RCLCPP_WARN(get_logger(), "Collision monitor is disabled at startup.");
   } else {
     RCLCPP_INFO(get_logger(), "Collision monitor is enabled.");
   }

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -108,7 +108,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
   if (!enabled_) {
     RCLCPP_WARN(get_logger(), "Collision monitor is disabled at startup.");
   } else {
-    RCLCPP_INFO(get_logger(), "Collision monitor is enabled.");
+    RCLCPP_INFO(get_logger(), "Collision monitor is enabled at startup.");
   }
 
   return nav2::CallbackReturn::SUCCESS;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -102,8 +102,8 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
     }
   }
 
-  nav2::declare_parameter_if_not_declared(node, "enabled_at_start", rclcpp::ParameterValue(true));
-  node->get_parameter("enabled_at_start", enabled_);
+  nav2::declare_parameter_if_not_declared(node, "enabled", rclcpp::ParameterValue(true));
+  node->get_parameter("enabled", enabled_);
 
   if (!enabled_) {
     RCLCPP_WARN(get_logger(), "Collision monitor is disabled at startup.");

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -102,6 +102,15 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
     }
   }
 
+  nav2::declare_parameter_if_not_declared(node, "enabled_at_start", rclcpp::ParameterValue(true));
+  node->get_parameter("enabled_at_start", enabled_);
+
+  if (!enabled_) {
+    RCLCPP_WARN(get_logger(), "Collision monitor is disabled!");
+  } else {
+    RCLCPP_INFO(get_logger(), "Collision monitor is enabled.");
+  }
+
   return nav2::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -302,7 +302,7 @@ Tester::~Tester()
 
 void Tester::setCommonParameters()
 {
-  cm_->declare_parameter("enabled_at_start", rclcpp::ParameterValue(true));
+  cm_->declare_parameter("enabled", rclcpp::ParameterValue(true));
 
   cm_->declare_parameter(
     "cmd_vel_in_topic", rclcpp::ParameterValue(CMD_VEL_IN_TOPIC));
@@ -844,7 +844,7 @@ TEST_F(Tester, testToggleService)
   setVectors({"Stop"}, {SCAN_NAME});
 
   // Test the parameter in disabled state
-  cm_->set_parameter(rclcpp::Parameter("enabled_at_start", false));
+  cm_->set_parameter(rclcpp::Parameter("enabled", false));
 
   // Start collision monitor node
   cm_->start();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5493 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 Loopback Simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Added a parameter to set the initial state for for the collision monitor to start in enabled/disabled state. 

## Description of documentation updates required from your changes

* Need to add this parameter to the [collision monitor node documentation](https://docs.nav2.org/configuration/packages/collision_monitor/configuring-collision-monitor-node.html)

## Description of how this change was tested

* This change was tested in the TB3 Loopback simulation to check if it actually works. I kept an eye on the console log to see if the correct message was printed during node configuration. I also tried modifying the parameter in the parameters file within the bring up package to see if the changes were applied correctly.

---

## Future work that may be required in bullet points

--

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
