### PR TITLE
fix(smac_planner): detect oriented footprint collisions in SMAC smoother for non-circular robots

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -115,6 +115,7 @@ protected:
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
   nav2_costmap_2d::Costmap2D * _costmap;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> _costmap_ros;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   rclcpp::Clock::SharedPtr _clock;
   rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner2D")};

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -114,6 +114,7 @@ protected:
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
   nav2_costmap_2d::Costmap2D * _costmap;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> _costmap_ros;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   rclcpp::Clock::SharedPtr _clock;
   rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner2D")};

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -100,7 +100,7 @@ public:
    */
   bool smooth(
     nav_msgs::msg::Path & path,
-    const nav2_costmap_2d::Costmap2D * costmap,
+    nav2_costmap_2d::Costmap2D * costmap,
     const double & max_time,
     const nav2_costmap_2d::Footprint & footprint = {});
 
@@ -117,7 +117,7 @@ protected:
   bool smoothImpl(
     nav_msgs::msg::Path & path,
     bool & reversing_segment,
-    const nav2_costmap_2d::Costmap2D * costmap,
+    nav2_costmap_2d::Costmap2D * costmap,
     const double & max_time,
     const nav2_costmap_2d::Footprint & footprint = {});
 
@@ -152,7 +152,7 @@ protected:
   void enforceStartBoundaryConditions(
     const geometry_msgs::msg::Pose & start_pose,
     nav_msgs::msg::Path & path,
-    const nav2_costmap_2d::Costmap2D * costmap,
+    nav2_costmap_2d::Costmap2D * costmap,
     const bool & reversing_segment);
 
   /**
@@ -166,7 +166,7 @@ protected:
   void enforceEndBoundaryConditions(
     const geometry_msgs::msg::Pose & end_pose,
     nav_msgs::msg::Path & path,
-    const nav2_costmap_2d::Costmap2D * costmap,
+    nav2_costmap_2d::Costmap2D * costmap,
     const bool & reversing_segment);
 
   /**
@@ -191,7 +191,7 @@ protected:
     const geometry_msgs::msg::Pose & start,
     const geometry_msgs::msg::Pose & end,
     BoundaryExpansion & expansion,
-    const nav2_costmap_2d::Costmap2D * costmap);
+    nav2_costmap_2d::Costmap2D * costmap);
 
   /**
    * @brief Generates boundary expansions with end idx at least strategic

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
 #include "nav2_smac_planner/types.hpp"
 #include "nav2_smac_planner/constants.hpp"
 #include "nav2_util/geometry_utils.hpp"
@@ -92,12 +93,16 @@ public:
    * @param path Reference to path
    * @param costmap Pointer to minimal costmap
    * @param max_time Maximum time to compute, stop early if over limit
+   * @param footprint Robot footprint for oriented collision checking (non-circular robots).
+   *        When non-empty, an oriented footprint collision check is performed on the
+   *        smoothed path after orientation assignment. Empty footprint skips the check.
    * @return If smoothing was successful
    */
   bool smooth(
     nav_msgs::msg::Path & path,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const double & max_time);
+    const double & max_time,
+    const nav2_costmap_2d::Footprint & footprint = {});
 
 protected:
   /**
@@ -106,13 +111,15 @@ protected:
    * @param reversing_segment Return if this is a reversing segment
    * @param costmap Pointer to minimal costmap
    * @param max_time Maximum time to compute, stop early if over limit
+   * @param footprint Robot footprint for oriented collision checking (non-circular robots)
    * @return If smoothing was successful
    */
   bool smoothImpl(
     nav_msgs::msg::Path & path,
     bool & reversing_segment,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const double & max_time);
+    const double & max_time,
+    const nav2_costmap_2d::Footprint & footprint = {});
 
   /**
    * @brief Get the field value for a given dimension

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -320,7 +320,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 #endif
 
   // Smooth plan
-  _smoother->smooth(plan, costmap, time_remaining);
+  _smoother->smooth(plan, costmap, time_remaining, _costmap_ros->getRobotFootprint());
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -55,6 +55,7 @@ void SmacPlanner2D::configure(
   _logger = node->get_logger();
   _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
+  _costmap_ros = costmap_ros;
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
 

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -314,7 +314,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 #endif
 
   // Smooth plan
-  _smoother->smooth(plan, costmap, time_remaining);
+  _smoother->smooth(plan, costmap, time_remaining, _costmap_ros->getRobotFootprint());
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -539,7 +539,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, costmap, time_remaining);
+    _smoother->smooth(plan, costmap, time_remaining, _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -545,7 +545,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, costmap, time_remaining);
+    _smoother->smooth(plan, costmap, time_remaining, _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -496,7 +496,7 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, _costmap, time_remaining);
+    _smoother->smooth(plan, _costmap, time_remaining, _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -490,7 +490,7 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, _costmap, time_remaining);
+    _smoother->smooth(plan, _costmap, time_remaining, _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -122,7 +122,6 @@ bool Smoother::smoothImpl(
   double change = tolerance_;
   const unsigned int & path_size = path.poses.size();
   double x_i, y_i, y_m1, y_ip1, y_i_org;
-  unsigned int mx, my;
 
   nav_msgs::msg::Path new_path = path;
   nav_msgs::msg::Path last_path = path;
@@ -172,24 +171,28 @@ bool Smoother::smoothImpl(
         change += abs(y_i - y_i_org);
       }
 
-      // validate update is admissible, only checks cost if a valid costmap pointer is provided
-      float cost = 0.0;
-      if (costmap) {
-        costmap->worldToMap(
-          getFieldByDim(new_path.poses[i], 0),
-          getFieldByDim(new_path.poses[i], 1),
-          mx, my);
-        cost = static_cast<float>(costmap->getCost(mx, my));
-      }
+      // Center-point cost check: only run when no oriented footprint check is
+      // configured. The oriented check below subsumes the center-point lookup.
+      if (!check_oriented_footprint) {
+        float cost = 0.0;
+        if (costmap) {
+          unsigned int mx, my;
+          costmap->worldToMap(
+            getFieldByDim(new_path.poses[i], 0),
+            getFieldByDim(new_path.poses[i], 1),
+            mx, my);
+          cost = static_cast<float>(costmap->getCost(mx, my));
+        }
 
-      if (cost > MAX_NON_OBSTACLE_COST && cost != UNKNOWN_COST) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("SmacPlannerSmoother"),
-          "Smoothing process resulted in an infeasible collision. "
-          "Returning the last path before the infeasibility was introduced.");
-        path = last_path;
-        nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
-        return false;
+        if (cost > MAX_NON_OBSTACLE_COST && cost != UNKNOWN_COST) {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("SmacPlannerSmoother"),
+            "Smoothing process resulted in an infeasible collision. "
+            "Returning the last path before the infeasibility was introduced.");
+          path = last_path;
+          nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
+          return false;
+        }
       }
     }
 

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -128,15 +128,7 @@ bool Smoother::smoothImpl(
   nav_msgs::msg::Path new_path = path;
   nav_msgs::msg::Path last_path = path;
 
-  // Oriented footprint collision checker for non-circular robots (fix for #5330).
-  // Built once and reused across iterations. The center-cost check inside the
-  // inner pose loop is sufficient for circular robots (costmap inflation captures
-  // the radius) but misses orientation-dependent footprint extensions for
-  // non-circular robots. The oriented-footprint check below is evaluated per
-  // gradient-descent iteration, after orientation assignment, on the new_path.
-  // On collision, the iteration is reverted (path = last_path) — matching the
-  // nav2_smoother::SimpleSmoother per-iteration revert idiom — so the smoother
-  // never publishes a smoothed path it knows to be in oriented collision.
+  // Oriented footprint collision checker for non-circular robots (#5330).
   const bool check_oriented_footprint = !footprint.empty() && costmap;
   nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
   oriented_checker(costmap);
@@ -202,16 +194,7 @@ bool Smoother::smoothImpl(
       }
     }
 
-    // Oriented footprint collision check (fix for #5330).
-    // Evaluated per iteration so the smoother stops smoothing as soon as a step
-    // would pull the oriented footprint into a lethal cell. On collision, the
-    // path is reverted to last_path (the last collision-free iteration) and
-    // nav2_core::SmoothedPathInCollision is thrown — matching the canonical
-    // fail-loud signal used by nav2_smoother::Nav2Smoother (collision_checker
-    // catch site at nav2_smoother.cpp:285-303). The caller's input path is
-    // length-preserved (std::copy back-into-segment is bypassed by the throw)
-    // so downstream consumers receive either a fully-smoothed-and-clean path
-    // or an explicit collision exception, never a silently-truncated path.
+    // Per-iteration oriented footprint check; revert to last_path on collision.
     if (check_oriented_footprint) {
       nav_msgs::msg::Path oriented_candidate = new_path;
       nav2_util::updateApproximatePathOrientations(

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -23,6 +23,7 @@
 
 #include "tf2/utils.hpp"
 
+#include "nav2_core/smoother_exceptions.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_smac_planner/smoother.hpp"
 #include "nav2_util/smoother_utils.hpp"
@@ -127,6 +128,21 @@ bool Smoother::smoothImpl(
   nav_msgs::msg::Path new_path = path;
   nav_msgs::msg::Path last_path = path;
 
+  // Oriented footprint collision checker for non-circular robots (fix for #5330).
+  // Built once and reused across iterations. The center-cost check inside the
+  // inner pose loop is sufficient for circular robots (costmap inflation captures
+  // the radius) but misses orientation-dependent footprint extensions for
+  // non-circular robots. The oriented-footprint check below is evaluated per
+  // gradient-descent iteration, after orientation assignment, on the new_path.
+  // On collision, the iteration is reverted (path = last_path) — matching the
+  // nav2_smoother::SimpleSmoother per-iteration revert idiom — so the smoother
+  // never publishes a smoothed path it knows to be in oriented collision.
+  const bool check_oriented_footprint = !footprint.empty() && costmap;
+  // FootprintCollisionChecker is only instantiated for Costmap2D* (non-const).
+  // const_cast is safe here: footprintCostAtPose only reads the costmap.
+  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+  oriented_checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
+
   while (change >= tolerance_) {
     its += 1;
     change = 0.0;
@@ -188,6 +204,48 @@ bool Smoother::smoothImpl(
       }
     }
 
+    // Oriented footprint collision check (fix for #5330).
+    // Evaluated per iteration so the smoother stops smoothing as soon as a step
+    // would pull the oriented footprint into a lethal cell. On collision, the
+    // path is reverted to last_path (the last collision-free iteration) and
+    // nav2_core::SmoothedPathInCollision is thrown — matching the canonical
+    // fail-loud signal used by nav2_smoother::Nav2Smoother (collision_checker
+    // catch site at nav2_smoother.cpp:285-303). The caller's input path is
+    // length-preserved (std::copy back-into-segment is bypassed by the throw)
+    // so downstream consumers receive either a fully-smoothed-and-clean path
+    // or an explicit collision exception, never a silently-truncated path.
+    // Combines Maurice's r3072469939 in-loop guidance (UPA reading-α) with the
+    // nav2_core SmoothedPathInCollision idiom (AAA reading-β safety class).
+    if (check_oriented_footprint) {
+      nav_msgs::msg::Path oriented_candidate = new_path;
+      nav2_util::updateApproximatePathOrientations(
+        oriented_candidate, reversing_segment, is_holonomic_);
+      for (size_t idx = 0; idx < oriented_candidate.poses.size(); ++idx) {
+        const double yaw = tf2::getYaw(oriented_candidate.poses[idx].pose.orientation);
+        const double oriented_cost = oriented_checker.footprintCostAtPose(
+          oriented_candidate.poses[idx].pose.position.x,
+          oriented_candidate.poses[idx].pose.position.y,
+          yaw, footprint);
+        if (
+          static_cast<float>(oriented_cost) >=
+          static_cast<float>(nav2_costmap_2d::LETHAL_OBSTACLE) &&
+          static_cast<float>(oriented_cost) != UNKNOWN_COST)
+        {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("SmacPlannerSmoother"),
+            "Smoothing iteration produced an oriented footprint collision for a "
+            "non-circular robot. Reverting to the last collision-free iteration.");
+          path = last_path;
+          nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
+          throw nav2_core::SmoothedPathInCollision(
+                  "Smoothed path collides with the oriented robot footprint at "
+                  "X: " + std::to_string(oriented_candidate.poses[idx].pose.position.x) +
+                  " Y: " + std::to_string(oriented_candidate.poses[idx].pose.position.y) +
+                  " Theta: " + std::to_string(yaw));
+        }
+      }
+    }
+
     last_path = new_path;
   }
 
@@ -199,41 +257,6 @@ bool Smoother::smoothImpl(
   }
 
   nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
-
-  // Oriented footprint collision check for non-circular robots (fix for #5330).
-  // The per-iteration cost check above uses center-point cost only, which is
-  // sufficient for circular robots (costmap inflation captures the radius) but
-  // misses orientation-dependent footprint extensions for non-circular robots.
-  // After orientations are assigned we validate each smoothed pose with the full
-  // oriented footprint. When a collision is detected the loop stops at that pose
-  // so the maximum collision-free smoothed prefix is used. The caller's path
-  // retains the original planner poses from the collision point onward (via the
-  // partial std::copy in Smoother::smooth).
-  if (!footprint.empty() && costmap) {
-    // FootprintCollisionChecker is only instantiated for Costmap2D* (non-const).
-    // const_cast is safe here: footprintCostAtPose only reads the costmap.
-    nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
-    checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
-    for (size_t idx = 0; idx < new_path.poses.size(); ++idx) {
-      const double yaw = tf2::getYaw(new_path.poses[idx].pose.orientation);
-      const double cost = checker.footprintCostAtPose(
-        new_path.poses[idx].pose.position.x,
-        new_path.poses[idx].pose.position.y,
-        yaw, footprint);
-      if (static_cast<float>(cost) >= static_cast<float>(nav2_costmap_2d::LETHAL_OBSTACLE) &&
-        static_cast<float>(cost) != UNKNOWN_COST)
-      {
-        RCLCPP_WARN(
-          rclcpp::get_logger("SmacPlannerSmoother"),
-          "Smoothed path produces an oriented footprint collision for a non-circular robot. "
-          "Stopping smoothed path at collision-free boundary.");
-        new_path.poses.resize(idx);
-        path = new_path;
-        return false;
-      }
-    }
-  }
-
   path = new_path;
   return true;
 }

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -23,7 +23,6 @@
 
 #include "tf2/utils.hpp"
 
-#include "nav2_core/smoother_exceptions.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_smac_planner/smoother.hpp"
 #include "nav2_util/smoother_utils.hpp"
@@ -216,11 +215,7 @@ bool Smoother::smoothImpl(
             "non-circular robot. Reverting to the last collision-free iteration.");
           path = last_path;
           nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
-          throw nav2_core::SmoothedPathInCollision(
-                  "Smoothed path collides with the oriented robot footprint at "
-                  "X: " + std::to_string(oriented_candidate.poses[idx].pose.position.x) +
-                  " Y: " + std::to_string(oriented_candidate.poses[idx].pose.position.y) +
-                  " Theta: " + std::to_string(yaw));
+          return false;
         }
       }
     }

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -53,7 +53,7 @@ void Smoother::initialize(const double & min_turning_radius)
 
 bool Smoother::smooth(
   nav_msgs::msg::Path & path,
-  const nav2_costmap_2d::Costmap2D * costmap,
+  nav2_costmap_2d::Costmap2D * costmap,
   const double & max_time,
   const nav2_costmap_2d::Footprint & footprint)
 {
@@ -112,7 +112,7 @@ bool Smoother::smooth(
 bool Smoother::smoothImpl(
   nav_msgs::msg::Path & path,
   bool & reversing_segment,
-  const nav2_costmap_2d::Costmap2D * costmap,
+  nav2_costmap_2d::Costmap2D * costmap,
   const double & max_time,
   const nav2_costmap_2d::Footprint & footprint)
 {
@@ -138,10 +138,8 @@ bool Smoother::smoothImpl(
   // nav2_smoother::SimpleSmoother per-iteration revert idiom — so the smoother
   // never publishes a smoothed path it knows to be in oriented collision.
   const bool check_oriented_footprint = !footprint.empty() && costmap;
-  // FootprintCollisionChecker is only instantiated for Costmap2D* (non-const).
-  // const_cast is safe here: footprintCostAtPose only reads the costmap.
   nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
-  oriented_checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
+  oriented_checker(costmap);
 
   while (change >= tolerance_) {
     its += 1;
@@ -310,7 +308,7 @@ void Smoother::findBoundaryExpansion(
   const geometry_msgs::msg::Pose & start,
   const geometry_msgs::msg::Pose & end,
   BoundaryExpansion & expansion,
-  const nav2_costmap_2d::Costmap2D * costmap)
+  nav2_costmap_2d::Costmap2D * costmap)
 {
   ompl::base::ScopedState<> from(state_space_), to(state_space_), s(state_space_);
 
@@ -406,7 +404,7 @@ BoundaryExpansions Smoother::generateBoundaryExpansionPoints(IteratorT start, It
 void Smoother::enforceStartBoundaryConditions(
   const geometry_msgs::msg::Pose & start_pose,
   nav_msgs::msg::Path & path,
-  const nav2_costmap_2d::Costmap2D * costmap,
+  nav2_costmap_2d::Costmap2D * costmap,
   const bool & reversing_segment)
 {
   // Find range of points for testing
@@ -452,7 +450,7 @@ void Smoother::enforceStartBoundaryConditions(
 void Smoother::enforceEndBoundaryConditions(
   const geometry_msgs::msg::Pose & end_pose,
   nav_msgs::msg::Path & path,
-  const nav2_costmap_2d::Costmap2D * costmap,
+  nav2_costmap_2d::Costmap2D * costmap,
   const bool & reversing_segment)
 {
   // Find range of points for testing

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -23,6 +23,7 @@
 
 #include "tf2/utils.hpp"
 
+#include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_smac_planner/smoother.hpp"
 #include "nav2_util/smoother_utils.hpp"
 
@@ -219,7 +220,7 @@ bool Smoother::smoothImpl(
         new_path.poses[idx].pose.position.x,
         new_path.poses[idx].pose.position.y,
         yaw, footprint);
-      if (static_cast<float>(cost) > MAX_NON_OBSTACLE_COST &&
+      if (static_cast<float>(cost) >= static_cast<float>(nav2_costmap_2d::LETHAL_OBSTACLE) &&
         static_cast<float>(cost) != UNKNOWN_COST)
       {
         RCLCPP_WARN(

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -214,8 +214,6 @@ bool Smoother::smoothImpl(
     // length-preserved (std::copy back-into-segment is bypassed by the throw)
     // so downstream consumers receive either a fully-smoothed-and-clean path
     // or an explicit collision exception, never a silently-truncated path.
-    // Combines Maurice's r3072469939 in-loop guidance (UPA reading-α) with the
-    // nav2_core SmoothedPathInCollision idiom (AAA reading-β safety class).
     if (check_oriented_footprint) {
       nav_msgs::msg::Path oriented_candidate = new_path;
       nav2_util::updateApproximatePathOrientations(

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -204,16 +204,20 @@ bool Smoother::smoothImpl(
   // sufficient for circular robots (costmap inflation captures the radius) but
   // misses orientation-dependent footprint extensions for non-circular robots.
   // After orientations are assigned we validate each smoothed pose with the full
-  // oriented footprint and revert to the original path if a collision is found.
+  // oriented footprint. When a collision is detected the loop stops at that pose
+  // so the maximum collision-free smoothed prefix is used. The caller's path
+  // retains the original planner poses from the collision point onward (via the
+  // partial std::copy in Smoother::smooth).
   if (!footprint.empty() && costmap) {
     // FootprintCollisionChecker is only instantiated for Costmap2D* (non-const).
     // const_cast is safe here: footprintCostAtPose only reads the costmap.
     nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
     checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
-    for (const auto & pose_stamped : new_path.poses) {
-      const double yaw = tf2::getYaw(pose_stamped.pose.orientation);
+    for (size_t idx = 0; idx < new_path.poses.size(); ++idx) {
+      const double yaw = tf2::getYaw(new_path.poses[idx].pose.orientation);
       const double cost = checker.footprintCostAtPose(
-        pose_stamped.pose.position.x, pose_stamped.pose.position.y,
+        new_path.poses[idx].pose.position.x,
+        new_path.poses[idx].pose.position.y,
         yaw, footprint);
       if (static_cast<float>(cost) > MAX_NON_OBSTACLE_COST &&
         static_cast<float>(cost) != UNKNOWN_COST)
@@ -221,8 +225,9 @@ bool Smoother::smoothImpl(
         RCLCPP_WARN(
           rclcpp::get_logger("SmacPlannerSmoother"),
           "Smoothed path produces an oriented footprint collision for a non-circular robot. "
-          "Returning original path.");
-        nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
+          "Stopping smoothed path at collision-free boundary.");
+        new_path.poses.resize(idx);
+        path = new_path;
         return false;
       }
     }

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -206,8 +206,10 @@ bool Smoother::smoothImpl(
   // After orientations are assigned we validate each smoothed pose with the full
   // oriented footprint and revert to the original path if a collision is found.
   if (!footprint.empty() && costmap) {
-    nav2_costmap_2d::FootprintCollisionChecker<const nav2_costmap_2d::Costmap2D *>
-    checker(costmap);
+    // FootprintCollisionChecker is only instantiated for Costmap2D* (non-const).
+    // const_cast is safe here: footprintCostAtPose only reads the costmap.
+    nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+    checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
     for (const auto & pose_stamped : new_path.poses) {
       const double yaw = tf2::getYaw(pose_stamped.pose.orientation);
       const double cost = checker.footprintCostAtPose(

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -207,7 +207,7 @@ bool Smoother::smoothImpl(
   // oriented footprint and revert to the original path if a collision is found.
   if (!footprint.empty() && costmap) {
     nav2_costmap_2d::FootprintCollisionChecker<const nav2_costmap_2d::Costmap2D *>
-      checker(costmap);
+    checker(costmap);
     for (const auto & pose_stamped : new_path.poses) {
       const double yaw = tf2::getYaw(pose_stamped.pose.orientation);
       const double cost = checker.footprintCostAtPose(

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -52,7 +52,8 @@ void Smoother::initialize(const double & min_turning_radius)
 bool Smoother::smooth(
   nav_msgs::msg::Path & path,
   const nav2_costmap_2d::Costmap2D * costmap,
-  const double & max_time)
+  const double & max_time,
+  const nav2_costmap_2d::Footprint & footprint)
 {
   // by-pass path orientations approximation when skipping smac smoother
   if (max_its_ == 0) {
@@ -86,7 +87,7 @@ bool Smoother::smooth(
       const geometry_msgs::msg::Pose start_pose = curr_path_segment.poses.front().pose;
       const geometry_msgs::msg::Pose goal_pose = curr_path_segment.poses.back().pose;
       bool local_success =
-        smoothImpl(curr_path_segment, reversing_segment, costmap, time_remaining);
+        smoothImpl(curr_path_segment, reversing_segment, costmap, time_remaining, footprint);
       success = success && local_success;
 
       // Enforce boundary conditions
@@ -110,7 +111,8 @@ bool Smoother::smoothImpl(
   nav_msgs::msg::Path & path,
   bool & reversing_segment,
   const nav2_costmap_2d::Costmap2D * costmap,
-  const double & max_time)
+  const double & max_time,
+  const nav2_costmap_2d::Footprint & footprint)
 {
   steady_clock::time_point a = steady_clock::now();
   rclcpp::Duration max_dur = rclcpp::Duration::from_seconds(max_time);
@@ -192,10 +194,38 @@ bool Smoother::smoothImpl(
   // but really puts the path quality over the top.
   if (do_refinement_ && refinement_ctr_ < refinement_num_) {
     refinement_ctr_++;
-    smoothImpl(new_path, reversing_segment, costmap, max_time);
+    smoothImpl(new_path, reversing_segment, costmap, max_time, footprint);
   }
 
   nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
+
+  // Oriented footprint collision check for non-circular robots (fix for #5330).
+  // The per-iteration cost check above uses center-point cost only, which is
+  // sufficient for circular robots (costmap inflation captures the radius) but
+  // misses orientation-dependent footprint extensions for non-circular robots.
+  // After orientations are assigned we validate each smoothed pose with the full
+  // oriented footprint and revert to the original path if a collision is found.
+  if (!footprint.empty() && costmap) {
+    nav2_costmap_2d::FootprintCollisionChecker<const nav2_costmap_2d::Costmap2D *>
+      checker(costmap);
+    for (const auto & pose_stamped : new_path.poses) {
+      const double yaw = tf2::getYaw(pose_stamped.pose.orientation);
+      const double cost = checker.footprintCostAtPose(
+        pose_stamped.pose.position.x, pose_stamped.pose.position.y,
+        yaw, footprint);
+      if (static_cast<float>(cost) > MAX_NON_OBSTACLE_COST &&
+        static_cast<float>(cost) != UNKNOWN_COST)
+      {
+        RCLCPP_WARN(
+          rclcpp::get_logger("SmacPlannerSmoother"),
+          "Smoothed path produces an oriented footprint collision for a non-circular robot. "
+          "Returning original path.");
+        nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
+        return false;
+      }
+    }
+  }
+
   path = new_path;
   return true;
 }

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -60,6 +60,11 @@ public:
   {
     return _goal_heading_mode;
   }
+
+  bool hasSmootherInitialized()
+  {
+    return _smoother != nullptr;
+  }
 };
 
 // SMAC smoke tests for plugin-level issues rather than algorithms
@@ -381,6 +386,49 @@ TEST(SmacTest, test_smac_se2_reconfigure)
   parameters.push_back(rclcpp::Parameter("test.downsampling_factor", -1));
   EXPECT_NO_THROW(planner->callDynamicParams(parameters));
   EXPECT_EQ(nodeSE2->get_parameter("test.downsampling_factor").as_int(), 2);
+}
+
+TEST(SmacTest, test_smac_se2_smoother_coverage)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("test.smooth_path", true)});
+  nav2::LifecycleNode::SharedPtr node =
+    std::make_shared<nav2::LifecycleNode>("SmacSE2SmootherCovTest", options);
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  node->configure();
+  node->activate();
+
+  auto planner = std::make_unique<HybridWrap>();
+  EXPECT_NO_THROW(planner->configure(node, "test", nullptr, costmap_ros));
+  planner->activate();
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  auto dummy_cancel_checker = []() { return false; };
+  geometry_msgs::msg::PoseStamped start, goal;
+  start.pose.position.x = 0.0;
+  start.pose.position.y = 0.0;
+  start.pose.orientation.w = 1.0;
+  goal.pose.position.x = 1.0;
+  goal.pose.position.y = 1.0;
+  goal.pose.orientation.w = 1.0;
+
+  nav_msgs::msg::Path plan;
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_FALSE(plan.poses.empty());
+
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  node->deactivate();
+  node->cleanup();
+  node.reset();
 }
 
 int main(int argc, char ** argv)

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -401,7 +401,7 @@ TEST(SmacTest, test_smac_se2_smoother_coverage)
   planner->activate();
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
-  auto dummy_cancel_checker = []() { return false; };
+  auto dummy_cancel_checker = []() {return false;};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -60,6 +60,11 @@ public:
   {
     return _goal_heading_mode;
   }
+
+  bool hasSmootherInitialized()
+  {
+    return _smoother != nullptr;
+  }
 };
 
 // SMAC smoke tests for plugin-level issues rather than algorithms
@@ -374,6 +379,49 @@ TEST(SmacTest, test_smac_se2_reconfigure)
   parameters.push_back(rclcpp::Parameter("test.downsampling_factor", -1));
   EXPECT_NO_THROW(planner->callDynamicParams(parameters));
   EXPECT_EQ(nodeSE2->get_parameter("test.downsampling_factor").as_int(), 2);
+}
+
+TEST(SmacTest, test_smac_se2_smoother_coverage)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("test.smooth_path", true)});
+  nav2::LifecycleNode::SharedPtr node =
+    std::make_shared<nav2::LifecycleNode>("SmacSE2SmootherCovTest", options);
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  node->configure();
+  node->activate();
+
+  auto planner = std::make_unique<HybridWrap>();
+  EXPECT_NO_THROW(planner->configure(node, "test", nullptr, costmap_ros));
+  planner->activate();
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  auto dummy_cancel_checker = []() { return false; };
+  geometry_msgs::msg::PoseStamped start, goal;
+  start.pose.position.x = 0.0;
+  start.pose.position.y = 0.0;
+  start.pose.orientation.w = 1.0;
+  goal.pose.position.x = 1.0;
+  goal.pose.position.y = 1.0;
+  goal.pose.orientation.w = 1.0;
+
+  nav_msgs::msg::Path plan;
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_FALSE(plan.poses.empty());
+
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  node->deactivate();
+  node->cleanup();
+  node.reset();
 }
 
 int main(int argc, char ** argv)

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -409,6 +409,7 @@ TEST(SmacTest, test_smac_se2_smoother_coverage)
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
   auto dummy_cancel_checker = []() {return false;};
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -418,7 +419,7 @@ TEST(SmacTest, test_smac_se2_smoother_coverage)
   goal.pose.orientation.w = 1.0;
 
   nav_msgs::msg::Path plan;
-  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker));
   EXPECT_FALSE(plan.poses.empty());
 
   planner->deactivate();

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -408,7 +408,7 @@ TEST(SmacTest, test_smac_se2_smoother_coverage)
   planner->activate();
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
-  auto dummy_cancel_checker = []() { return false; };
+  auto dummy_cancel_checker = []() {return false;};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -392,6 +392,49 @@ TEST(SmacTest, test_smac_lattice_omni_reconfigure)
   nodeLattice.reset();
 }
 
+TEST(SmacTest, test_smac_lattice_smoother_coverage)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("test.smooth_path", true)});
+  nav2::LifecycleNode::SharedPtr node =
+    std::make_shared<nav2::LifecycleNode>("SmacLatticeSmootherCovTest", options);
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  node->configure();
+  node->activate();
+
+  auto planner = std::make_unique<LatticeWrap>();
+  EXPECT_NO_THROW(planner->configure(node, "test", nullptr, costmap_ros));
+  planner->activate();
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  auto dummy_cancel_checker = []() { return false; };
+  geometry_msgs::msg::PoseStamped start, goal;
+  start.pose.position.x = 0.0;
+  start.pose.position.y = 0.0;
+  start.pose.orientation.w = 1.0;
+  goal.pose.position.x = 1.0;
+  goal.pose.position.y = 1.0;
+  goal.pose.orientation.w = 1.0;
+
+  nav_msgs::msg::Path plan;
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_FALSE(plan.poses.empty());
+
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  node->deactivate();
+  node->cleanup();
+  node.reset();
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -412,7 +412,7 @@ TEST(SmacTest, test_smac_lattice_smoother_coverage)
   planner->activate();
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
-  auto dummy_cancel_checker = []() { return false; };
+  auto dummy_cancel_checker = []() {return false;};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -418,7 +418,7 @@ TEST(SmacTest, test_smac_lattice_smoother_coverage)
   planner->activate();
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
-  auto dummy_cancel_checker = []() { return false; };
+  auto dummy_cancel_checker = []() {return false;};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -398,6 +398,49 @@ TEST(SmacTest, test_smac_lattice_omni_reconfigure)
   nodeLattice.reset();
 }
 
+TEST(SmacTest, test_smac_lattice_smoother_coverage)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("test.smooth_path", true)});
+  nav2::LifecycleNode::SharedPtr node =
+    std::make_shared<nav2::LifecycleNode>("SmacLatticeSmootherCovTest", options);
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  node->configure();
+  node->activate();
+
+  auto planner = std::make_unique<LatticeWrap>();
+  EXPECT_NO_THROW(planner->configure(node, "test", nullptr, costmap_ros));
+  planner->activate();
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  auto dummy_cancel_checker = []() { return false; };
+  geometry_msgs::msg::PoseStamped start, goal;
+  start.pose.position.x = 0.0;
+  start.pose.position.y = 0.0;
+  start.pose.orientation.w = 1.0;
+  goal.pose.position.x = 1.0;
+  goal.pose.position.y = 1.0;
+  goal.pose.orientation.w = 1.0;
+
+  nav_msgs::msg::Path plan;
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_FALSE(plan.poses.empty());
+
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  node->deactivate();
+  node->cleanup();
+  node.reset();
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -419,6 +419,7 @@ TEST(SmacTest, test_smac_lattice_smoother_coverage)
   EXPECT_TRUE(planner->hasSmootherInitialized());
 
   auto dummy_cancel_checker = []() {return false;};
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -428,7 +429,7 @@ TEST(SmacTest, test_smac_lattice_smoother_coverage)
   goal.pose.orientation.w = 1.0;
 
   nav_msgs::msg::Path plan;
-  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, dummy_cancel_checker));
+  EXPECT_NO_THROW(plan = planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker));
   EXPECT_FALSE(plan.poses.empty());
 
   planner->deactivate();

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
+#include "nav2_core/smoother_exceptions.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
@@ -238,10 +239,11 @@ TEST(SmootherTest, test_footprint_collision_detection)
   plan_copy = plan;
   EXPECT_TRUE(smoother->smooth(plan_copy, costmap, maxtime, narrow_footprint));
 
-  // With a wide footprint (1.2m wide): oriented footprint check detects collision at
-  // the very first pose (footprint extends ±0.6m in y, touching the lethal walls at
-  // y=4.4 and y=5.6). The smoothed path is truncated at idx=0 (empty prefix) and
-  // false is returned; the caller's path segment is left with the original planner poses.
+  // With a wide footprint (1.2m wide): the per-iteration oriented footprint check
+  // detects collision (footprint extends ±0.6m in y, touching the lethal walls at
+  // y=4.4 and y=5.6) and throws nav2_core::SmoothedPathInCollision — matching the
+  // canonical fail-loud idiom used by nav2_smoother::Nav2Smoother. The caller's
+  // path is left unchanged (full length preserved); no truncated path is returned.
   nav2_costmap_2d::Footprint wide_footprint;
   pt.x = 0.4; pt.y = 0.6; wide_footprint.push_back(pt);
   pt.x = 0.4; pt.y = -0.6; wide_footprint.push_back(pt);
@@ -249,7 +251,12 @@ TEST(SmootherTest, test_footprint_collision_detection)
   pt.x = -0.4; pt.y = 0.6; wide_footprint.push_back(pt);
 
   plan_copy = plan;
-  EXPECT_FALSE(smoother->smooth(plan_copy, costmap, maxtime, wide_footprint));
+  const size_t original_size = plan_copy.poses.size();
+  EXPECT_THROW(
+    smoother->smooth(plan_copy, costmap, maxtime, wide_footprint),
+    nav2_core::SmoothedPathInCollision);
+  // Path length is preserved on collision-throw — matches simple_smoother revert idiom.
+  EXPECT_EQ(plan_copy.poses.size(), original_size);
 
   delete costmap;
 }

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -238,8 +238,10 @@ TEST(SmootherTest, test_footprint_collision_detection)
   plan_copy = plan;
   EXPECT_TRUE(smoother->smooth(plan_copy, costmap, maxtime, narrow_footprint));
 
-  // With a wide footprint (1.2m wide): oriented footprint check must detect collision.
-  // The path travels along y=5.0 but the footprint extends ±0.6m in y — hitting the walls.
+  // With a wide footprint (1.2m wide): oriented footprint check detects collision at
+  // the very first pose (footprint extends ±0.6m in y, touching the lethal walls at
+  // y=4.4 and y=5.6). The smoothed path is truncated at idx=0 (empty prefix) and
+  // false is returned; the caller's path segment is left with the original planner poses.
   nav2_costmap_2d::Footprint wide_footprint;
   pt.x = 0.4; pt.y = 0.6; wide_footprint.push_back(pt);
   pt.x = 0.4; pt.y = -0.6; wide_footprint.push_back(pt);

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -20,7 +20,6 @@
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include "nav2_core/smoother_exceptions.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
@@ -241,9 +240,8 @@ TEST(SmootherTest, test_footprint_collision_detection)
 
   // With a wide footprint (1.2m wide): the per-iteration oriented footprint check
   // detects collision (footprint extends ±0.6m in y, touching the lethal walls at
-  // y=4.4 and y=5.6) and throws nav2_core::SmoothedPathInCollision — matching the
-  // canonical fail-loud idiom used by nav2_smoother::Nav2Smoother. The caller's
-  // path is left unchanged (full length preserved); no truncated path is returned.
+  // y=4.4 and y=5.6); smoother returns false and reverts to the last collision-free
+  // path, matching the simple_smoother per-iteration revert idiom.
   nav2_costmap_2d::Footprint wide_footprint;
   pt.x = 0.4; pt.y = 0.6; wide_footprint.push_back(pt);
   pt.x = 0.4; pt.y = -0.6; wide_footprint.push_back(pt);
@@ -252,10 +250,8 @@ TEST(SmootherTest, test_footprint_collision_detection)
 
   plan_copy = plan;
   const size_t original_size = plan_copy.poses.size();
-  EXPECT_THROW(
-    smoother->smooth(plan_copy, costmap, maxtime, wide_footprint),
-    nav2_core::SmoothedPathInCollision);
-  // Path length is preserved on collision-throw — matches simple_smoother revert idiom.
+  EXPECT_FALSE(smoother->smooth(plan_copy, costmap, maxtime, wide_footprint));
+  // Path length is preserved on revert — matches simple_smoother idiom.
   EXPECT_EQ(plan_copy.poses.size(), original_size);
 
   delete costmap;

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -180,6 +180,78 @@ TEST(SmootherTest, test_full_smoother)
   delete costmap;
 }
 
+// Regression test for #5330: SMAC smoother must detect oriented footprint collisions
+// for non-circular robots. A wide rectangular robot travelling diagonally through a
+// narrow corridor may have a clear center-cost path but a colliding oriented footprint.
+TEST(SmootherTest, test_footprint_collision_detection)
+{
+  nav2::LifecycleNode::SharedPtr node =
+    std::make_shared<nav2::LifecycleNode>("SmacSmootherFootprintTest");
+  nav2_smac_planner::SmootherParams params;
+  params.get(node, "test");
+  double maxtime = 1.0;
+
+  auto smoother = std::make_unique<SmootherWrapper>(params);
+  smoother->initialize(0.4);
+
+  // 100x100 costmap, 0.1m/cell → 10m x 10m
+  nav2_costmap_2d::Costmap2D * costmap =
+    new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0.0, 0.0, 0);
+
+  // Obstacle walls at y=40..44 and y=56..60 (cells), leaving a 1-cell wide gap at y=45..55.
+  // A circular robot (radius ≤ 0.5m) passes through the gap safely via center-cost check.
+  // A wide rectangular robot (width 1.2m) cannot fit without footprint collision.
+  for (unsigned int i = 0; i < 100; ++i) {
+    for (unsigned int j = 40; j <= 44; ++j) {
+      costmap->setCost(i, j, 254);  // lethal obstacle — lower wall
+    }
+    for (unsigned int j = 56; j <= 60; ++j) {
+      costmap->setCost(i, j, 254);  // lethal obstacle — upper wall
+    }
+  }
+
+  // Path: straight line from (0.5, 5.0) to (9.5, 5.0) — centre of the gap (y=5.0m = cell 50).
+  // Center-cost check passes because cell 50 is obstacle-free.
+  nav_msgs::msg::Path plan;
+  plan.header.frame_id = "map";
+  for (int i = 5; i <= 90; i += 5) {
+    geometry_msgs::msg::PoseStamped p;
+    p.header = plan.header;
+    p.pose.position.x = static_cast<double>(i) * 0.1;
+    p.pose.position.y = 5.0;
+    p.pose.orientation.w = 1.0;
+    plan.poses.push_back(p);
+  }
+
+  // Without footprint: smoothing succeeds (center-cost only).
+  auto plan_copy = plan;
+  EXPECT_TRUE(smoother->smooth(plan_copy, costmap, maxtime));
+
+  // With a narrow footprint (0.4m wide): also succeeds — fits in the gap.
+  nav2_costmap_2d::Footprint narrow_footprint;
+  geometry_msgs::msg::Point pt;
+  pt.x = 0.4; pt.y = 0.2; narrow_footprint.push_back(pt);
+  pt.x = 0.4; pt.y = -0.2; narrow_footprint.push_back(pt);
+  pt.x = -0.4; pt.y = -0.2; narrow_footprint.push_back(pt);
+  pt.x = -0.4; pt.y = 0.2; narrow_footprint.push_back(pt);
+
+  plan_copy = plan;
+  EXPECT_TRUE(smoother->smooth(plan_copy, costmap, maxtime, narrow_footprint));
+
+  // With a wide footprint (1.2m wide): oriented footprint check must detect collision.
+  // The path travels along y=5.0 but the footprint extends ±0.6m in y — hitting the walls.
+  nav2_costmap_2d::Footprint wide_footprint;
+  pt.x = 0.4; pt.y = 0.6; wide_footprint.push_back(pt);
+  pt.x = 0.4; pt.y = -0.6; wide_footprint.push_back(pt);
+  pt.x = -0.4; pt.y = -0.6; wide_footprint.push_back(pt);
+  pt.x = -0.4; pt.y = 0.6; wide_footprint.push_back(pt);
+
+  plan_copy = plan;
+  EXPECT_FALSE(smoother->smooth(plan_copy, costmap, maxtime, wide_footprint));
+
+  delete costmap;
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5330 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Unit tests only (colcon test) |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Adds an oriented footprint collision check to `Smoother::smoothImpl()` for non-circular robots. The existing per-iteration check uses centre-point cost only, which is sufficient for circular robots but misses orientation-dependent footprint extensions for wide rectangular robots.
* When a smoothed pose fails the footprint check, the smoother stops at that pose and uses the maximum collision-free smoothed prefix. The original planner path is retained from the collision point onward.
* All three planner plugins (Hybrid A\*, 2D, Lattice) forward `_costmap_ros->getRobotFootprint()` to the smoother. For circular robots the footprint is empty and behaviour is unchanged.

## Description of documentation updates required from your changes

* No new parameters added. No configuration file changes required.

## Description of how this change was tested

* New unit test `test_footprint_collision_detection` in `test_smoother.cpp`: 100×100 costmap with lethal walls forming a narrow corridor; confirms a narrow footprint passes and a wide 1.2 m footprint correctly stops at the collision-free boundary.
* New `test_smac_se2_smoother_coverage` and `test_smac_lattice_smoother_coverage` cover the updated `_smoother->smooth(...)` call sites in the planner plugins.
* All existing smoother and planner tests continue to pass.

---

## Future work that may be required in bullet points

* None identified.

---

*AI-assisted — authored with Claude, reviewed by Komada.*