### PR TITLE
Fix build with kilted and jazzy on main because missing conversions

### DIFF
--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -94,7 +94,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   callback_group_executor_.spin_all(bt_loop_duration_);
 
   if (last_goal_received_set_) {
-    if (last_goal_received_.header.stamp == rclcpp::Time(0)) {
+    if (rclcpp::Time(last_goal_received_.header.stamp) == rclcpp::Time(0)) {
       // if the goal doesn't have a timestamp, we reject it
       RCLCPP_WARN(
         node_->get_logger(), "The received goal has no timestamp. Ignoring.");
@@ -119,7 +119,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   if (last_goals_received_set_) {
     if (last_goals_received_.goals.empty()) {
       setOutput("output_goals", goals);
-    } else if (last_goals_received_.header.stamp == rclcpp::Time(0)) {
+    } else if (rclcpp::Time(last_goals_received_.header.stamp) == rclcpp::Time(0)) {
       RCLCPP_WARN(
         node_->get_logger(), "The received goals array has no timestamp. Ignoring.");
       setOutput("output_goals", goals);

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -523,19 +523,19 @@ bool FollowingServer::getRefinedPose(geometry_msgs::msg::PoseStamped & pose)
   geometry_msgs::msg::PoseStamped detected = detected_dynamic_pose_;
 
   // If we haven't received any detection yet, wait up to detection_timeout_ for one to arrive.
-  if (detected.header.stamp == rclcpp::Time(0)) {
+  if (rclcpp::Time(detected.header.stamp) == rclcpp::Time(0)) {
     auto start = this->now();
     auto timeout = rclcpp::Duration::from_seconds(params_->detection_timeout);
     nav2::Rate wait_rate(this, params_->controller_frequency);
     while (this->now() - start < timeout) {
       // Check if a new detection arrived
-      if (detected_dynamic_pose_.header.stamp != rclcpp::Time(0)) {
+      if (rclcpp::Time(detected_dynamic_pose_.header.stamp) != rclcpp::Time(0)) {
         detected = detected_dynamic_pose_;
         break;
       }
       wait_rate.sleep();
     }
-    if (detected.header.stamp == rclcpp::Time(0)) {
+    if (rclcpp::Time(detected.header.stamp) == rclcpp::Time(0)) {
       RCLCPP_WARN(this->get_logger(), "No detection received within timeout period");
       return false;
     }


### PR DESCRIPTION
This PR fixes build with missing conversions errors in `nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp` and `nav2_following/opennav_following/src/following_server.cpp`. I got those while building ROS2 Kilted and Jazzy with the main branch version of Nav2, on Ubuntu 22.04 with GCC 11.4.0. I still don't understand (I searched but not find an answer) why those errors appeared but I guess it's due to some implicit or removed conversion (`builtin_interfaces::msg::Time_` and `rclcpp::Time` does not seem to be implicitly convertible nor have a comparison operator anymore). Here are the error log:
```
--- stderr: nav2_behavior_tree
/root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp: In member function ‘virtual BT::NodeStatus nav2_behavior_tree::GoalUpdater::tick()’:
/root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:97:42: error: ambiguous overload for ‘operator==’ (operand types are ‘std_msgs::msg::Header_<std::allocator<void> >::_stamp_type’ {aka ‘builtin_interfaces::msg::Time_<std::allocator<void> >’} and ‘rclcpp::Time’)
   97 |     if (last_goal_received_.header.stamp == rclcpp::Time(0)) {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~         ~~~~~~~
      |                                    |                |
      |                                    |                rclcpp::Time
      |                                    std_msgs::msg::Header_<std::allocator<void> >::_stamp_type {aka builtin_interfaces::msg::Time_<std::allocator<void> >}
In file included from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/clock.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/client.hpp:38,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/callback_group.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executor_options.hpp:22,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executor.hpp:38,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executors.hpp:21,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/rclcpp.hpp:172,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/nav2_ros_common/nav2_ros_common/node_utils.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/nav2_ros_common/nav2_ros_common/lifecycle_node.hpp:26,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp:22,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp:28,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:22:
/tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/time.hpp:121:3: note: candidate: ‘bool rclcpp::Time::operator==(const rclcpp::Time&) const’ (reversed)
  121 |   operator==(const rclcpp::Time & rhs) const;
      |   ^~~~~~~~
In file included from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/std_msgs/std_msgs/msg/detail/header__struct.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/geometry_msgs/geometry_msgs/msg/detail/pose_stamped__struct.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/geometry_msgs/geometry_msgs/msg/pose_stamped.hpp:7,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp:26,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:22:
/tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/builtin_interfaces/builtin_interfaces/msg/detail/time__struct.hpp:123:8: note: candidate: ‘bool builtin_interfaces::msg::Time_<ContainerAllocator>::operator==(const builtin_interfaces::msg::Time_<ContainerAllocator>&) const [with ContainerAllocator = std::allocator<void>]’
  123 |   bool operator==(const Time_ & other) const
      |        ^~~~~~~~
/root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:122:50: error: ambiguous overload for ‘operator==’ (operand types are ‘std_msgs::msg::Header_<std::allocator<void> >::_stamp_type’ {aka ‘builtin_interfaces::msg::Time_<std::allocator<void> >’} and ‘rclcpp::Time’)
  122 |     } else if (last_goals_received_.header.stamp == rclcpp::Time(0)) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~         ~~~~~~~
      |                                            |                |
      |                                            |                rclcpp::Time
      |                                            std_msgs::msg::Header_<std::allocator<void> >::_stamp_type {aka builtin_interfaces::msg::Time_<std::allocator<void> >}
In file included from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/clock.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/client.hpp:38,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/callback_group.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executor_options.hpp:22,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executor.hpp:38,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/executors.hpp:21,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/rclcpp.hpp:172,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/nav2_ros_common/nav2_ros_common/node_utils.hpp:25,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/nav2_ros_common/nav2_ros_common/lifecycle_node.hpp:26,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp:22,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp:28,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:22:
/tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/rclcpp/rclcpp/time.hpp:121:3: note: candidate: ‘bool rclcpp::Time::operator==(const rclcpp::Time&) const’ (reversed)
  121 |   operator==(const rclcpp::Time & rhs) const;
      |   ^~~~~~~~
In file included from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/std_msgs/std_msgs/msg/detail/header__struct.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/geometry_msgs/geometry_msgs/msg/detail/pose_stamped__struct.hpp:24,
                 from /tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/geometry_msgs/geometry_msgs/msg/pose_stamped.hpp:7,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp:26,
                 from /root/ros2_ws/src/navigation2/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp:22:
/tmp/ros2_deb_stage/opt/ros2-yona-kilted-all/include/builtin_interfaces/builtin_interfaces/msg/detail/time__struct.hpp:123:8: note: candidate: ‘bool builtin_interfaces::msg::Time_<ContainerAllocator>::operator==(const builtin_interfaces::msg::Time_<ContainerAllocator>&) const [with ContainerAllocator = std::allocator<void>]’
  123 |   bool operator==(const Time_ & other) const
      |        ^~~~~~~~
gmake[2]: *** [CMakeFiles/nav2_goal_updater_node_bt_node.dir/build.make:76: CMakeFiles/nav2_goal_updater_node_bt_node.dir/plugins/decorator/goal_updater_node.cpp.o] Error 1
```


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
