### PR TITLE
nav2_mppi_controller: add optional LP-MPPI-style low-pass perturbation sampling (paper-based, unofficial)

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -154,6 +154,9 @@ controller_server:
       visualize: true
       publish_optimal_trajectory: true
       regenerate_noises: true
+      use_low_pass_filter: false
+      filter_cutoff_frequency: 2.0
+      filter_order: 2
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -58,6 +58,10 @@ This process is then repeated a number of times and returns a converged solution
  | visualize                  | bool   | Default: false. Publish visualization of trajectories, which can slow down the controller significantly. Use only for debugging.                                                                                                                                       |
  | retry_attempt_limit        | int    | Default 1. Number of attempts to find feasible trajectory on failure for soft-resets before reporting failure.                                                                                                                                                                                                       |
  | regenerate_noises          | bool   | Default false. Whether to regenerate noises each iteration or use single noise distribution computed on initialization and reset. Practically, this is found to work fine since the trajectories are being sampled stochastically from a normal distribution and reduces compute jittering at run-time due to thread wake-ups to resample normal distribution. |
+ <!-- AI-generated contribution marker: LP-MPPI parameter documentation additions below (`use_low_pass_filter`, `filter_cutoff_frequency`, `filter_order`) were added with AI assistance. -->
+ | use_low_pass_filter        | bool   | Default false. If true, apply a Butterworth low-pass filter to sampled control perturbations before adding them to the nominal control sequence (LP-MPPI-style sampling). |
+ | filter_cutoff_frequency    | double | Default 2.0. Cutoff frequency (Hz) of the perturbation low-pass filter. Must be in (0, Nyquist), where Nyquist = 1 / (2 * model_dt). Values above Nyquist are clamped with a warning. |
+ | filter_order               | int    | Default 2. Order of the Butterworth low-pass filter for perturbation sampling. Higher order increases attenuation above cutoff. |
  | publish_optimal_trajectory | bool   | Publishes the full optimal trajectory sequence each control iteration for downstream  control systems, collision checkers, etc to have context beyond the next timestep. |
  | publish_critics_stats      | bool   | Default false. Whether to publish statistics about each critic's performance. When enabled, publishes a `nav2_msgs::msg::CriticsStats` message containing critic names, whether they changed costs, and the sum of costs added by each critic. Useful for debugging and tuning critic behavior. |
  | open_loop        | bool    | Default false. Useful when using low accelerations and when wheel odometry's latency causes issues in initial state estimation. |
@@ -200,6 +204,9 @@ controller_server:
       gamma: 0.015
       motion_model: "DiffDrive"
       visualize: false
+      use_low_pass_filter: false
+      filter_cutoff_frequency: 2.0
+      filter_order: 2
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
@@ -23,8 +23,10 @@
 #include <mutex>
 #include <condition_variable>
 #include <random>
+#include <vector>
 
 #include "nav2_ros_common/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "nav2_mppi_controller/models/optimizer_settings.hpp"
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 #include "nav2_mppi_controller/models/control_sequence.hpp"
@@ -81,6 +83,25 @@ public:
   void reset(mppi::models::OptimizerSettings & settings, bool is_holonomic);
 
 protected:
+  // AI-generated contribution marker:
+  // LP-MPPI low-pass perturbation sampling interfaces below were added with AI assistance.
+  /**
+   * @brief Configure optional low-pass filtering of sampled perturbations
+   */
+  void configureLowPassFilter();
+
+  /**
+   * @brief Design digital Butterworth low-pass filter coefficients
+   * @return True on successful design, false if configuration is invalid
+   */
+  bool designButterworthLowPass();
+
+  /**
+   * @brief Apply configured low-pass filter over time axis for each sampled trajectory row
+   * @param signal Matrix in shape [batch_size, time_steps]
+   */
+  void applyLowPassFilter(Eigen::ArrayXXf & signal) const;
+
   /**
    * @brief Thread to execute noise generation process
    */
@@ -111,6 +132,18 @@ protected:
   std::condition_variable noise_cond_;
   std::mutex noise_lock_;
   bool active_{false}, ready_{false}, regenerate_noises_{false};
+
+  // AI-generated contribution marker:
+  // LP-MPPI low-pass perturbation sampling state below was added with AI assistance.
+  // Optional LP-MPPI sampling filter configuration.
+  bool use_low_pass_filter_{false};
+  double filter_cutoff_frequency_{0.0};
+  int filter_order_{2};
+  std::vector<double> lpf_a_;
+  std::vector<double> lpf_b_;
+  bool lpf_configured_{false};
+
+  rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/src/noise_generator.cpp
+++ b/nav2_mppi_controller/src/noise_generator.cpp
@@ -14,8 +14,14 @@
 
 #include "nav2_mppi_controller/tools/noise_generator.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
 #include <memory>
 #include <mutex>
+#include <numeric>
+#include <vector>
 
 namespace mppi
 {
@@ -34,6 +40,13 @@ void NoiseGenerator::initialize(
 
   auto getParam = param_handler->getParamGetter(name);
   getParam(regenerate_noises_, "regenerate_noises", false);
+  getParam(use_low_pass_filter_, "use_low_pass_filter", false, ParameterType::Static);
+  getParam(
+    filter_cutoff_frequency_, "filter_cutoff_frequency", 2.0,
+    ParameterType::Static);
+  getParam(filter_order_, "filter_order", 2, ParameterType::Static);
+
+  configureLowPassFilter();
 
   if (regenerate_noises_) {
     noise_thread_ = std::thread(std::bind(&NoiseGenerator::noiseThread, this));
@@ -78,6 +91,10 @@ void NoiseGenerator::reset(mppi::models::OptimizerSettings & settings, bool is_h
 {
   settings_ = settings;
   is_holonomic_ = is_holonomic;
+  ndistribution_vx_ = std::normal_distribution(0.0f, settings_.sampling_std.vx);
+  ndistribution_vy_ = std::normal_distribution(0.0f, settings_.sampling_std.vy);
+  ndistribution_wz_ = std::normal_distribution(0.0f, settings_.sampling_std.wz);
+  configureLowPassFilter();
 
   // Recompute the noises on reset, initialization, and fallback
   {
@@ -115,6 +132,186 @@ void NoiseGenerator::generateNoisedControls()
   if (is_holonomic_) {
     noises_vy_ = Eigen::ArrayXXf::NullaryExpr(
       s.batch_size, s.time_steps, [&]() {return ndistribution_vy_(generator_);});
+  }
+
+  if (lpf_configured_) {
+    applyLowPassFilter(noises_vx_);
+    applyLowPassFilter(noises_wz_);
+    if (is_holonomic_) {
+      applyLowPassFilter(noises_vy_);
+    }
+  }
+}
+
+void NoiseGenerator::configureLowPassFilter()
+{
+  lpf_configured_ = false;
+  lpf_a_.clear();
+  lpf_b_.clear();
+
+  if (!use_low_pass_filter_) {
+    return;
+  }
+
+  if (settings_.model_dt <= 0.0f) {
+    RCLCPP_WARN(
+      logger_,
+      "Low-pass filter disabled: model_dt must be > 0, got %.6f",
+      settings_.model_dt);
+    return;
+  }
+
+  const double fs = 1.0 / static_cast<double>(settings_.model_dt);
+  const double nyquist = 0.5 * fs;
+
+  if (filter_cutoff_frequency_ <= 0.0) {
+    RCLCPP_WARN(
+      logger_,
+      "Low-pass filter disabled: filter_cutoff_frequency must be > 0, got %.6f",
+      filter_cutoff_frequency_);
+    return;
+  }
+
+  if (filter_order_ < 1) {
+    RCLCPP_WARN(
+      logger_,
+      "Low-pass filter disabled: filter_order must be >= 1, got %d",
+      filter_order_);
+    return;
+  }
+
+  if (filter_cutoff_frequency_ >= nyquist) {
+    const double clamped = std::max(
+      std::nextafter(nyquist, 0.0),
+      nyquist * 0.99);
+    RCLCPP_WARN(
+      logger_,
+      "filter_cutoff_frequency %.6f Hz is >= Nyquist %.6f Hz. Clamping to %.6f Hz.",
+      filter_cutoff_frequency_, nyquist, clamped);
+    filter_cutoff_frequency_ = clamped;
+  }
+
+  if (!designButterworthLowPass()) {
+    RCLCPP_WARN(logger_, "Low-pass filter disabled: failed to design coefficients.");
+    return;
+  }
+
+  lpf_configured_ = true;
+}
+
+bool NoiseGenerator::designButterworthLowPass()
+{
+  const int order_i = filter_order_;
+  if (order_i < 1) {
+    return false;
+  }
+  const size_t order = static_cast<size_t>(order_i);
+
+  const double fs = 1.0 / static_cast<double>(settings_.model_dt);
+  const double pi = std::acos(-1.0);
+  const double omega_c = 2.0 * fs * std::tan(pi * filter_cutoff_frequency_ / fs);
+
+  if (!std::isfinite(omega_c) || omega_c <= 0.0) {
+    return false;
+  }
+
+  std::vector<std::complex<double>> z_poles;
+  z_poles.reserve(order);
+
+  for (int k = 0; k < order_i; ++k) {
+    const double theta = pi * (2.0 * static_cast<double>(k) + 1.0 + order_i) /
+      (2.0 * static_cast<double>(order_i));
+    const std::complex<double> s_pole = omega_c * std::exp(std::complex<double>(0.0, theta));
+    const std::complex<double> z_pole = (2.0 * fs + s_pole) / (2.0 * fs - s_pole);
+    z_poles.push_back(z_pole);
+  }
+
+  // Denominator A(z^-1) = Π (1 - z_pole * z^-1)
+  std::vector<std::complex<double>> a_poly(1, std::complex<double>(1.0, 0.0));
+  for (const auto & pole : z_poles) {
+    std::vector<std::complex<double>> next(a_poly.size() + 1, std::complex<double>(0.0, 0.0));
+    for (size_t i = 0; i < a_poly.size(); ++i) {
+      next[i] += a_poly[i];
+      next[i + 1] -= a_poly[i] * pole;
+    }
+    a_poly = std::move(next);
+  }
+
+  lpf_a_.resize(a_poly.size());
+  for (size_t i = 0; i < a_poly.size(); ++i) {
+    lpf_a_[i] = a_poly[i].real();
+  }
+
+  // Numerator B(z^-1) = K * (1 + z^-1)^order
+  std::vector<double> b_poly(1, 1.0);
+  b_poly.resize(order + 1, 0.0);
+  for (int i = 1; i <= order_i; ++i) {
+    for (int j = i; j > 0; --j) {
+      b_poly[static_cast<size_t>(j)] += b_poly[static_cast<size_t>(j - 1)];
+    }
+  }
+
+  const double sum_a = std::accumulate(lpf_a_.begin(), lpf_a_.end(), 0.0);
+  const double sum_b = std::accumulate(b_poly.begin(), b_poly.end(), 0.0);
+  if (std::abs(sum_b) < std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  const double dc_gain = sum_a / sum_b;
+  lpf_b_.resize(b_poly.size());
+  for (size_t i = 0; i < b_poly.size(); ++i) {
+    lpf_b_[i] = b_poly[i] * dc_gain;
+  }
+
+  if (std::abs(lpf_a_.front()) < std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  // Normalize by a0 for direct-form implementation.
+  const double a0 = lpf_a_.front();
+  for (auto & a : lpf_a_) {
+    a /= a0;
+  }
+  for (auto & b : lpf_b_) {
+    b /= a0;
+  }
+
+  return true;
+}
+
+void NoiseGenerator::applyLowPassFilter(Eigen::ArrayXXf & signal) const
+{
+  if (!lpf_configured_) {
+    return;
+  }
+
+  const size_t order = static_cast<size_t>(filter_order_);
+  std::vector<double> x_hist(order + 1, 0.0);
+  std::vector<double> y_hist(order + 1, 0.0);
+
+  for (int row = 0; row < signal.rows(); ++row) {
+    std::fill(x_hist.begin(), x_hist.end(), 0.0);
+    std::fill(y_hist.begin(), y_hist.end(), 0.0);
+
+    for (int col = 0; col < signal.cols(); ++col) {
+      for (size_t idx = order; idx > 0; --idx) {
+        x_hist[idx] = x_hist[idx - 1];
+        y_hist[idx] = y_hist[idx - 1];
+      }
+
+      x_hist[0] = static_cast<double>(signal(row, col));
+
+      double y = 0.0;
+      for (size_t idx = 0; idx <= order; ++idx) {
+        y += lpf_b_[idx] * x_hist[idx];
+      }
+      for (size_t idx = 1; idx <= order; ++idx) {
+        y -= lpf_a_[idx] * y_hist[idx];
+      }
+
+      y_hist[0] = y;
+      signal(row, col) = static_cast<float>(y);
+    }
   }
 }
 

--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -27,6 +29,52 @@
 // Tests noise generator object
 
 using namespace mppi;  // NOLINT
+
+// AI-generated contribution marker:
+// LP-MPPI-focused helpers and tests below were added with AI assistance.
+class NoiseGeneratorTester : public NoiseGenerator
+{
+public:
+  void setFilterInputsForTest(float model_dt, double cutoff_hz, int order)
+  {
+    settings_.model_dt = model_dt;
+    filter_cutoff_frequency_ = cutoff_hz;
+    filter_order_ = order;
+  }
+
+  bool designLowPassForTest()
+  {
+    return designButterworthLowPass();
+  }
+
+  double getConfiguredCutoff() const
+  {
+    return filter_cutoff_frequency_;
+  }
+
+  bool isFilterConfigured() const
+  {
+    return lpf_configured_;
+  }
+};
+
+double meanAbsTemporalDifference(const Eigen::ArrayXXf & data)
+{
+  if (data.cols() < 2) {
+    return 0.0;
+  }
+
+  double total = 0.0;
+  size_t count = 0;
+  for (int row = 0; row < data.rows(); ++row) {
+    for (int col = 1; col < data.cols(); ++col) {
+      total += std::abs(data(row, col) - data(row, col - 1));
+      ++count;
+    }
+  }
+
+  return count > 0 ? total / static_cast<double>(count) : 0.0;
+}
 
 TEST(NoiseGeneratorTest, NoiseGeneratorLifecycle)
 {
@@ -133,6 +181,215 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   EXPECT_NEAR(state.cwz(0, 9), 9, 0.3);
 
   generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterSmoothsPerturbations)
+{
+  auto filtered_node = std::make_shared<nav2::LifecycleNode>("filtered_node");
+  filtered_node->declare_parameter("filtered_ns.regenerate_noises", rclcpp::ParameterValue(false));
+  filtered_node->declare_parameter("filtered_ns.use_low_pass_filter", rclcpp::ParameterValue(true));
+  filtered_node->declare_parameter(
+    "filtered_ns.filter_cutoff_frequency", rclcpp::ParameterValue(0.8));
+  filtered_node->declare_parameter("filtered_ns.filter_order", rclcpp::ParameterValue(2));
+  std::string filtered_name = "filtered";
+  ParametersHandler filtered_handler(filtered_node, filtered_name);
+
+  auto raw_node = std::make_shared<nav2::LifecycleNode>("raw_node");
+  raw_node->declare_parameter("raw_ns.regenerate_noises", rclcpp::ParameterValue(false));
+  raw_node->declare_parameter("raw_ns.use_low_pass_filter", rclcpp::ParameterValue(false));
+  std::string raw_name = "raw";
+  ParametersHandler raw_handler(raw_node, raw_name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 128;
+  settings.time_steps = 80;
+  settings.model_dt = 0.05;
+  settings.sampling_std.vx = 0.25;
+  settings.sampling_std.vy = 0.25;
+  settings.sampling_std.wz = 0.25;
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State filtered_state, raw_state;
+  filtered_state.reset(settings.batch_size, settings.time_steps);
+  raw_state.reset(settings.batch_size, settings.time_steps);
+
+  NoiseGenerator filtered_generator;
+  filtered_generator.initialize(settings, false, "filtered_ns", &filtered_handler);
+  filtered_generator.reset(settings, false);
+  filtered_generator.setNoisedControls(filtered_state, control_sequence);
+  filtered_generator.shutdown();
+
+  NoiseGenerator raw_generator;
+  raw_generator.initialize(settings, false, "raw_ns", &raw_handler);
+  raw_generator.reset(settings, false);
+  raw_generator.setNoisedControls(raw_state, control_sequence);
+  raw_generator.shutdown();
+
+  const double filtered_vx_diff = meanAbsTemporalDifference(filtered_state.cvx);
+  const double raw_vx_diff = meanAbsTemporalDifference(raw_state.cvx);
+  const double filtered_wz_diff = meanAbsTemporalDifference(filtered_state.cwz);
+  const double raw_wz_diff = meanAbsTemporalDifference(raw_state.cwz);
+
+  EXPECT_LT(filtered_vx_diff, raw_vx_diff);
+  EXPECT_LT(filtered_wz_diff, raw_wz_diff);
+
+  // Repeat in holonomic mode to verify vy smoothing path.
+  filtered_state.reset(settings.batch_size, settings.time_steps);
+  raw_state.reset(settings.batch_size, settings.time_steps);
+
+  NoiseGenerator filtered_holo_generator;
+  filtered_holo_generator.initialize(settings, true, "filtered_ns", &filtered_handler);
+  filtered_holo_generator.reset(settings, true);
+  filtered_holo_generator.setNoisedControls(filtered_state, control_sequence);
+  filtered_holo_generator.shutdown();
+
+  NoiseGenerator raw_holo_generator;
+  raw_holo_generator.initialize(settings, true, "raw_ns", &raw_handler);
+  raw_holo_generator.reset(settings, true);
+  raw_holo_generator.setNoisedControls(raw_state, control_sequence);
+  raw_holo_generator.shutdown();
+
+  const double filtered_vy_diff = meanAbsTemporalDifference(filtered_state.cvy);
+  const double raw_vy_diff = meanAbsTemporalDifference(raw_state.cvy);
+
+  EXPECT_LT(filtered_vy_diff, raw_vy_diff);
+}
+
+TEST(NoiseGeneratorTest, CutoffClampedToNyquist)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.use_low_pass_filter", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.filter_cutoff_frequency", rclcpp::ParameterValue(1000.0));
+  node->declare_parameter("test_name.filter_order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 64;
+  settings.time_steps = 32;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  const double nyquist = 1.0 / (2.0 * settings.model_dt);
+  EXPECT_TRUE(generator.isFilterConfigured());
+  EXPECT_GT(generator.getConfiguredCutoff(), 0.0);
+  EXPECT_LT(generator.getConfiguredCutoff(), nyquist);
+
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithNonPositiveModelDt)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_dt");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.use_low_pass_filter", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.filter_cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter("test_name.filter_order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.0;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithNonPositiveCutoff)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_cutoff");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.use_low_pass_filter", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.filter_cutoff_frequency", rclcpp::ParameterValue(0.0));
+  node->declare_parameter("test_name.filter_order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithInvalidOrder)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_order");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.use_low_pass_filter", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.filter_cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter("test_name.filter_order", rclcpp::ParameterValue(0));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWhenDesignFails)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_design_fail");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.use_low_pass_filter", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.filter_cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter("test_name.filter_order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = std::numeric_limits<float>::quiet_NaN();
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, DesignRejectsInvalidOrderInput)
+{
+  NoiseGeneratorTester generator;
+  generator.setFilterInputsForTest(0.1f, 1.0, 0);
+  EXPECT_FALSE(generator.designLowPassForTest());
 }
 
 TEST(NoiseGeneratorTest, NoiseGeneratorMainNoRegenerate)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---
<!-- Please fill out the following pull request template for non-trivial
  changes to help us process your PR faster and more efficiently.-->


  ## Basic Info

  | Info | Please fill out this column |
  | ------ | ----------- |
  | Ticket(s) this addresses   | N/A |
  | Primary OS tested on | Ubuntu (dev container) |
  | Robotic platform tested on | Unit tests only (no hardware run in this PR) |
  | Does this PR contain AI generated software? | Yes and it is marked inline in the code |
  | Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

  ---

  ## Description of contribution in a few bullet points

  * This PR adds an **unofficial Nav2 implementation** of the sampling idea from the paper: **LP-MPPI: Low-Pass Filtering for Efficient Model Predictive Path Integral Control** (accepted at **ICRA 2026**).
  * I've designed this feature to be strictly opt-in, so it won't affect any existing MPPI configurations or change the current default behavior of the controller.
  * New parameters:
    * `use_low_pass_filter` (bool, default `false`)
    * `filter_cutoff_frequency` (double, Hz, default `2.0`)
    * `filter_order` (int, default `2`)
  * Nyquist safety guard added:
    * validates cutoff against Nyquist frequency `f_N = 1 / (2 * model_dt)`
    * clamps invalid cutoff and logs warning

  ## Algorithm details implemented in this PR

  * Baseline MPPI sampling in Nav2 uses Gaussian perturbations:
    * `epsilon ~ N(0, Sigma)`
    * `u_sampled = u_nominal + epsilon`
  * This PR adds LP-MPPI-style perturbation shaping:
    * `epsilon_lp = LPF(epsilon, cutoff, order)`
    * `u_sampled = u_nominal + epsilon_lp`
  * Filtering is applied:
    * on perturbations (not on final command output)
    * per rollout trajectory
    * along the **time_steps axis**
    * for each control dimension (`vx`, `wz`, and `vy` when holonomic)
  * Filter implementation:
    * digital Butterworth low-pass
    * runtime coefficient design
    * direct-form recursive application

  ## Files changed

  * `nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp`
    * Added LP filter config/data members and helper method declarations.
  * `nav2_mppi_controller/src/noise_generator.cpp`
    * Added parameter loading for LP filter controls.
    * Added Nyquist validation/clamping.
    * Added Butterworth coefficient design and perturbation filtering.
    * Integrated filtering into the perturbation generation path.
  * `nav2_mppi_controller/test/noise_generator_test.cpp`
    * Added `LowPassFilterSmoothsPerturbations` test.
    * Added holonomic `vy` smoothing assertion.
    * Added `CutoffClampedToNyquist` test.
  * `nav2_mppi_controller/README.md`
    * Added parameter docs and example config.
  * `nav2_bringup/params/nav2_params.yaml`
    * Added sample/default LP filter parameters under `FollowPath`.

  ## Usage

  Example configuration:

  ```yaml
  controller_server:
    ros__parameters:
      FollowPath:
        plugin: "nav2_mppi_controller::MPPIController"
        model_dt: 0.05
        regenerate_noises: true
        use_low_pass_filter: true
        filter_cutoff_frequency: 2.0
        filter_order: 2
```
  Tuning notes:

  - Increase filter_cutoff_frequency for more responsiveness.
  - Decrease filter_cutoff_frequency for smoother perturbations and less high-frequency chatter.
  - Higher filter_order increases attenuation above cutoff but can make exploration more conservative.
  - Keep regenerate_noises: true for behavior closest to LP-MPPI paper sampling assumptions.

  ## Description of documentation updates required from your changes

  - Add use_low_pass_filter, filter_cutoff_frequency, and filter_order to docs.nav2.org MPPI parameter reference.
  - Add tuning guidance for cutoff/order vs responsiveness/smoothness tradeoff.
  - No migration guide entry required for breaking changes (feature is opt-in), but could be listed under new controller capabilities.

  ## Description of how this change was tested

  - Focused new-test validation:
      - GTEST_FILTER=NoiseGeneratorTest.LowPassFilterSmoothsPerturbations colcon
        test --packages-select nav2_mppi_controller --ctest-args -R
        noise_generator_test --event-handlers console_direct+
  - Full package test run:
      - colcon test --packages-select nav2_mppi_controller
      - colcon test-result --verbose
  - Observed result in environment:
      - 0 errors, 0 failures (skips present, expected for Nav2 CI/dev
        environments)

  

  ## Future work that may be required in bullet points

  - Add noise_filter_type mode selector when additional filter families are introduced.
  - Add comparative benchmark plots for tracking error/control smoothness / compute-time impact vs baseline MPPI across robot classes.
  - Evaluate explicit synchronization strategy after reset() to avoid potential first-cycle zero-perturbation edge case with async regeneration.
  - Add documentation examples for differential, omni, and Ackermann recommended

  #### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

  - [ ] Check that any new parameters added are updated in docs.nav2.org and reflected in the tuning guide
  - [ ] Check that any new functions have Doxygen added
  - [ ] Check that any new features have test coverage
  - [ ] Check that any new plugins are added to the plugins page
  - [ ] If BT Node, additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
  - [ ] Should this be backported to current distributions? If so, tag with backport-*.

