### PR TITLE
Implementation of model_delay with dynamic parameter

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
@@ -31,6 +31,7 @@ struct OptimizerSettings
   models::ControlConstraints constraints{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
   models::SamplingStd sampling_std{0.0f, 0.0f, 0.0f};
   float model_dt{0.0f};
+  float model_delay{0.0f};
   float temperature{0.0f};
   float gamma{0.0f};
   unsigned int batch_size{0u};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -60,10 +60,12 @@ public:
     * @param control_constraints Constraints on control
     * @param model_dt duration of a time step
     */
-  void initialize(const models::ControlConstraints & control_constraints, float model_dt)
+  void initialize(const models::ControlConstraints & control_constraints, float model_dt,
+    float model_delay)
   {
     control_constraints_ = control_constraints;
     model_dt_ = model_dt;
+    model_delay_ = model_delay;
   }
 
   /**
@@ -116,6 +118,25 @@ public:
         state.vy.col(i) = state.cvy.col(i - 1);
       }
     }
+
+    // Apply model delay
+    if(model_delay_ == 0.0) {return;}
+    unsigned int offset = std::floor((model_delay_ / model_dt_) + 0.5);
+    auto state_copy = state;
+    for (unsigned int i = 0; i != state.vx.shape(0); i++) {
+      for (unsigned int j = 1; j != state.vx.shape(1); j++) {
+        // Keep the first value before delay (because we cannot do better)
+        if (j < offset) {
+          state.vx(i, j) = state_copy.vx(i, 0);
+          state.wz(i, j) = state_copy.wz(i, 0);
+          if (is_holo) {state.vy(i, j) = state_copy.vy(i, 0);}
+        } else { // move the command to express delay
+          state.vx(i, j) = state_copy.vx(i, j - offset);
+          state.wz(i, j) = state_copy.wz(i, j - offset);
+          if (is_holo) {state.vy(i, j) = state_copy.vy(i, j - offset);}
+        }
+      }
+    }
   }
 
   /**
@@ -132,6 +153,7 @@ public:
 
 protected:
   float model_dt_{0.0};
+  float model_delay_{0.0};
   models::ControlConstraints control_constraints_{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
     0.0f, 0.0f};
 };

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -102,6 +102,7 @@ void Optimizer::getParams()
   }
 
   getParam(s.model_dt, "model_dt", 0.05f);
+  getParam(s.model_delay, "model_delay", 0.0f);
   getParam(s.time_steps, "time_steps", 56);
   getParam(s.batch_size, "batch_size", 1000);
   getParam(s.iteration_count, "iteration_count", 1);
@@ -192,7 +193,7 @@ void Optimizer::reset(bool reset_dynamic_speed_limits)
   generated_trajectories_.reset(settings_.batch_size, settings_.time_steps);
 
   noise_generator_.reset(settings_, isHolonomic());
-  motion_model_->initialize(settings_.constraints, settings_.model_dt);
+  motion_model_->initialize(settings_.constraints, settings_.model_dt, settings_.model_delay);
   trajectory_validator_->initialize(
     parent_, name_ + ".TrajectoryValidator",
     costmap_ros_, parameters_handler_, tf_buffer_, settings_);
@@ -590,7 +591,7 @@ void Optimizer::setMotionModel(const std::string & model)
               "Model " + model + " is not valid! Valid options are DiffDrive, Omni, "
               "or Ackermann"));
   }
-  motion_model_->initialize(settings_.constraints, settings_.model_dt);
+  motion_model_->initialize(settings_.constraints, settings_.model_dt, settings_.model_delay);
 }
 
 void Optimizer::setSpeedLimit(double speed_limit, bool percentage)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #6065) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Our real robot|
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---
@SteveMacenski and @doisyg , here is a small implementation of our talk long ago.

## Description of contribution in a few bullet points

* Add a new parameter in the mppi model call `model_delay`
* Shift the command vector according to the model delay

## Description of how this change was tested

* This modification runs in our robot, and the behavior in long narrow corridor was improved, it reduces zigzag.

---

## Future work that may be required in bullet points

* Implement the same shift on the visualization to see the real trajectory preview.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
