### PR TITLE
Use the new_declare_or_get_parameter API for nav2_collision_monitor.

### DIFF
--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -147,27 +147,14 @@ bool CollisionDetector::getParameters()
 
   auto node = shared_from_this();
 
-  nav2::declare_parameter_if_not_declared(
-    node, "frequency", rclcpp::ParameterValue(10.0));
-  frequency_ = get_parameter("frequency").as_double();
-  nav2::declare_parameter_if_not_declared(
-    node, "base_frame_id", rclcpp::ParameterValue("base_footprint"));
-  base_frame_id = get_parameter("base_frame_id").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "odom_frame_id", rclcpp::ParameterValue("odom"));
-  odom_frame_id = get_parameter("odom_frame_id").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "transform_tolerance", rclcpp::ParameterValue(0.1));
-  transform_tolerance =
-    tf2::durationFromSec(get_parameter("transform_tolerance").as_double());
-  nav2::declare_parameter_if_not_declared(
-    node, "source_timeout", rclcpp::ParameterValue(2.0));
-  source_timeout =
-    rclcpp::Duration::from_seconds(get_parameter("source_timeout").as_double());
-  nav2::declare_parameter_if_not_declared(
-    node, "base_shift_correction", rclcpp::ParameterValue(true));
-  const bool base_shift_correction =
-    get_parameter("base_shift_correction").as_bool();
+  frequency_ = node->declare_or_get_parameter("frequency", 10.0);
+  base_frame_id = node->declare_or_get_parameter("base_frame_id", std::string("base_footprint"));
+  odom_frame_id = node->declare_or_get_parameter("odom_frame_id", std::string("odom"));
+  transform_tolerance = tf2::durationFromSec(
+    node->declare_or_get_parameter("transform_tolerance", 0.1));
+  source_timeout = rclcpp::Duration::from_seconds(
+    node->declare_or_get_parameter("source_timeout", 2.0));
+  const bool base_shift_correction = node->declare_or_get_parameter("base_shift_correction", true);
 
   if (!configureSources(
       base_frame_id, odom_frame_id, transform_tolerance, source_timeout,
@@ -259,10 +246,8 @@ bool CollisionDetector::configureSources(
       node, "observation_sources", rclcpp::PARAMETER_STRING_ARRAY);
     std::vector<std::string> source_names = get_parameter("observation_sources").as_string_array();
     for (std::string source_name : source_names) {
-      nav2::declare_parameter_if_not_declared(
-        node, source_name + ".type",
-        rclcpp::ParameterValue("scan"));  // Laser scanner by default
-      const std::string source_type = get_parameter(source_name + ".type").as_string();
+      const std::string source_type = node->declare_or_get_parameter(
+        source_name + ".type", std::string("scan"));  // Laser scanner by default
 
       if (source_type == "scan") {
         std::shared_ptr<Scan> s = std::make_shared<Scan>(

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -88,10 +88,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
     "~/toggle",
     std::bind(&CollisionMonitor::toggleCMServiceCallback, this, _1, _2, _3));
 
-  nav2::declare_parameter_if_not_declared(
-    node, "use_realtime_priority", rclcpp::ParameterValue(false));
-  bool use_realtime_priority = false;
-  node->get_parameter("use_realtime_priority", use_realtime_priority);
+  bool use_realtime_priority = node->declare_or_get_parameter("use_realtime_priority", false);
   if (use_realtime_priority) {
     try {
       nav2::setSoftRealTimePriority();
@@ -102,8 +99,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
     }
   }
 
-  nav2::declare_parameter_if_not_declared(node, "enabled", rclcpp::ParameterValue(true));
-  node->get_parameter("enabled", enabled_);
+  enabled_ = node->declare_or_get_parameter("enabled", true);
 
   if (!enabled_) {
     RCLCPP_WARN(get_logger(), "Collision monitor is disabled at startup.");
@@ -253,39 +249,23 @@ bool CollisionMonitor::getParameters(
 
   auto node = shared_from_this();
 
-  nav2::declare_parameter_if_not_declared(
-    node, "cmd_vel_in_topic", rclcpp::ParameterValue("cmd_vel_smoothed"));
-  cmd_vel_in_topic = get_parameter("cmd_vel_in_topic").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "cmd_vel_out_topic", rclcpp::ParameterValue("cmd_vel"));
-  cmd_vel_out_topic = get_parameter("cmd_vel_out_topic").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "state_topic", rclcpp::ParameterValue(""));
-  state_topic = get_parameter("state_topic").as_string();
+  cmd_vel_in_topic = node->declare_or_get_parameter(
+    "cmd_vel_in_topic", std::string("cmd_vel_smoothed"));
+  cmd_vel_out_topic = node->declare_or_get_parameter(
+    "cmd_vel_out_topic", std::string("cmd_vel"));
+  state_topic = node->declare_or_get_parameter("state_topic", std::string(""));
 
-  nav2::declare_parameter_if_not_declared(
-    node, "base_frame_id", rclcpp::ParameterValue("base_footprint"));
-  base_frame_id = get_parameter("base_frame_id").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "odom_frame_id", rclcpp::ParameterValue("odom"));
-  odom_frame_id = get_parameter("odom_frame_id").as_string();
-  nav2::declare_parameter_if_not_declared(
-    node, "transform_tolerance", rclcpp::ParameterValue(0.1));
-  transform_tolerance =
-    tf2::durationFromSec(get_parameter("transform_tolerance").as_double());
-  nav2::declare_parameter_if_not_declared(
-    node, "source_timeout", rclcpp::ParameterValue(2.0));
-  source_timeout =
-    rclcpp::Duration::from_seconds(get_parameter("source_timeout").as_double());
-  nav2::declare_parameter_if_not_declared(
-    node, "base_shift_correction", rclcpp::ParameterValue(true));
-  const bool base_shift_correction =
-    get_parameter("base_shift_correction").as_bool();
+  base_frame_id = node->declare_or_get_parameter(
+    "base_frame_id", std::string("base_footprint"));
+  odom_frame_id = node->declare_or_get_parameter("odom_frame_id", std::string("odom"));
+  transform_tolerance = tf2::durationFromSec(
+    node->declare_or_get_parameter("transform_tolerance", 0.1));
+  source_timeout = rclcpp::Duration::from_seconds(
+    node->declare_or_get_parameter("source_timeout", 2.0));
+  const bool base_shift_correction = node->declare_or_get_parameter("base_shift_correction", true);
 
-  nav2::declare_parameter_if_not_declared(
-    node, "stop_pub_timeout", rclcpp::ParameterValue(1.0));
-  stop_pub_timeout_ =
-    rclcpp::Duration::from_seconds(get_parameter("stop_pub_timeout").as_double());
+  stop_pub_timeout_ = rclcpp::Duration::from_seconds(
+    node->declare_or_get_parameter("stop_pub_timeout", 1.0));
 
   if (
     !configureSources(
@@ -366,10 +346,8 @@ bool CollisionMonitor::configureSources(
       node, "observation_sources", rclcpp::PARAMETER_STRING_ARRAY);
     std::vector<std::string> source_names = get_parameter("observation_sources").as_string_array();
     for (std::string source_name : source_names) {
-      nav2::declare_parameter_if_not_declared(
-        node, source_name + ".type",
-        rclcpp::ParameterValue("scan"));  // Laser scanner by default
-      const std::string source_type = get_parameter(source_name + ".type").as_string();
+      const std::string source_type = node->declare_or_get_parameter(
+        source_name + ".type", std::string("scan"));  // Laser scanner by default
 
       if (source_type == "scan") {
         std::shared_ptr<Scan> s = std::make_shared<Scan>(

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -136,18 +136,11 @@ void PointCloud::getParameters(std::string & source_topic)
 
   getCommonParameters(source_topic);
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".min_height", rclcpp::ParameterValue(0.05));
-  min_height_ = node->get_parameter(source_name_ + ".min_height").as_double();
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".max_height", rclcpp::ParameterValue(0.5));
-  max_height_ = node->get_parameter(source_name_ + ".max_height").as_double();
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".min_range", rclcpp::ParameterValue(0.0));
-  min_range_ = node->get_parameter(source_name_ + ".min_range").as_double();
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".transport_type", rclcpp::ParameterValue(std::string("raw")));
-  transport_type_ = node->get_parameter(source_name_ + ".transport_type").as_string();
+  min_height_ = node->declare_or_get_parameter(source_name_ + ".min_height", 0.05);
+  max_height_ = node->declare_or_get_parameter(source_name_ + ".max_height", 0.5);
+  min_range_ = node->declare_or_get_parameter(source_name_ + ".min_range", 0.0);
+  transport_type_ = node->declare_or_get_parameter(
+    source_name_ + ".transport_type", std::string("raw"));
 }
 
 void PointCloud::dataCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -351,13 +351,8 @@ bool Polygon::getCommonParameters(
       return false;
     }
 
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".enabled", rclcpp::ParameterValue(true));
-    enabled_ = node->get_parameter(polygon_name_ + ".enabled").as_bool();
-
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".min_points", rclcpp::ParameterValue(4));
-    min_points_ = node->get_parameter(polygon_name_ + ".min_points").as_int();
+    enabled_ = node->declare_or_get_parameter(polygon_name_ + ".enabled", true);
+    min_points_ = node->declare_or_get_parameter(polygon_name_ + ".min_points", 4);
 
     try {
       nav2::declare_parameter_if_not_declared(
@@ -373,45 +368,33 @@ bool Polygon::getCommonParameters(
     }
 
     if (action_type_ == SLOWDOWN) {
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".slowdown_ratio", rclcpp::ParameterValue(0.5));
-      slowdown_ratio_ = node->get_parameter(polygon_name_ + ".slowdown_ratio").as_double();
+      slowdown_ratio_ = node->declare_or_get_parameter(
+        polygon_name_ + ".slowdown_ratio", 0.5);
     }
 
     if (action_type_ == LIMIT) {
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".linear_limit", rclcpp::ParameterValue(0.5));
-      linear_limit_ = node->get_parameter(polygon_name_ + ".linear_limit").as_double();
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".angular_limit", rclcpp::ParameterValue(0.5));
-      angular_limit_ = node->get_parameter(polygon_name_ + ".angular_limit").as_double();
+      linear_limit_ = node->declare_or_get_parameter(
+        polygon_name_ + ".linear_limit", 0.5);
+      angular_limit_ = node->declare_or_get_parameter(
+        polygon_name_ + ".angular_limit", 0.5);
     }
 
     if (action_type_ == APPROACH) {
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".time_before_collision", rclcpp::ParameterValue(2.0));
-      time_before_collision_ =
-        node->get_parameter(polygon_name_ + ".time_before_collision").as_double();
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".simulation_time_step", rclcpp::ParameterValue(0.1));
-      simulation_time_step_ =
-        node->get_parameter(polygon_name_ + ".simulation_time_step").as_double();
+      time_before_collision_ = node->declare_or_get_parameter(
+        polygon_name_ + ".time_before_collision", 2.0);
+      simulation_time_step_ = node->declare_or_get_parameter(
+        polygon_name_ + ".simulation_time_step", 0.1);
     }
 
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".visualize", rclcpp::ParameterValue(false));
-    visualize_ = node->get_parameter(polygon_name_ + ".visualize").as_bool();
+    visualize_ = node->declare_or_get_parameter(polygon_name_ + ".visualize", false);
     if (visualize_) {
       // Get polygon topic parameter in case if it is going to be published
-      nav2::declare_parameter_if_not_declared(
-        node, polygon_name_ + ".polygon_pub_topic", rclcpp::ParameterValue(polygon_name_));
-      polygon_pub_topic = node->get_parameter(polygon_name_ + ".polygon_pub_topic").as_string();
+      polygon_pub_topic = node->declare_or_get_parameter(
+        polygon_name_ + ".polygon_pub_topic", polygon_name_);
     }
 
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".polygon_subscribe_transient_local", rclcpp::ParameterValue(false));
-    polygon_subscribe_transient_local_ =
-      node->get_parameter(polygon_name_ + ".polygon_subscribe_transient_local").as_bool();
+    polygon_subscribe_transient_local_ = node->declare_or_get_parameter(
+      polygon_name_ + ".polygon_subscribe_transient_local", false);
 
     if (use_dynamic_sub_topic) {
       if (action_type_ != APPROACH) {
@@ -422,11 +405,9 @@ bool Polygon::getCommonParameters(
           node->get_parameter(polygon_name_ + ".polygon_sub_topic").as_string();
       } else {
         // Obtain the footprint topic to make a footprint subscription for approach polygon
-        nav2::declare_parameter_if_not_declared(
-          node, polygon_name_ + ".footprint_topic",
-          rclcpp::ParameterValue("local_costmap/published_footprint"));
-        footprint_topic =
-          node->get_parameter(polygon_name_ + ".footprint_topic").as_string();
+        footprint_topic = node->declare_or_get_parameter(
+          polygon_name_ + ".footprint_topic",
+          std::string("local_costmap/published_footprint"));
       }
     }
 
@@ -435,9 +416,8 @@ bool Polygon::getCommonParameters(
       node, "observation_sources", rclcpp::PARAMETER_STRING_ARRAY);
     const std::vector<std::string> observation_sources =
       node->get_parameter("observation_sources").as_string_array();
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".sources_names", rclcpp::ParameterValue(observation_sources));
-    sources_names_ = node->get_parameter(polygon_name_ + ".sources_names").as_string_array();
+    sources_names_ = node->declare_or_get_parameter(
+      polygon_name_ + ".sources_names", observation_sources);
 
     // Check the observation sources configured for polygon are defined
     for (auto source_name : sources_names_) {

--- a/nav2_collision_monitor/src/polygon_source.cpp
+++ b/nav2_collision_monitor/src/polygon_source.cpp
@@ -160,9 +160,8 @@ void PolygonSource::getParameters(std::string & source_topic)
 
   getCommonParameters(source_topic);
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".sampling_distance", rclcpp::ParameterValue(0.1));
-  sampling_distance_ = node->get_parameter(source_name_ + ".sampling_distance").as_double();
+  sampling_distance_ = node->declare_or_get_parameter(
+    source_name_ + ".sampling_distance", 0.1);
 }
 
 void PolygonSource::dataCallback(geometry_msgs::msg::PolygonInstanceStamped::ConstSharedPtr msg)

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -137,9 +137,8 @@ void Range::getParameters(std::string & source_topic)
 
   getCommonParameters(source_topic);
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".obstacles_angle", rclcpp::ParameterValue(M_PI / 180));
-  obstacles_angle_ = node->get_parameter(source_name_ + ".obstacles_angle").as_double();
+  obstacles_angle_ = node->declare_or_get_parameter(
+    source_name_ + ".obstacles_angle", M_PI / 180);
 }
 
 void Range::dataCallback(sensor_msgs::msg::Range::ConstSharedPtr msg)

--- a/nav2_collision_monitor/src/source.cpp
+++ b/nav2_collision_monitor/src/source.cpp
@@ -62,20 +62,16 @@ void Source::getCommonParameters(std::string & source_topic)
     throw std::runtime_error{"Failed to lock node"};
   }
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".topic",
-    rclcpp::ParameterValue("scan"));  // Set default topic for laser scanner
-  source_topic = node->get_parameter(source_name_ + ".topic").as_string();
+  source_topic = node->declare_or_get_parameter(
+    source_name_ + ".topic", std::string("scan"));  // Set default topic for laser scanner
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".enabled", rclcpp::ParameterValue(true));
-  enabled_ = node->get_parameter(source_name_ + ".enabled").as_bool();
+  enabled_ = node->declare_or_get_parameter(
+    source_name_ + ".enabled", true);
 
-  nav2::declare_parameter_if_not_declared(
-    node, source_name_ + ".source_timeout",
-    rclcpp::ParameterValue(source_timeout_.seconds()));      // node source_timeout by default
   source_timeout_ = rclcpp::Duration::from_seconds(
-    node->get_parameter(source_name_ + ".source_timeout").as_double());
+    node->declare_or_get_parameter(
+      source_name_ + ".source_timeout",
+      source_timeout_.seconds()));  // node source_timeout by default
 }
 
 bool Source::sourceValid(

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -56,9 +56,8 @@ bool VelocityPolygon::getParameters(
       node->get_parameter(polygon_name_ + ".velocity_polygons").as_string_array();
 
     // holonomic param
-    nav2::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".holonomic", rclcpp::ParameterValue(false));
-    holonomic_ = node->get_parameter(polygon_name_ + ".holonomic").as_bool();
+    holonomic_ = node->declare_or_get_parameter(
+      polygon_name_ + ".holonomic", false);
 
     for (std::string velocity_polygon_name : velocity_polygons) {
       // polygon points parameter
@@ -73,55 +72,42 @@ bool VelocityPolygon::getParameters(
       }
 
       // linear_min param
-      double linear_min;
       nav2::declare_parameter_if_not_declared(
         node, polygon_name_ + "." + velocity_polygon_name + ".linear_min",
         rclcpp::PARAMETER_DOUBLE);
-      linear_min = node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".linear_min")
-        .as_double();
+      double linear_min = node->get_parameter(
+        polygon_name_ + "." + velocity_polygon_name + ".linear_min").as_double();
 
       // linear_max param
-      double linear_max;
       nav2::declare_parameter_if_not_declared(
         node, polygon_name_ + "." + velocity_polygon_name + ".linear_max",
         rclcpp::PARAMETER_DOUBLE);
-      linear_max = node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".linear_max")
-        .as_double();
+      double linear_max = node->get_parameter(
+        polygon_name_ + "." + velocity_polygon_name + ".linear_max").as_double();
 
       // theta_min param
-      double theta_min;
       nav2::declare_parameter_if_not_declared(
         node, polygon_name_ + "." + velocity_polygon_name + ".theta_min",
         rclcpp::PARAMETER_DOUBLE);
-      theta_min =
-        node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".theta_min").as_double();
+      double theta_min = node->get_parameter(
+        polygon_name_ + "." + velocity_polygon_name + ".theta_min").as_double();
 
       // theta_max param
-      double theta_max;
       nav2::declare_parameter_if_not_declared(
         node, polygon_name_ + "." + velocity_polygon_name + ".theta_max",
         rclcpp::PARAMETER_DOUBLE);
-      theta_max =
-        node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".theta_max").as_double();
+      double theta_max = node->get_parameter(
+        polygon_name_ + "." + velocity_polygon_name + ".theta_max").as_double();
 
       // direction_end_angle param and direction_start_angle param
       double direction_end_angle = 0.0;
       double direction_start_angle = 0.0;
       if (holonomic_) {
-        nav2::declare_parameter_if_not_declared(
-          node, polygon_name_ + "." + velocity_polygon_name + ".direction_end_angle",
-          rclcpp::ParameterValue(M_PI));
-        direction_end_angle =
-          node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".direction_end_angle")
-          .as_double();
+        direction_end_angle = node->declare_or_get_parameter(
+          polygon_name_ + "." + velocity_polygon_name + ".direction_end_angle", M_PI);
 
-        nav2::declare_parameter_if_not_declared(
-          node, polygon_name_ + "." + velocity_polygon_name + ".direction_start_angle",
-          rclcpp::ParameterValue(-M_PI));
-        direction_start_angle =
-          node
-          ->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".direction_start_angle")
-          .as_double();
+        direction_start_angle = node->declare_or_get_parameter(
+          polygon_name_ + "." + velocity_polygon_name + ".direction_start_angle", -M_PI);
       }
 
       SubPolygonParameter sub_polygon = {

--- a/nav2_collision_monitor/test/collision_detector_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_detector_node_test.cpp
@@ -260,25 +260,15 @@ void Tester::setCommonParameters()
 {
   cd_->declare_parameter(
     "base_frame_id", rclcpp::ParameterValue(BASE_FRAME_ID));
-  cd_->set_parameter(
-    rclcpp::Parameter("base_frame_id", BASE_FRAME_ID));
   cd_->declare_parameter(
     "odom_frame_id", rclcpp::ParameterValue(ODOM_FRAME_ID));
-  cd_->set_parameter(
-    rclcpp::Parameter("odom_frame_id", ODOM_FRAME_ID));
 
   cd_->declare_parameter(
     "transform_tolerance", rclcpp::ParameterValue(TRANSFORM_TOLERANCE));
-  cd_->set_parameter(
-    rclcpp::Parameter("transform_tolerance", TRANSFORM_TOLERANCE));
   cd_->declare_parameter(
     "source_timeout", rclcpp::ParameterValue(SOURCE_TIMEOUT));
-  cd_->set_parameter(
-    rclcpp::Parameter("source_timeout", SOURCE_TIMEOUT));
   cd_->declare_parameter(
     "frequency", rclcpp::ParameterValue(FREQUENCY));
-  cd_->set_parameter(
-    rclcpp::Parameter("frequency", FREQUENCY));
 }
 
 void Tester::addPolygon(
@@ -288,8 +278,6 @@ void Tester::addPolygon(
   if (type == POLYGON) {
     cd_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("polygon"));
-    cd_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "polygon"));
 
     const std::string points = "[[" +
       std::to_string(size) + ", " + std::to_string(size) + "], [" +
@@ -298,49 +286,31 @@ void Tester::addPolygon(
       std::to_string(-size) + ", " + std::to_string(size) + "]]";
     cd_->declare_parameter(
       polygon_name + ".points", rclcpp::ParameterValue(points));
-    cd_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".points", points));
   } else if (type == CIRCLE) {
     cd_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("circle"));
-    cd_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "circle"));
 
     cd_->declare_parameter(
       polygon_name + ".radius", rclcpp::ParameterValue(size));
-    cd_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".radius", size));
   } else {  // type == POLYGON_UNKNOWN
     cd_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("unknown"));
-    cd_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "unknown"));
   }
 
   cd_->declare_parameter(
     polygon_name + ".action_type", rclcpp::ParameterValue(at));
-  cd_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".action_type", at));
 
   cd_->declare_parameter(
     polygon_name + ".min_points", rclcpp::ParameterValue(MIN_POINTS));
-  cd_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".min_points", MIN_POINTS));
 
   cd_->declare_parameter(
     polygon_name + ".simulation_time_step", rclcpp::ParameterValue(SIMULATION_TIME_STEP));
-  cd_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".simulation_time_step", SIMULATION_TIME_STEP));
 
   cd_->declare_parameter(
     polygon_name + ".visualize", rclcpp::ParameterValue(false));
-  cd_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".visualize", false));
 
   cd_->declare_parameter(
     polygon_name + ".polygon_pub_topic", rclcpp::ParameterValue(polygon_name));
-  cd_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".polygon_pub_topic", polygon_name));
 }
 
 void Tester::addSource(
@@ -349,57 +319,35 @@ void Tester::addSource(
   if (type == SCAN) {
     cd_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("scan"));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "scan"));
   } else if (type == POINTCLOUD) {
     cd_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("pointcloud"));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "pointcloud"));
 
     cd_->declare_parameter(
       source_name + ".min_height", rclcpp::ParameterValue(0.1));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".min_height", 0.1));
     cd_->declare_parameter(
       source_name + ".max_height", rclcpp::ParameterValue(1.0));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".max_height", 1.0));
   } else if (type == RANGE) {
     cd_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("range"));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "range"));
 
     cd_->declare_parameter(
       source_name + ".obstacles_angle", rclcpp::ParameterValue(M_PI / 200));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".obstacles_angle", M_PI / 200));
   } else if (type == POLYGON_SOURCE) {
     cd_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("polygon"));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "polygon"));
 
     cd_->declare_parameter(
       source_name + ".sampling_distance", rclcpp::ParameterValue(0.1));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".sampling_distance", 0.1));
     cd_->declare_parameter(
       source_name + ".polygon_similarity_threshold", rclcpp::ParameterValue(2.0));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".polygon_similarity_threshold", 2.0));
   } else {  // type == SOURCE_UNKNOWN
     cd_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("unknown"));
-    cd_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "unknown"));
   }
 
   cd_->declare_parameter(
     source_name + ".topic", rclcpp::ParameterValue(source_name));
-  cd_->set_parameter(
-    rclcpp::Parameter(source_name + ".topic", source_name));
 }
 
 void Tester::setVectors(
@@ -407,10 +355,7 @@ void Tester::setVectors(
   const std::vector<std::string> & sources)
 {
   cd_->declare_parameter("polygons", rclcpp::ParameterValue(polygons));
-  cd_->set_parameter(rclcpp::Parameter("polygons", polygons));
-
   cd_->declare_parameter("observation_sources", rclcpp::ParameterValue(sources));
-  cd_->set_parameter(rclcpp::Parameter("observation_sources", sources));
 }
 
 void Tester::sendTransforms(const rclcpp::Time & stamp)
@@ -606,7 +551,6 @@ TEST_F(Tester, testSourcesNotSet)
   cd_->declare_parameter(
     "polygons",
     rclcpp::ParameterValue(std::vector<std::string>{"DetectionRegion"}));
-  cd_->set_parameter(rclcpp::Parameter("polygons", std::vector<std::string>{"DetectionRegion"}));
 
   // Check that Collision Detector node can not be configured for this parameters set
   cd_->cant_configure();

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -306,39 +306,23 @@ void Tester::setCommonParameters()
 
   cm_->declare_parameter(
     "cmd_vel_in_topic", rclcpp::ParameterValue(CMD_VEL_IN_TOPIC));
-  cm_->set_parameter(
-    rclcpp::Parameter("cmd_vel_in_topic", CMD_VEL_IN_TOPIC));
   cm_->declare_parameter(
     "cmd_vel_out_topic", rclcpp::ParameterValue(CMD_VEL_OUT_TOPIC));
-  cm_->set_parameter(
-    rclcpp::Parameter("cmd_vel_out_topic", CMD_VEL_OUT_TOPIC));
   cm_->declare_parameter(
     "state_topic", rclcpp::ParameterValue(STATE_TOPIC));
-  cm_->set_parameter(
-    rclcpp::Parameter("state_topic", STATE_TOPIC));
 
   cm_->declare_parameter(
     "base_frame_id", rclcpp::ParameterValue(BASE_FRAME_ID));
-  cm_->set_parameter(
-    rclcpp::Parameter("base_frame_id", BASE_FRAME_ID));
   cm_->declare_parameter(
     "odom_frame_id", rclcpp::ParameterValue(ODOM_FRAME_ID));
-  cm_->set_parameter(
-    rclcpp::Parameter("odom_frame_id", ODOM_FRAME_ID));
 
   cm_->declare_parameter(
     "transform_tolerance", rclcpp::ParameterValue(TRANSFORM_TOLERANCE));
-  cm_->set_parameter(
-    rclcpp::Parameter("transform_tolerance", TRANSFORM_TOLERANCE));
   cm_->declare_parameter(
     "source_timeout", rclcpp::ParameterValue(SOURCE_TIMEOUT));
-  cm_->set_parameter(
-    rclcpp::Parameter("source_timeout", SOURCE_TIMEOUT));
 
   cm_->declare_parameter(
     "stop_pub_timeout", rclcpp::ParameterValue(STOP_PUB_TIMEOUT));
-  cm_->set_parameter(
-    rclcpp::Parameter("stop_pub_timeout", STOP_PUB_TIMEOUT));
 }
 
 void Tester::addPolygon(
@@ -349,8 +333,6 @@ void Tester::addPolygon(
   if (type == POLYGON) {
     cm_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("polygon"));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "polygon"));
 
     if (at != "approach") {
       const std::string points = "[[" +
@@ -360,95 +342,59 @@ void Tester::addPolygon(
         std::to_string(-size) + ", " + std::to_string(size) + "]]";
       cm_->declare_parameter(
         polygon_name + ".points", rclcpp::ParameterValue(points));
-      cm_->set_parameter(
-        rclcpp::Parameter(polygon_name + ".points", points));
     } else {  // at == "approach"
       cm_->declare_parameter(
         polygon_name + ".footprint_topic", rclcpp::ParameterValue(FOOTPRINT_TOPIC));
-      cm_->set_parameter(
-        rclcpp::Parameter(polygon_name + ".footprint_topic", FOOTPRINT_TOPIC));
     }
   } else if (type == CIRCLE) {
     cm_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("circle"));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "circle"));
 
     cm_->declare_parameter(
       polygon_name + ".radius", rclcpp::ParameterValue(size));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".radius", size));
   } else if (type == VELOCITY_POLYGON) {
     cm_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("velocity_polygon"));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "velocity_polygon"));
     cm_->declare_parameter(
       polygon_name + ".holonomic", rclcpp::ParameterValue(false));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".holonomic", false));
   } else {  // type == POLYGON_UNKNOWN
     cm_->declare_parameter(
       polygon_name + ".type", rclcpp::ParameterValue("unknown"));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".type", "unknown"));
   }
 
   cm_->declare_parameter(
     polygon_name + ".enabled", rclcpp::ParameterValue(true));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".enabled", true));
 
   cm_->declare_parameter(
     polygon_name + ".action_type", rclcpp::ParameterValue(at));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".action_type", at));
 
   cm_->declare_parameter(
     polygon_name + ".min_points", rclcpp::ParameterValue(MIN_POINTS));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".min_points", MIN_POINTS));
 
   cm_->declare_parameter(
     polygon_name + ".slowdown_ratio", rclcpp::ParameterValue(SLOWDOWN_RATIO));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".slowdown_ratio", SLOWDOWN_RATIO));
 
   cm_->declare_parameter(
     polygon_name + ".linear_limit", rclcpp::ParameterValue(LINEAR_LIMIT));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".linear_limit", LINEAR_LIMIT));
 
   cm_->declare_parameter(
     polygon_name + ".angular_limit", rclcpp::ParameterValue(ANGULAR_LIMIT));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".angular_limit", ANGULAR_LIMIT));
 
   cm_->declare_parameter(
     polygon_name + ".time_before_collision", rclcpp::ParameterValue(TIME_BEFORE_COLLISION));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".time_before_collision", TIME_BEFORE_COLLISION));
 
   cm_->declare_parameter(
     polygon_name + ".simulation_time_step", rclcpp::ParameterValue(SIMULATION_TIME_STEP));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".simulation_time_step", SIMULATION_TIME_STEP));
 
   cm_->declare_parameter(
     polygon_name + ".visualize", rclcpp::ParameterValue(false));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".visualize", false));
 
   cm_->declare_parameter(
     polygon_name + ".polygon_pub_topic", rclcpp::ParameterValue(polygon_name));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".polygon_pub_topic", polygon_name));
 
   if (!sources_names.empty()) {
     cm_->declare_parameter(
       polygon_name + ".sources_names", rclcpp::ParameterValue(sources_names));
-    cm_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".sources_names", sources_names));
   }
 }
 
@@ -465,28 +411,18 @@ void Tester::addPolygonVelocitySubPolygon(
     std::to_string(-size) + ", " + std::to_string(size) + "]]";
   cm_->declare_parameter(
     polygon_name + "." + sub_polygon_name + ".points", rclcpp::ParameterValue(points));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".points", points));
 
   cm_->declare_parameter(
     polygon_name + "." + sub_polygon_name + ".linear_min", rclcpp::ParameterValue(linear_min));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".linear_min", linear_min));
 
   cm_->declare_parameter(
     polygon_name + "." + sub_polygon_name + ".linear_max", rclcpp::ParameterValue(linear_max));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".linear_max", linear_max));
 
   cm_->declare_parameter(
     polygon_name + "." + sub_polygon_name + ".theta_min", rclcpp::ParameterValue(theta_min));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".theta_min", theta_min));
 
   cm_->declare_parameter(
     polygon_name + "." + sub_polygon_name + ".theta_max", rclcpp::ParameterValue(theta_max));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".theta_max", theta_max));
 }
 
 void Tester::addSource(
@@ -495,57 +431,35 @@ void Tester::addSource(
   if (type == SCAN) {
     cm_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("scan"));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "scan"));
   } else if (type == POINTCLOUD) {
     cm_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("pointcloud"));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "pointcloud"));
 
     cm_->declare_parameter(
       source_name + ".min_height", rclcpp::ParameterValue(0.1));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".min_height", 0.1));
     cm_->declare_parameter(
       source_name + ".max_height", rclcpp::ParameterValue(1.0));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".max_height", 1.0));
   } else if (type == RANGE) {
     cm_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("range"));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "range"));
 
     cm_->declare_parameter(
       source_name + ".obstacles_angle", rclcpp::ParameterValue(M_PI / 200));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".obstacles_angle", M_PI / 200));
   } else if (type == POLYGON_SOURCE) {
     cm_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("polygon"));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "polygon"));
 
     cm_->declare_parameter(
       source_name + ".sampling_distance", rclcpp::ParameterValue(0.1));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".sampling_distance", 0.1));
     cm_->declare_parameter(
       source_name + ".polygon_similarity_threshold", rclcpp::ParameterValue(2.0));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".polygon_similarity_threshold", 2.0));
   } else {  // type == SOURCE_UNKNOWN
     cm_->declare_parameter(
       source_name + ".type", rclcpp::ParameterValue("unknown"));
-    cm_->set_parameter(
-      rclcpp::Parameter(source_name + ".type", "unknown"));
   }
 
   cm_->declare_parameter(
     source_name + ".topic", rclcpp::ParameterValue(source_name));
-  cm_->set_parameter(
-    rclcpp::Parameter(source_name + ".topic", source_name));
 }
 
 void Tester::setVectors(
@@ -553,10 +467,7 @@ void Tester::setVectors(
   const std::vector<std::string> & sources)
 {
   cm_->declare_parameter("polygons", rclcpp::ParameterValue(polygons));
-  cm_->set_parameter(rclcpp::Parameter("polygons", polygons));
-
   cm_->declare_parameter("observation_sources", rclcpp::ParameterValue(sources));
-  cm_->set_parameter(rclcpp::Parameter("observation_sources", sources));
 }
 
 void Tester::setPolygonVelocityVectors(
@@ -564,7 +475,6 @@ void Tester::setPolygonVelocityVectors(
   const std::vector<std::string> & polygons)
 {
   cm_->declare_parameter(polygon_name + ".velocity_polygons", rclcpp::ParameterValue(polygons));
-  cm_->set_parameter(rclcpp::Parameter(polygon_name + ".velocity_polygons", polygons));
 }
 
 void Tester::sendTransforms(const rclcpp::Time & stamp)
@@ -1576,7 +1486,6 @@ TEST_F(Tester, testSourcesNotSet)
   addPolygon("Stop", POLYGON, 1.0, "stop");
   addSource(SCAN_NAME, SCAN);
   cm_->declare_parameter("polygons", rclcpp::ParameterValue(std::vector<std::string>{"Stop"}));
-  cm_->set_parameter(rclcpp::Parameter("polygons", std::vector<std::string>{"Stop"}));
 
   // Check that Collision Monitor node can not be configured for this parameters set
   cm_->cant_configure();

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -310,60 +310,38 @@ void Tester::setCommonParameters(
 {
   test_node_->declare_parameter(
     polygon_name + ".action_type", rclcpp::ParameterValue(action_type));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".action_type", action_type));
 
   test_node_->declare_parameter(
     polygon_name + ".min_points", rclcpp::ParameterValue(MIN_POINTS));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".min_points", MIN_POINTS));
 
   test_node_->declare_parameter(
     polygon_name + ".slowdown_ratio", rclcpp::ParameterValue(SLOWDOWN_RATIO));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".slowdown_ratio", SLOWDOWN_RATIO));
 
   test_node_->declare_parameter(
     polygon_name + ".linear_limit", rclcpp::ParameterValue(LINEAR_LIMIT));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".linear_limit", LINEAR_LIMIT));
 
   test_node_->declare_parameter(
     polygon_name + ".angular_limit", rclcpp::ParameterValue(ANGULAR_LIMIT));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".angular_limit", ANGULAR_LIMIT));
 
   test_node_->declare_parameter(
     polygon_name + ".time_before_collision",
     rclcpp::ParameterValue(TIME_BEFORE_COLLISION));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".time_before_collision", TIME_BEFORE_COLLISION));
 
   test_node_->declare_parameter(
     polygon_name + ".simulation_time_step", rclcpp::ParameterValue(SIMULATION_TIME_STEP));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".simulation_time_step", SIMULATION_TIME_STEP));
 
   test_node_->declare_parameter(
     polygon_name + ".visualize", rclcpp::ParameterValue(true));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".visualize", true));
 
   test_node_->declare_parameter(
     polygon_name + ".polygon_pub_topic", rclcpp::ParameterValue(POLYGON_PUB_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".polygon_pub_topic", POLYGON_PUB_TOPIC));
 
   test_node_->declare_parameter(
     "observation_sources", rclcpp::ParameterValue(observation_sources));
-  test_node_->set_parameter(
-    rclcpp::Parameter("observation_sources", observation_sources));
 
   if (!sources_names.empty()) {
     test_node_->declare_parameter(
       polygon_name + ".sources_names", rclcpp::ParameterValue(sources_names));
-    test_node_->set_parameter(
-      rclcpp::Parameter(polygon_name + ".sources_names", sources_names));
   }
 }
 
@@ -373,18 +351,12 @@ void Tester::setPolygonParameters(
   if (is_static) {
     test_node_->declare_parameter(
       std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(points));
-    test_node_->set_parameter(
-      rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", points));
   } else {
     test_node_->declare_parameter(
       std::string(POLYGON_NAME) + ".polygon_sub_topic", rclcpp::ParameterValue(POLYGON_SUB_TOPIC));
-    test_node_->set_parameter(
-      rclcpp::Parameter(std::string(POLYGON_NAME) + ".polygon_sub_topic", POLYGON_SUB_TOPIC));
 
     test_node_->declare_parameter(
       std::string(POLYGON_NAME) + ".footprint_topic", rclcpp::ParameterValue(FOOTPRINT_TOPIC));
-    test_node_->set_parameter(
-      rclcpp::Parameter(std::string(POLYGON_NAME) + ".footprint_topic", FOOTPRINT_TOPIC));
   }
 }
 
@@ -393,13 +365,9 @@ void Tester::setCircleParameters(const double radius, const bool is_static)
   if (is_static) {
     test_node_->declare_parameter(
       std::string(CIRCLE_NAME) + ".radius", rclcpp::ParameterValue(radius));
-    test_node_->set_parameter(
-      rclcpp::Parameter(std::string(CIRCLE_NAME) + ".radius", radius));
   } else {
     test_node_->declare_parameter(
       std::string(CIRCLE_NAME) + ".polygon_sub_topic", rclcpp::ParameterValue(POLYGON_SUB_TOPIC));
-    test_node_->set_parameter(
-      rclcpp::Parameter(std::string(CIRCLE_NAME) + ".polygon_sub_topic", POLYGON_SUB_TOPIC));
   }
 }
 
@@ -625,8 +593,6 @@ TEST_F(Tester, testPolygonUndeclaredPoints)
   // "points" and "polygon_sub_topic" parameters are not initialized
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".action_type", rclcpp::ParameterValue("stop"));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".action_type", "stop"));
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,
     tf_buffer_, BASE_FRAME_ID, TRANSFORM_TOLERANCE);
@@ -654,8 +620,6 @@ TEST_F(Tester, testPolygonIncorrectPoints1)
   // Triangle points
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(INCORRECT_POINTS_1_STR));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", INCORRECT_POINTS_1_STR));
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,
@@ -670,8 +634,6 @@ TEST_F(Tester, testPolygonIncorrectPoints2)
   // Odd number of elements
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(INCORRECT_POINTS_2_STR));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", INCORRECT_POINTS_2_STR));
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,
@@ -688,8 +650,6 @@ TEST_F(Tester, testPolygonMaxPoints)
   const int max_points = 5;
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".max_points", rclcpp::ParameterValue(max_points));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".max_points", max_points));
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,
@@ -989,11 +949,8 @@ TEST_F(Tester, testPolygonDefaultVisualize)
   // Use default parameters, visualize should be false by-default
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".action_type", rclcpp::ParameterValue("stop"));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".action_type", "stop"));
   std::vector<std::string> observation_sources = {OBSERVATION_SOURCE_NAME};
   test_node_->declare_parameter("observation_sources", rclcpp::ParameterValue(observation_sources));
-  test_node_->set_parameter(rclcpp::Parameter("observation_sources", observation_sources));
   setPolygonParameters(SQUARE_POLYGON_STR, true);
 
   // Create new polygon
@@ -1017,8 +974,6 @@ TEST_F(Tester, testPolygonInvalidPointsString)
   // Invalid points
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(INVALID_POINTS_STR));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", INVALID_POINTS_STR));
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,

--- a/nav2_collision_monitor/test/sources_test.cpp
+++ b/nav2_collision_monitor/test/sources_test.cpp
@@ -410,8 +410,6 @@ void Tester::createSources(const bool base_shift_correction)
   // Create Scan object
   test_node_->declare_parameter(
     std::string(SCAN_NAME) + ".topic", rclcpp::ParameterValue(SCAN_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(SCAN_NAME) + ".topic", SCAN_TOPIC));
 
   scan_ = std::make_shared<ScanWrapper>(
     test_node_, SCAN_NAME, tf_buffer_,
@@ -422,16 +420,10 @@ void Tester::createSources(const bool base_shift_correction)
   // Create PointCloud object
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".topic", rclcpp::ParameterValue(POINTCLOUD_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".topic", POINTCLOUD_TOPIC));
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".min_height", rclcpp::ParameterValue(0.1));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".min_height", 0.1));
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".max_height", rclcpp::ParameterValue(1.0));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".max_height", 1.0));
 
   pointcloud_ = std::make_shared<PointCloudWrapper>(
     test_node_, POINTCLOUD_NAME, tf_buffer_,
@@ -442,8 +434,6 @@ void Tester::createSources(const bool base_shift_correction)
   // Create Range object
   test_node_->declare_parameter(
     std::string(RANGE_NAME) + ".topic", rclcpp::ParameterValue(RANGE_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(RANGE_NAME) + ".topic", RANGE_TOPIC));
 
   test_node_->declare_parameter(
     std::string(RANGE_NAME) + ".obstacles_angle", rclcpp::ParameterValue(M_PI / 199));
@@ -457,8 +447,6 @@ void Tester::createSources(const bool base_shift_correction)
   // Create Polygon object
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".topic", rclcpp::ParameterValue(POLYGON_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".topic", POLYGON_TOPIC));
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".sampling_distance", rclcpp::ParameterValue(0.1));
@@ -807,20 +795,12 @@ TEST_F(Tester, testPointCloudMinRange)
   // Create PointCloud object with min_range = 0.2
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".topic", rclcpp::ParameterValue(POINTCLOUD_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".topic", POINTCLOUD_TOPIC));
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".min_height", rclcpp::ParameterValue(0.1));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".min_height", 0.1));
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".max_height", rclcpp::ParameterValue(1.0));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".max_height", 1.0));
   test_node_->declare_parameter(
     std::string(POINTCLOUD_NAME) + ".min_range", rclcpp::ParameterValue(0.16));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POINTCLOUD_NAME) + ".min_range", 0.16));
 
   pointcloud_ = std::make_shared<PointCloudWrapper>(
     test_node_, POINTCLOUD_NAME, tf_buffer_,

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -188,37 +188,25 @@ void Tester::setCommonParameters(const std::string & polygon_name, const std::st
 {
   test_node_->declare_parameter(
     polygon_name + ".action_type", rclcpp::ParameterValue(action_type));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".action_type", action_type));
 
   test_node_->declare_parameter(
     polygon_name + ".min_points", rclcpp::ParameterValue(MIN_POINTS));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".min_points", MIN_POINTS));
 
   test_node_->declare_parameter(
     polygon_name + ".visualize", rclcpp::ParameterValue(true));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".visualize", true));
 
   test_node_->declare_parameter(
     polygon_name + ".polygon_pub_topic", rclcpp::ParameterValue(POLYGON_PUB_TOPIC));
-  test_node_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".polygon_pub_topic", POLYGON_PUB_TOPIC));
 
   std::vector<std::string> default_observation_sources = {"source"};
   test_node_->declare_parameter(
     "observation_sources", rclcpp::ParameterValue(default_observation_sources));
-  test_node_->set_parameter(
-    rclcpp::Parameter("observation_sources", default_observation_sources));
 }
 
 void Tester::setVelocityPolygonParameters(const bool is_holonomic)
 {
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".holonomic", rclcpp::ParameterValue(is_holonomic));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".holonomic", is_holonomic));
 
   std::vector<std::string> velocity_polygons =
   {SUB_POLYGON_FORWARD_NAME, SUB_POLYGON_BACKWARD_NAME};
@@ -268,8 +256,6 @@ void Tester::setVelocityPolygonParameters(const bool is_holonomic)
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".velocity_polygons", rclcpp::ParameterValue(velocity_polygons));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".velocity_polygons", velocity_polygons));
 }
 
 void Tester::addPolygonVelocitySubPolygon(
@@ -282,48 +268,22 @@ void Tester::addPolygonVelocitySubPolygon(
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".points",
     rclcpp::ParameterValue(polygon_points));
-  test_node_->set_parameter(
-    rclcpp::Parameter(
-      std::string(
-        POLYGON_NAME) +
-      "." + sub_polygon_name + ".points",
-      polygon_points));
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".linear_min",
     rclcpp::ParameterValue(linear_min));
-  test_node_->set_parameter(
-    rclcpp::Parameter(
-      std::string(
-        POLYGON_NAME) +
-      "." + sub_polygon_name + ".linear_min",
-      linear_min));
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".linear_max",
     rclcpp::ParameterValue(linear_max));
-  test_node_->set_parameter(
-    rclcpp::Parameter(
-      std::string(
-        POLYGON_NAME) +
-      "." + sub_polygon_name + ".linear_max",
-      linear_max));
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".theta_min",
     rclcpp::ParameterValue(theta_min));
-  test_node_->set_parameter(
-    rclcpp::Parameter(
-      std::string(POLYGON_NAME) + "." + sub_polygon_name + ".theta_min",
-      theta_min));
 
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".theta_max",
     rclcpp::ParameterValue(theta_max));
-  test_node_->set_parameter(
-    rclcpp::Parameter(
-      std::string(POLYGON_NAME) + "." + sub_polygon_name + ".theta_max",
-      theta_max));
 
   if (is_holonomic) {
     test_node_->declare_parameter(
@@ -331,21 +291,12 @@ void Tester::addPolygonVelocitySubPolygon(
         POLYGON_NAME) +
       "." + sub_polygon_name + ".direction_end_angle",
       rclcpp::ParameterValue(direction_end_angle));
-    test_node_->set_parameter(
-      rclcpp::Parameter(
-        std::string(POLYGON_NAME) + "." + sub_polygon_name + ".direction_end_angle",
-        direction_end_angle));
 
     test_node_->declare_parameter(
       std::string(
         POLYGON_NAME) +
       "." + sub_polygon_name + ".direction_start_angle",
       rclcpp::ParameterValue(direction_start_angle));
-    test_node_->set_parameter(
-      rclcpp::Parameter(
-        std::string(POLYGON_NAME) + "." + sub_polygon_name +
-        ".direction_start_angle",
-        direction_start_angle));
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5299  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | N/A |

---

## Description of contribution in a few bullet points

* Migrated the `get_parameter` and `declare_parameter` fields to use the new `declare_or_get_parameter` API for nav2_collision_monitor.
* There are a bunch of `declare_parameter_if_not_declared` functions still left that are **not ported**, as these are declared with **no default value**. In addition, the codebase is created to raise exceptions when the default value is not assigned to these parameters.

   For instance:
   
   ```cpp
   // Leave it not initialized: the will cause an error if it will not set
   nav2::declare_parameter_if_not_declared(
     node, polygon_name_ + ".radius", rclcpp::PARAMETER_DOUBLE);
   radius_ = node->get_parameter(polygon_name_ + ".radius").as_double();
   ```
* Removed redundant `set_parameter()` calls when preceeded by `declare_parameter`.


## Description of documentation updates required from your changes

* N/A

## Description of how this change was tested

* Performed linting validation using `pre-commit run --all` and testing locally using `colcon test`

---

## Future work that may be required in bullet points

* N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
