### PR TITLE
Allow using latest time for transform lookups

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -922,7 +922,7 @@ bool ControllerServer::isGoalReached()
 bool ControllerServer::getRobotPose(geometry_msgs::msg::PoseStamped & pose)
 {
   geometry_msgs::msg::PoseStamped current_pose;
-  if (!costmap_ros_->getRobotPose(current_pose)) {
+  if (!costmap_ros_->getRobotPose(current_pose, true)) {
     return false;
   }
   pose = current_pose;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -201,7 +201,8 @@ public:
    * @param global_pose Will be set to the pose of the robot in the global frame of the costmap
    * @return True if the pose was set successfully, false otherwise
    */
-  bool getRobotPose(geometry_msgs::msg::PoseStamped & global_pose);
+  bool getRobotPose(
+    geometry_msgs::msg::PoseStamped & global_pose, bool use_latest_time = false);
 
   /**
    * @brief Transform the input_pose in the global frame of the costmap

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -728,8 +728,15 @@ Costmap2DROS::resetLayers()
 }
 
 bool
-Costmap2DROS::getRobotPose(geometry_msgs::msg::PoseStamped & global_pose)
+Costmap2DROS::getRobotPose(
+  geometry_msgs::msg::PoseStamped & global_pose, bool use_latest_time)
 {
+  if (use_latest_time) {
+    return nav2_util::getCurrentPose(
+      global_pose, *tf_buffer_,
+      global_frame_, robot_base_frame_, transform_tolerance_, now());
+  }
+
   return nav2_util::getCurrentPose(
     global_pose, *tf_buffer_,
     global_frame_, robot_base_frame_, transform_tolerance_);


### PR DESCRIPTION
Hi!

I was recently playing around with possible failures that can be induced on a system, and realized that with the current implementation of nav2, a freeze in the tf tree does not cause the stack to stop immediately (ex: the node publishing odom->baselink died).

I'm submitting this proposal to raise a failure immediately when that happens. Is there something i may be missing out?