### PR TITLE
MPPI: add visualization of furthest_reached_path_point

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -127,6 +127,24 @@ public:
   const Eigen::ArrayXf & getCosts() const {return costs_;}
 
   /**
+   * @brief Get the furthest reached path point index from the last evaluation
+   * @return Optional index of furthest reached path point, if path was provided and evaluated.
+   */
+  const std::optional<size_t> & getFurthestReachedPathPoint() const
+  {
+    return critics_data_.furthest_reached_path_point;
+  }
+
+  /**
+   * @brief Get the path data from the last evaluation
+   * @return Path data if path was provided and evaluated.
+   */
+  const models::Path & getPath() const
+  {
+    return path_;
+  }
+  
+  /**
    * @brief Get per-critic cost breakdown from last evaluation
    * @return Vector of (critic_name, cost_array) pairs
    */

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
@@ -22,12 +22,14 @@
 #include <utility>
 #include <vector>
 
+#include "geometry_msgs/msg/point_stamped.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
+#include "nav2_mppi_controller/models/path.hpp"
 #include "nav2_mppi_controller/models/trajectories.hpp"
 
 namespace mppi
@@ -93,6 +95,17 @@ public:
     const builtin_interfaces::msg::Time & stamp);
 
   /**
+    * @brief Publish the furthest reached path point as a PointStamped
+    * @param path Path data containing x, y coordinates
+    * @param furthest_idx Index into the path of the furthest reached point
+    * @param stamp Timestamp for the message
+    */
+  void setFurthestReachedPoint(
+    const models::Path & path,
+    size_t furthest_idx,
+    const builtin_interfaces::msg::Time & stamp);
+
+  /**
     * @brief Visualize the plan
     */
   void visualize();
@@ -129,6 +142,7 @@ protected:
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     trajectories_publisher_;
   nav2::Publisher<nav_msgs::msg::Path>::SharedPtr optimal_path_pub_;
+  nav2::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr furthest_point_pub_;
 
   std::unique_ptr<nav_msgs::msg::Path> optimal_path_;
   std::unique_ptr<visualization_msgs::msg::MarkerArray> points_;

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -153,6 +153,13 @@ void MPPIController::visualize(
     cmd_stamp);
 
   trajectory_visualizer_.add(optimal_trajectory, "Optimal Trajectory", cmd_stamp);
+
+  const auto & furthest = optimizer_.getFurthestReachedPathPoint();
+  if (furthest.has_value()) {
+    trajectory_visualizer_.setFurthestReachedPoint(
+      optimizer_.getPath(), furthest.value(), cmd_stamp);
+  }
+
   trajectory_visualizer_.visualize();
 }
 

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -31,6 +31,8 @@ void TrajectoryVisualizer::on_configure(
   trajectories_publisher_ =
     node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
   optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
+  furthest_point_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>("~/furthest_reached_point");
+
   parameters_handler_ = parameters_handler;
 
   auto getParam = parameters_handler->getParamGetter(name + ".TrajectoryVisualizer");
@@ -45,18 +47,21 @@ void TrajectoryVisualizer::on_cleanup()
 {
   trajectories_publisher_.reset();
   optimal_path_pub_.reset();
+  furthest_point_pub_.reset();
 }
 
 void TrajectoryVisualizer::on_activate()
 {
   trajectories_publisher_->on_activate();
   optimal_path_pub_->on_activate();
+  furthest_point_pub_->on_activate();
 }
 
 void TrajectoryVisualizer::on_deactivate()
 {
   trajectories_publisher_->on_deactivate();
   optimal_path_pub_->on_deactivate();
+  furthest_point_pub_->on_deactivate();
 }
 
 void TrajectoryVisualizer::add(
@@ -183,6 +188,24 @@ void TrajectoryVisualizer::addCostColoredTrajectory(
   }
 
   points_->markers.push_back(std::move(marker));
+}
+
+void TrajectoryVisualizer::setFurthestReachedPoint(
+  const models::Path & path,
+  size_t furthest_idx,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  if (furthest_point_pub_->get_subscription_count() == 0) {
+    return;
+  }
+
+  geometry_msgs::msg::PointStamped msg;
+  msg.header.frame_id = frame_id_;
+  msg.header.stamp = stamp;
+  msg.point.x = path.x(furthest_idx);
+  msg.point.y = path.y(furthest_idx);
+  msg.point.z = 0.1;  // slightly above ground for visibility
+  furthest_point_pub_->publish(msg);
 }
 
 std_msgs::msg::ColorRGBA TrajectoryVisualizer::costToColor(float normalized)


### PR DESCRIPTION
Publishes the furthest reached path point as a PointStamped on ~/furthest_reached_point when visualization is enabled. This helps debug path-following behavior by showing where MPPI thinks the trajectories reach on the global path.

The value is already computed by PathFollowCritic, PathAlignCritic, and PathAngleCritic. This change exposes it through the Optimizer and publishes it via TrajectoryVisualizer.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
