### PR TITLE
Fix optimal plan frame id

### DIFF
--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -119,8 +119,8 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
 
     std_msgs::msg::Header trajectory_header;
     trajectory_header.stamp = cmd.header.stamp;
-    trajectory_header.frame_id = costmap_ros_->getGlobalFrameID(); 
-    
+    trajectory_header.frame_id = costmap_ros_->getGlobalFrameID();
+
     auto trajectory_msg = utils::toTrajectoryMsg(
       optimal_trajectory,
       optimizer_.getOptimalControlSequence(),

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -116,7 +116,6 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
 #endif
 
   if (publish_optimal_trajectory_ && opt_traj_pub_->get_subscription_count() > 0) {
-
     std_msgs::msg::Header trajectory_header;
     trajectory_header.stamp = cmd.header.stamp;
     trajectory_header.frame_id = costmap_ros_->getGlobalFrameID();

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -116,11 +116,16 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
 #endif
 
   if (publish_optimal_trajectory_ && opt_traj_pub_->get_subscription_count() > 0) {
+
+    std_msgs::msg::Header trajectory_header;
+    trajectory_header.stamp = cmd.header.stamp;
+    trajectory_header.frame_id = costmap_ros_->getGlobalFrameID(); 
+    
     auto trajectory_msg = utils::toTrajectoryMsg(
       optimal_trajectory,
       optimizer_.getOptimalControlSequence(),
       optimizer_.getSettings().model_dt,
-      cmd.header);
+      trajectory_header);
     opt_traj_pub_->publish(std::move(trajectory_msg));
   }
 


### PR DESCRIPTION
The cmd is wrt to the base frame while the optimal_trajectory is wrt to global frame.  Fix the frame id for the trajectory_msg. 
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | / |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Custom simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

## Description of documentation updates required from your changes

## Description of how this change was tested

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
