### PR TITLE
fix(mypy): update pyproject.toml to pass ament_mypy on rolling (#5830)

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -14,11 +14,18 @@ force_single_line = false
 line_length = 99
 
 [tool.mypy]
+namespace_packages = true
 explicit_package_bases = true
 strict = true
+python_version = "3.10"
+disable_error_code = ["import-untyped"]
+warn_unused_ignores = false
+disallow_subclassing_any = false
 
 [[tool.mypy.overrides]]
 module = [
+    "launch_ros.*",
+    "rclpy.*",
     "matplotlib.*",
     "rtree.*",
     "launch.*",


### PR DESCRIPTION
## Problem

The `ament_mypy` pre-commit check fails in fresh `ros:rolling` environments after `apt upgrade` (issue #5830). Newer mypy (1.9.0 on Ubuntu Noble) introduced `[import-untyped]` as a distinct error code that fires when a package is **installed but has no `py.typed` marker or type stubs**. This affects all ROS message packages (`nav2_msgs`, `geometry_msgs`, `action_msgs`, etc.) and `launch_ros`, causing ament_mypy to fail on any Python file that imports them.

PR #5959 temporarily commented out `ament_mypy` as a workaround. This PR provides the proper fix.

## Changes (`tools/pyproject.toml`)

- `disable_error_code = ["import-untyped"]` — directly silences the new error code for packages that are installed but lack type stubs; these cannot be fixed without adding `py.typed` markers upstream in each ROS package
- `namespace_packages = true` — required for mypy to correctly resolve ROS namespace packages
- `python_version = "3.10"` — explicit target version for consistent behavior across environments
- `warn_unused_ignores = false` — with some ROS packages treated as `Any`, existing `# type: ignore` comments in files like `robot_navigator.py` become stale; disabling this avoids unnecessary churn in source files
- `disallow_subclassing_any = false` — nav2 nodes subclass `rclpy.node.Node`; on environments where rclpy has no stubs, `Node` is typed as `Any` and strict mode rejects subclassing it
- Added `rclpy.*` and `launch_ros.*` to the `ignore_missing_imports` overrides

## Testing

Verified locally with `ament_mypy --config tools/pyproject.toml` on representative Python files including `nav2_simple_commander/robot_navigator.py` and the benchmarking tools — all pass with exit code 0.

Fixes #5830