### PR TITLE
Fix compiler ambiguity error in Time type comparisons

### DIFF
--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -94,7 +94,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   callback_group_executor_.spin_all(bt_loop_duration_);
 
   if (last_goal_received_set_) {
-    if (rclcpp::Time(last_goal_received_.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
+    if (last_goal_received_.header.stamp == builtin_interfaces::msg::Time{}) {
       // if the goal doesn't have a timestamp, we reject it
       RCLCPP_WARN(
         node_->get_logger(), "The received goal has no timestamp. Ignoring.");
@@ -119,7 +119,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   if (last_goals_received_set_) {
     if (last_goals_received_.goals.empty()) {
       setOutput("output_goals", goals);
-    } else if (rclcpp::Time(last_goals_received_.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
+    } else if (last_goals_received_.header.stamp == builtin_interfaces::msg::Time{}) {
       RCLCPP_WARN(
         node_->get_logger(), "The received goals array has no timestamp. Ignoring.");
       setOutput("output_goals", goals);

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -94,7 +94,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   callback_group_executor_.spin_all(bt_loop_duration_);
 
   if (last_goal_received_set_) {
-    if (last_goal_received_.header.stamp == rclcpp::Time(0)) {
+    if (rclcpp::Time(last_goal_received_.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
       // if the goal doesn't have a timestamp, we reject it
       RCLCPP_WARN(
         node_->get_logger(), "The received goal has no timestamp. Ignoring.");
@@ -119,7 +119,7 @@ inline BT::NodeStatus GoalUpdater::tick()
   if (last_goals_received_set_) {
     if (last_goals_received_.goals.empty()) {
       setOutput("output_goals", goals);
-    } else if (last_goals_received_.header.stamp == rclcpp::Time(0)) {
+    } else if (rclcpp::Time(last_goals_received_.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
       RCLCPP_WARN(
         node_->get_logger(), "The received goals array has no timestamp. Ignoring.");
       setOutput("output_goals", goals);

--- a/nav2_behavior_tree/test/plugins/action/test_compute_and_track_route_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_and_track_route_action.cpp
@@ -154,7 +154,7 @@ TEST_F(ComputeAndTrackRouteActionTestFixture, test_tick_poses)
   builtin_interfaces::msg::Duration time1;
   EXPECT_TRUE(
     config_->blackboard->get<builtin_interfaces::msg::Duration>("execution_duration", time1));
-  EXPECT_EQ(time1, rclcpp::Duration::from_seconds(0.1));
+  EXPECT_EQ(rclcpp::Duration(time1), rclcpp::Duration::from_seconds(0.1));
 
   // halt node so another goal can be sent
   tree_->haltTree();
@@ -202,7 +202,7 @@ TEST_F(ComputeAndTrackRouteActionTestFixture, test_tick_ids)
   builtin_interfaces::msg::Duration time1;
   EXPECT_TRUE(
     config_->blackboard->get<builtin_interfaces::msg::Duration>("execution_duration", time1));
-  EXPECT_EQ(time1, rclcpp::Duration::from_seconds(0.1));
+  EXPECT_EQ(rclcpp::Duration(time1), rclcpp::Duration::from_seconds(0.1));
 
   // halt node so another goal can be sent
   tree_->haltTree();

--- a/nav2_behavior_tree/test/plugins/action/test_compute_route_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_route_action.cpp
@@ -163,7 +163,7 @@ TEST_F(ComputeRouteActionTestFixture, test_IDs)
 
   builtin_interfaces::msg::Duration time1;
   EXPECT_TRUE(config_->blackboard->get<builtin_interfaces::msg::Duration>("planning_time", time1));
-  EXPECT_EQ(time1, rclcpp::Duration::from_seconds(0.1));
+  EXPECT_EQ(rclcpp::Duration(time1), rclcpp::Duration::from_seconds(0.1));
 
   // halt node so another goal can be sent
   tree_->haltTree();
@@ -221,7 +221,7 @@ TEST_F(ComputeRouteActionTestFixture, test_poses)
 
   builtin_interfaces::msg::Duration time1;
   EXPECT_TRUE(config_->blackboard->get<builtin_interfaces::msg::Duration>("planning_time", time1));
-  EXPECT_EQ(time1, rclcpp::Duration::from_seconds(0.1));
+  EXPECT_EQ(rclcpp::Duration(time1), rclcpp::Duration::from_seconds(0.1));
 
   // halt node so another goal can be sent
   tree_->haltTree();

--- a/nav2_dwb_controller/nav_2d_utils/test/2d_utils_test.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/test/2d_utils_test.cpp
@@ -57,7 +57,7 @@ TEST(nav_2d_utils, PosesToPathEmpty)
 
   EXPECT_EQ(path.poses.size(), 0ul);
   EXPECT_EQ(path.header.frame_id, frame);
-  EXPECT_EQ(path.header.stamp, time);
+  EXPECT_EQ(rclcpp::Time(path.header.stamp, RCL_ROS_TIME), time);
 }
 
 TEST(nav_2d_utils, PosesToPathNonEmpty)
@@ -92,11 +92,11 @@ TEST(nav_2d_utils, PosesToPathNonEmpty)
 
   for (const auto & stamped_pose : path.poses) {
     EXPECT_EQ(stamped_pose.header.frame_id, frame);
-    EXPECT_EQ(stamped_pose.header.stamp, time);
+    EXPECT_EQ(rclcpp::Time(stamped_pose.header.stamp, RCL_ROS_TIME), time);
   }
 
   EXPECT_EQ(path.header.frame_id, frame);
-  EXPECT_EQ(path.header.stamp, time);
+  EXPECT_EQ(rclcpp::Time(path.header.stamp, RCL_ROS_TIME), time);
 }
 
 

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -523,19 +523,19 @@ bool FollowingServer::getRefinedPose(geometry_msgs::msg::PoseStamped & pose)
   geometry_msgs::msg::PoseStamped detected = detected_dynamic_pose_;
 
   // If we haven't received any detection yet, wait up to detection_timeout_ for one to arrive.
-  if (detected.header.stamp == rclcpp::Time(0)) {
+  if (rclcpp::Time(detected.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
     auto start = this->now();
     auto timeout = rclcpp::Duration::from_seconds(params_->detection_timeout);
     nav2::Rate wait_rate(this, params_->controller_frequency);
     while (this->now() - start < timeout) {
       // Check if a new detection arrived
-      if (detected_dynamic_pose_.header.stamp != rclcpp::Time(0)) {
+      if (rclcpp::Time(detected_dynamic_pose_.header.stamp, RCL_ROS_TIME) != rclcpp::Time(0)) {
         detected = detected_dynamic_pose_;
         break;
       }
       wait_rate.sleep();
     }
-    if (detected.header.stamp == rclcpp::Time(0)) {
+    if (rclcpp::Time(detected.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
       RCLCPP_WARN(this->get_logger(), "No detection received within timeout period");
       return false;
     }

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -523,19 +523,19 @@ bool FollowingServer::getRefinedPose(geometry_msgs::msg::PoseStamped & pose)
   geometry_msgs::msg::PoseStamped detected = detected_dynamic_pose_;
 
   // If we haven't received any detection yet, wait up to detection_timeout_ for one to arrive.
-  if (rclcpp::Time(detected.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
+  if (detected.header.stamp == builtin_interfaces::msg::Time{}) {
     auto start = this->now();
     auto timeout = rclcpp::Duration::from_seconds(params_->detection_timeout);
     nav2::Rate wait_rate(this, params_->controller_frequency);
     while (this->now() - start < timeout) {
       // Check if a new detection arrived
-      if (rclcpp::Time(detected_dynamic_pose_.header.stamp, RCL_ROS_TIME) != rclcpp::Time(0)) {
+      if (detected_dynamic_pose_.header.stamp != builtin_interfaces::msg::Time{}) {
         detected = detected_dynamic_pose_;
         break;
       }
       wait_rate.sleep();
     }
-    if (rclcpp::Time(detected.header.stamp, RCL_ROS_TIME) == rclcpp::Time(0)) {
+    if (detected.header.stamp == builtin_interfaces::msg::Time{}) {
       RCLCPP_WARN(this->get_logger(), "No detection received within timeout period");
       return false;
     }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Closes #6112  |
| Primary OS tested on | Ubuntu |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Followed the approach discussed in https://github.com/ros2/rclcpp/pull/2293 
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

Nothing
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Successfully built with `colcon build` and `g++-11` compiler
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
