### PR TITLE
Fix line of sight check computation for theta* planner

### DIFF
--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -176,28 +176,31 @@ void ThetaStar::backtrace(std::vector<coordsW> & raw_points, const tree_node * c
   }
 }
 
-bool ThetaStar::losCheck(const int & x0, const int & y0, const int & x1, const int & y1, double & sl_cost) const {
+bool ThetaStar::losCheck(
+  const int & x0, const int & y0, const int & x1, const int & y1,
+  double & sl_cost) const
+{
   sl_cost = 0;
-  
+
   int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
   int dy = abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
-  int cx = x0, cy = y0, f = (dx >= dy) ? - dx / 2 : - dy / 2;
+  int cx = x0, cy = y0, f = (dx >= dy) ? -dx / 2 : -dy / 2;
 
   if (!isSafe(cx, cy)) {
     return false;
   }
-  
+
   if (dx >= dy) {
-    for (int i = 0; i <= dx; i++) {
+    for (int i = 0; i < dx; i++) {
       f += dy;
-      if (f > 0) {        
+      if (f > 0) {
         if (!isSafe(cx + sx, cy)) {
           return false;
         }
         if (!isSafe(cx, cy + sy)) {
           return false;
         }
-        
+
         cx += sx;
         cy += sy;
         f -= dx;
@@ -210,7 +213,7 @@ bool ThetaStar::losCheck(const int & x0, const int & y0, const int & x1, const i
       }
     }
   } else {
-    for (int i = 0; i <= dy; i++) {
+    for (int i = 0; i < dy; i++) {
       f += dx;
       if (f > 0) {
         if (!isSafe(cx + sx, cy)) {
@@ -219,7 +222,7 @@ bool ThetaStar::losCheck(const int & x0, const int & y0, const int & x1, const i
         if (!isSafe(cx, cy + sy)) {
           return false;
         }
-        
+
         cx += sx;
         cy += sy;
         f -= dy;
@@ -235,7 +238,6 @@ bool ThetaStar::losCheck(const int & x0, const int & y0, const int & x1, const i
 
   return true;
 }
-
 
 void ThetaStar::resetContainers()
 {

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -176,62 +176,66 @@ void ThetaStar::backtrace(std::vector<coordsW> & raw_points, const tree_node * c
   }
 }
 
-bool ThetaStar::losCheck(
-  const int & x0, const int & y0, const int & x1, const int & y1,
-  double & sl_cost) const
-{
+bool ThetaStar::losCheck(const int & x0, const int & y0, const int & x1, const int & y1, double & sl_cost) const {
   sl_cost = 0;
+  
+  int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
+  int dy = abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
+  int cx = x0, cy = y0, f = (dx >= dy) ? - dx / 2 : - dy / 2;
 
-  int cx, cy;
-  int dy = abs(y1 - y0), dx = abs(x1 - x0), f = 0;
-  int sx, sy;
-  sx = x1 > x0 ? 1 : -1;
-  sy = y1 > y0 ? 1 : -1;
-
-  int u_x = (sx - 1) / 2;
-  int u_y = (sy - 1) / 2;
-  cx = x0;
-  cy = y0;
-
+  if (!isSafe(cx, cy)) {
+    return false;
+  }
+  
   if (dx >= dy) {
-    while (cx != x1) {
+    for (int i = 0; i <= dx; i++) {
       f += dy;
-      if (f >= dx) {
-        if (!isSafe(cx + u_x, cy + u_y, sl_cost)) {
+      if (f > 0) {        
+        if (!isSafe(cx + sx, cy)) {
           return false;
         }
+        if (!isSafe(cx, cy + sy)) {
+          return false;
+        }
+        
+        cx += sx;
         cy += sy;
         f -= dx;
+      } else {
+        cx += sx;
       }
-      if (f != 0 && !isSafe(cx + u_x, cy + u_y, sl_cost)) {
+
+      if (!isSafe(cx, cy, sl_cost)) {
         return false;
       }
-      if (dy == 0 && !isSafe(cx + u_x, cy, sl_cost) && !isSafe(cx + u_x, cy - 1, sl_cost)) {
-        return false;
-      }
-      cx += sx;
     }
   } else {
-    while (cy != y1) {
-      f = f + dx;
-      if (f >= dy) {
-        if (!isSafe(cx + u_x, cy + u_y, sl_cost)) {
+    for (int i = 0; i <= dy; i++) {
+      f += dx;
+      if (f > 0) {
+        if (!isSafe(cx + sx, cy)) {
           return false;
         }
+        if (!isSafe(cx, cy + sy)) {
+          return false;
+        }
+        
         cx += sx;
+        cy += sy;
         f -= dy;
+      } else {
+        cy += sy;
       }
-      if (f != 0 && !isSafe(cx + u_x, cy + u_y, sl_cost)) {
+
+      if (!isSafe(cx, cy, sl_cost)) {
         return false;
       }
-      if (dx == 0 && !isSafe(cx, cy + u_y, sl_cost) && !isSafe(cx - 1, cy + u_y, sl_cost)) {
-        return false;
-      }
-      cy += sy;
     }
   }
+
   return true;
 }
+
 
 void ThetaStar::resetContainers()
 {

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -184,56 +184,31 @@ bool ThetaStar::losCheck(
 
   int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
   int dy = abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
-  int cx = x0, cy = y0, f = (dx >= dy) ? -dx / 2 : -dy / 2;
+  int cx = x0, cy = y0, e = dx - dy;
 
-  if (!isSafe(cx, cy)) {
-    return false;
+  while (cx != x1 || cy != y1) {
+    if (!isSafe(cx, cy, sl_cost)) {
+      return false;
+    }
+    int e2 = 2 * e;
+    if (e2 > -dy && e2 < dx) {
+      if (!isSafe(cx + sx, cy) || !isSafe(cx, cy + sy)) {
+        return false;
+      }
+      cx += sx;
+      cy += sy;
+      e += dx - dy;
+    } else if (e2 > -dy) {
+      cx += sx;
+      e -= dy;
+    } else {
+      cy += sy;
+      e += dx;
+    }
   }
 
-  if (dx >= dy) {
-    for (int i = 0; i < dx; i++) {
-      f += dy;
-      if (f > 0) {
-        if (!isSafe(cx + sx, cy)) {
-          return false;
-        }
-        if (!isSafe(cx, cy + sy)) {
-          return false;
-        }
-
-        cx += sx;
-        cy += sy;
-        f -= dx;
-      } else {
-        cx += sx;
-      }
-
-      if (!isSafe(cx, cy, sl_cost)) {
-        return false;
-      }
-    }
-  } else {
-    for (int i = 0; i < dy; i++) {
-      f += dx;
-      if (f > 0) {
-        if (!isSafe(cx + sx, cy)) {
-          return false;
-        }
-        if (!isSafe(cx, cy + sy)) {
-          return false;
-        }
-
-        cx += sx;
-        cy += sy;
-        f -= dy;
-      } else {
-        cy += sy;
-      }
-
-      if (!isSafe(cx, cy, sl_cost)) {
-        return false;
-      }
-    }
+  if (!isSafe(cx, cy, sl_cost)) {
+    return false;
   }
 
   return true;

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -191,7 +191,7 @@ bool ThetaStar::losCheck(
       return false;
     }
     int e2 = 2 * e;
-    if (e2 > -dy && e2 < dx) {
+    if (e2 > -dy && e2 <= dx) {
       if (!isSafe(cx + sx, cy) || !isSafe(cx, cy + sy)) {
         return false;
       }
@@ -205,10 +205,6 @@ bool ThetaStar::losCheck(
       cy += sy;
       e += dx;
     }
-  }
-
-  if (!isSafe(cx, cy, sl_cost)) {
-    return false;
   }
 
   return true;


### PR DESCRIPTION
## Basic Info

| Info | |
| ------ | ----------- |
| Ticket(s) this addresses   | #5863 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed how the `losCheck` function performs line of sight checks in `nav2_theta_star_planner/src/theta_star.cpp`.
* Slightly improved overall readability of the `losCheck` function.
* No changes to `nav2_theta_star_planner/src/theta_star_planner.cpp`.
* No changes to header files.

## Description of documentation updates required from your changes

* None

## Description of how this change was tested

* Built `navigation2` from source code (`humble_main` branch), including package `nav2_theta_star_planner`, using `colcon build`.
* Tested package `nav2_theta_star_planner` on Ubuntu 22.04 + ROS2 Humble.
  * `colcon test --packages-select nav2_theta_star_planner`:
    ```
    Starting >>> nav2_theta_star_planner
    Finished <<< nav2_theta_star_planner [0.26s]          
    
    Summary: 1 package finished [0.41s]
    ```
  * `colcon test-result --verbose`:
    ```
    Summary: 4 tests, 0 errors, 0 failures, 0 skipped
    ```

---

## Future work that may be required in bullet points

* Maybe consider validating unit tests to check whether they cover all appropriate scenarios.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
