### PR TITLE
Migrate TransformBroadcaster to use shared_ptr

### DIFF
--- a/nav2_route/test/test_goal_intent_extractor.cpp
+++ b/nav2_route/test/test_goal_intent_extractor.cpp
@@ -83,7 +83,7 @@ TEST(GoalIntentExtractorTest, test_transform_pose)
     node->get_node_timers_interface());
   tf->setCreateTimerInterface(timer_interface);
   auto transform_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  tf2_ros::TransformBroadcaster broadcaster(node);
+  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_subscriber = nullptr;
   extractor.configure(node, graph, &id_map, tf, costmap_subscriber, "map", "base_link");
 
@@ -101,7 +101,7 @@ TEST(GoalIntentExtractorTest, test_transform_pose)
   transform.header.frame_id = "map";
   transform.header.stamp = node->now();
   transform.child_frame_id = "gps";
-  broadcaster.sendTransform(transform);
+  broadcaster->sendTransform(transform);
   EXPECT_NO_THROW(extractor.transformPose(pose, "map"));
 }
 

--- a/nav2_route/test/test_route_tracker.cpp
+++ b/nav2_route/test/test_route_tracker.cpp
@@ -69,7 +69,7 @@ TEST(RouteTrackerTest, test_get_robot_pose)
     node->get_node_timers_interface());
   tf->setCreateTimerInterface(timer_interface);
   auto transform_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  tf2_ros::TransformBroadcaster broadcaster(node);
+  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_subscriber;
 
   RouteTracker tracker;
@@ -81,7 +81,7 @@ TEST(RouteTrackerTest, test_get_robot_pose)
   transform.header.frame_id = "map";
   transform.header.stamp = node->now();
   transform.child_frame_id = "base_link";
-  broadcaster.sendTransform(transform);
+  broadcaster->sendTransform(transform);
   EXPECT_NO_THROW(tracker.getRobotPose());
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes the `system_build` [job](https://app.circleci.com/pipelines/github/ros-navigation/navigation2/16253/workflows/415fc0bc-a6c0-4788-ad75-e32d5f002e4a/jobs/47505) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI-generated software? | No|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Migrated to use the heap allocation over stack due to the new NodeInterfaces API for `TransformBroadcaster` enforced in [ros2/geometry2](https://github.com/ros2/geometry2/pull/714/files#diff-5bbc53dd6b24edebe2ad5c06f9659ed7387ebcdc638384552f66785950211c45R93-R100).

## Description of documentation updates required from your changes
* N/A

## Description of how this change was tested

* The local build of `nav2_route` now passes locally - `colcon build --packages-select nav2_route`.
---

## Future work that may be required in bullet points
* N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
