### PR TITLE
nav2_smac_planner: make A* return closest path found in case of timeout

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -239,6 +239,13 @@ protected:
   inline bool areInputsValid();
 
   /**
+   * @brief Get the closest path within tolerance if available
+   * @param path Vector of coordinates to fill with path
+   * @return if a valid path was found within tolerance
+   */
+  inline bool getClosestPathWithinTolerance(CoordinateVector & path);
+
+  /**
    * @brief Clear heuristic queue of nodes to search
    */
   inline void clearQueue();

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -323,6 +323,17 @@ bool AStarAlgorithm<NodeT>::areInputsValid()
 }
 
 template<typename NodeT>
+bool AStarAlgorithm<NodeT>::getClosestPathWithinTolerance(CoordinateVector & path)
+{
+  if (_best_heuristic_node.first < getToleranceHeuristic()) {
+    _graph.at(_best_heuristic_node.second).backtracePath(path);
+    return true;
+  }
+
+  return false;
+}
+
+template<typename NodeT>
 bool AStarAlgorithm<NodeT>::createPath(
   CoordinateVector & path, int & iterations,
   const float & tolerance,
@@ -381,7 +392,8 @@ bool AStarAlgorithm<NodeT>::createPath(
       std::chrono::duration<double> planning_duration =
         std::chrono::duration_cast<std::chrono::duration<double>>(steady_clock::now() - start_time);
       if (static_cast<double>(planning_duration.count()) >= _max_planning_time) {
-        return false;
+        // In case of timeout, return the path that is closest, if within tolerance.
+        return getClosestPathWithinTolerance(path);
       }
     }
 
@@ -448,12 +460,8 @@ bool AStarAlgorithm<NodeT>::createPath(
     }
   }
 
-  if (_best_heuristic_node.first < getToleranceHeuristic()) {
-    // If we run out of search options, return the path that is closest, if within tolerance.
-    return _graph.at(_best_heuristic_node.second).backtracePath(path);
-  }
-
-  return false;
+  // If we run out of search options, return the path that is closest, if within tolerance.
+  return getClosestPathWithinTolerance(path);
 }
 
 template<typename NodeT>


### PR DESCRIPTION
Until now, a path computation timeout would systematically lead to a nav2_core::PlannerTimedOut error, even though a path was found within the tolerance.

This commit makes the A* return the best path found if it's within the tolerance.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5577 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Custom simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
