### PR TITLE
Remove mypy and switch to precommit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,43 +2,42 @@ name: Lint
 on:
   pull_request:
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
-  ament_lint_general:
-    name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
-    strategy:
-      fail-fast: false
-      matrix:
-          linter: [xmllint, cpplint, uncrustify, pep257, flake8, mypy]
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Install typeshed for mypy
-      if: matrix.linter == 'mypy'
-      run: sudo apt update && sudo apt install -y python3-typeshed
-
-    - uses: ros-tooling/action-ros-lint@0.1.4
-      with:
-        linter: ${{ matrix.linter }}
-        distribution: rolling
-        package-name: "*"
-        arguments: ${{ matrix.linter == 'mypy' && '--config tools/pyproject.toml' || '' }}
-
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ros-navigation/navigation2:main
+    env:
+      repo_path: src/${{ github.repository }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-      - uses: pre-commit/action@v3.0.1
-        env:
-          SKIP: >-
-            ament_lint_cmake,
-            ament_cpplint,
-            ament_uncrustify,
-            ament_xmllint,
-            ament_flake8,
-            ament_pep257,
-            ament_mypy
+        with:
+          path: ${{ env.repo_path }}
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pre-commit
+            .venv
+          key: pre-commit-3|${{ env.repo_path }}|${{ hashFiles(format('{0}/.pre-commit-config.yaml', env.repo_path)) }}
+
+      - name: Install pre-commit
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install pre-commit
+
+      - name: Run pre-commit
+        run: |
+          source .venv/bin/activate
+          source /opt/ros/rolling/setup.bash
+          cd ${{ env.repo_path }}
+          pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,14 +33,14 @@ repos:
         exclude_types: [rst]
       - id: fix-byte-order-marker
 -   repo: https://github.com/pycqa/isort
-    rev: 9.0.0a3
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["tools/pyproject.toml"]
         name: isort (python)
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.1
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -48,7 +48,7 @@ repos:
         args:
             [--toml=./tools/pyproject.toml]
 -   repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 0.31.1
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 exclude: ".pgm$|.svg$"
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -33,14 +33,14 @@ repos:
         exclude_types: [rst]
       - id: fix-byte-order-marker
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 9.0.0a3
     hooks:
       - id: isort
         args: ["tools/pyproject.toml"]
         name: isort (python)
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -48,7 +48,7 @@ repos:
         args:
             [--toml=./tools/pyproject.toml]
 -   repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.31.1
+    rev: 0.37.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
@@ -96,11 +96,3 @@ repos:
         language: system
         types: [python]
         entry: ament_pep257
-    # Commented out until https://github.com/ros-navigation/navigation2/issues/5830 is fixed
-    # -   id: ament_mypy
-    #     name: ament_mypy
-    #     description: Check Python code style using mypy.
-    #     language: system
-    #     types: [python]
-    #     args: ["--config", "tools/pyproject.toml"]
-    #     entry: ament_mypy

--- a/nav2_bringup/package.xml
+++ b/nav2_bringup/package.xml
@@ -32,7 +32,6 @@
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_mypy</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch</test_depend>

--- a/nav2_common/package.xml
+++ b/nav2_common/package.xml
@@ -27,7 +27,6 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_mypy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_simple_commander/package.xml
+++ b/nav2_simple_commander/package.xml
@@ -15,7 +15,6 @@
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_mypy</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>


### PR DESCRIPTION
Based on my analysis in https://github.com/ros-navigation/navigation2/issues/5830#issuecomment-3699569808, the base image currently used for linting was last updated ~6 months ago. This leads to inconsistent results between CI linting and running pre-commit locally. https://github.com/ros-navigation/navigation2/pull/5322, https://github.com/ros-navigation/navigation2/pull/5280, https://github.com/ros-navigation/navigation2/pull/5382, #5575 tried to fix mypy-related issues, but some of those fixes may be partially incorrect due to the outdated mypy version in CI.

This PR switches linting to use our own images to ensure they stay up to date and resolves https://github.com/ros-navigation/navigation2/issues/5830.