### PR TITLE
Reduce runtime dependencies of packages

### DIFF
--- a/nav2_behavior_tree/package.xml
+++ b/nav2_behavior_tree/package.xml
@@ -11,11 +11,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>nav2_common</build_depend>
+
   <depend>action_msgs</depend>
   <depend>backward_ros</depend>
   <depend>behaviortree_cpp</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav2_common</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
   <depend>nav_msgs</depend>

--- a/nav2_collision_monitor/package.xml
+++ b/nav2_collision_monitor/package.xml
@@ -26,7 +26,8 @@
   <depend>visualization_msgs</depend>
   <depend>nav2_ros_common</depend>
   <depend>point_cloud_transport</depend>
-  <depend>point_cloud_transport_plugins</depend>
+
+  <exec_depend>point_cloud_transport_plugins</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_constrained_smoother/package.xml
+++ b/nav2_constrained_smoother/package.xml
@@ -9,12 +9,13 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>eigen</build_depend>
+  <build_depend>libceres-dev</build_depend>
   <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
-  <depend>libceres-dev</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_msgs</depend>

--- a/nav2_controller/package.xml
+++ b/nav2_controller/package.xml
@@ -8,9 +8,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>

--- a/nav2_costmap_2d/package.xml
+++ b/nav2_costmap_2d/package.xml
@@ -17,9 +17,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>laser_geometry</depend>
@@ -43,8 +45,8 @@
   <depend>visualization_msgs</depend>
   <depend>nav2_ros_common</depend>
   <depend>point_cloud_transport</depend>
-  <depend>point_cloud_transport_plugins</depend>
-  <depend>eigen</depend>
+
+  <exec_depend>point_cloud_transport_plugins</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_docking/opennav_docking/package.xml
+++ b/nav2_docking/opennav_docking/package.xml
@@ -8,9 +8,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_graceful_controller</depend>

--- a/nav2_dwb_controller/dwb_critics/package.xml
+++ b/nav2_dwb_controller/dwb_critics/package.xml
@@ -7,10 +7,11 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
 
   <depend>backward_ros</depend>
-  <depend>angles</depend>
   <depend>costmap_queue</depend>
   <depend>dwb_core</depend>
   <depend>dwb_msgs</depend>

--- a/nav2_dwb_controller/dwb_msgs/package.xml
+++ b/nav2_dwb_controller/dwb_msgs/package.xml
@@ -8,6 +8,7 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>backward_ros</depend>
   <depend>builtin_interfaces</depend>
@@ -15,7 +16,8 @@
   <depend>nav_2d_msgs</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>rosidl_default_runtime</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/nav2_dwb_controller/nav_2d_msgs/package.xml
+++ b/nav2_dwb_controller/nav_2d_msgs/package.xml
@@ -7,14 +7,14 @@
   <maintainer email="david@metrorobots.com">David V. Lu!!</maintainer>
   <license>BSD-3-Clause</license>
 
-  <build_export_depend>rosidl_default_runtime</build_export_depend>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>rosidl_default_generators</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/nav2_following/opennav_following/package.xml
+++ b/nav2_following/opennav_following/package.xml
@@ -8,9 +8,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>geometry_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_ros_common</depend>

--- a/nav2_graceful_controller/package.xml
+++ b/nav2_graceful_controller/package.xml
@@ -8,9 +8,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_core</depend>

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>eigen</build_depend>
   <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>
@@ -21,7 +22,6 @@
   <depend>rclcpp</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>launch_ros</depend>
-  <depend>launch_testing</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
@@ -31,7 +31,6 @@
   <depend>lifecycle_msgs</depend>
   <depend>nav2_ros_common</depend>
   <depend>uuid</depend>
-  <depend>eigen</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_mppi_controller/package.xml
+++ b/nav2_mppi_controller/package.xml
@@ -11,11 +11,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>angles</depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>angles</build_depend>
+  <build_depend>nav2_common</build_depend>
+
   <depend>backward_ros</depend>
-  <depend>benchmark</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav2_common</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_msgs</depend>
@@ -29,13 +30,13 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
-  <depend>eigen</depend>
   <depend>nav2_ros_common</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>benchmark</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_msgs/package.xml
+++ b/nav2_msgs/package.xml
@@ -10,18 +10,21 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
   <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>builtin_interfaces</depend>
-  <depend>rosidl_default_generators</depend>
   <depend>geometry_msgs</depend>
   <depend>action_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>unique_identifier_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/nav2_regulated_pure_pursuit_controller/package.xml
+++ b/nav2_regulated_pure_pursuit_controller/package.xml
@@ -9,9 +9,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_core</depend>

--- a/nav2_ros_common/package.xml
+++ b/nav2_ros_common/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>nav2_common</depend>
+  <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>
   <depend>bond</depend>
@@ -26,7 +26,6 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>pluginlib</depend>
   <depend>ament_index_cpp</depend>

--- a/nav2_rotation_shim_controller/package.xml
+++ b/nav2_rotation_shim_controller/package.xml
@@ -8,9 +8,10 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_core</depend>

--- a/nav2_route/package.xml
+++ b/nav2_route/package.xml
@@ -8,7 +8,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>libnanoflann-dev</build_depend>
   <build_depend>nav2_common</build_depend>
+  <build_depend>nlohmann-json-dev</build_depend>
+  <build_depend>angles</build_depend>
 
   <depend>backward_ros</depend>
   <depend>rclcpp</depend>
@@ -23,9 +27,6 @@
   <depend>tf2_ros</depend>
   <depend>nav2_util</depend>
   <depend>nav2_core</depend>
-  <depend>angles</depend>
-  <depend>libnanoflann-dev</depend>
-  <depend>nlohmann-json-dev</depend>
   <depend>nav2_ros_common</depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_smac_planner/package.xml
+++ b/nav2_smac_planner/package.xml
@@ -8,18 +8,19 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
   <build_depend>nav2_common</build_depend>
+  <build_depend>nlohmann-json-dev</build_depend>
+  <build_depend>angles</build_depend>
 
   <depend>ament_index_cpp</depend>
-  <depend>angles</depend>
   <depend>backward_ros</depend>
-  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_util</depend>
   <depend>nav_msgs</depend>
-  <depend>nlohmann-json-dev</depend>
   <depend>ompl</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/nav2_smoother/package.xml
+++ b/nav2_smoother/package.xml
@@ -9,9 +9,11 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <depend>angles</depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>nav2_common</build_depend>
+  <build_depend>angles</build_depend>
+
   <depend>backward_ros</depend>
   <depend>nav2_core</depend>
   <depend>nav2_costmap_2d</depend>
@@ -24,7 +26,6 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>nav2_ros_common</depend>
-  <depend>eigen</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -11,7 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>nav2_common</depend>
+  <build_depend>angles</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>
   <depend>bond</depend>
@@ -32,7 +33,6 @@
   <depend>tf2_ros</depend>
   <depend>pluginlib</depend>
   <depend>nav2_ros_common</depend>
-  <depend>angles</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Resolves #5379  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |N/A |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Declared `benchmark` as a testing dependency.

* Moved `point_cloud_transport_plugins` to a runtime dependency, as there are no headers from it being used.

* Reduce the runtime dependencies of certain packages by explicitly declaring the dependency as `<build_depend>` instead of `<depend>`

* The verification of the dropped runtime dependency can be seen when building the affected packages with `bloom`. Let's take `nav2_constrained_smoother` for instance:

   * `main`
   
  ```bash
  grep "^Depends:" /nav2_constrained_smoother/debian
  Depends: ${shlibs:Depends}, ${misc:Depends}, libceres-dev, ros-rolling-backward-ros, ros-rolling-geometry-msgs, ros-rolling-nav2-core, ros-rolling-nav2-costmap-2d, ros-rolling-nav2-msgs, ros-rolling-nav2-ros-common, ros-rolling-nav2-util, ros-rolling-pluginlib, ros-rolling-rclcpp, ros-rolling-rclcpp-lifecycle, ros-rolling-tf2-ros  
  ```

   * After this contribution:
   
   ```bash
  grep "^Depends:" /nav2_constrained_smoother/debian
  Depends: ${shlibs:Depends}, ${misc:Depends}, ros-rolling-backward-ros, ros-rolling-geometry-msgs, ros-rolling-nav2-core, ros-rolling-nav2-costmap-2d, ros-rolling-nav2-msgs, ros-rolling-nav2-ros-common, ros-rolling-nav2-util, ros-rolling-pluginlib, ros-rolling-rclcpp, ros-rolling-rclcpp-lifecycle, ros-rolling-tf2-ros  
  ```

   As you can see here, `libceres-dev` is omitted as a runtime dependency.

   The net savings for `nav2_constrained_smoother` is **19.8 MB** direct, **960 MB** transitive:
  ```bash
  # Direct size
  $ apt-cache show libceres-dev | grep "Installed-Size:"
  Installed-Size: 19792

  # Transitive tree (full recursive dependency chain)
  $ apt-cache depends --recurse \
      --no-recommends --no-suggests \
      --no-conflicts --no-breaks \
      --no-replaces --no-enhances \
      libceres-dev \
    | grep "^\w" | sort -u \
    | xargs -I{} apt-cache show {} 2>/dev/null \
    | grep "^Installed-Size:" \
    | awk '{sum+=$2} END{print sum " KB"}'
  960170 KB
  ```

* This is the estimated savings per dependency:

  | Runtime Dependency | Direct Size | Transitive Tree |
  |---|---|---|
  | `libceres-dev` | 19.8 MB | 960 MB |
  | `benchmark` | 0.2 MB | 33 MB |
  | `eigen` | 8.7 MB | 44 MB |
  | `libnanoflann-dev` | 2.1 MB | 2.1 MB |
  | `nlohmann-json-dev` | 1.4 MB | 1.4 MB |
  | `tf2_msgs` | 2.3 MB | 2.3 MB |


<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

* Maybe explicit development guidelines can be added to enable adding specific dependency type.

   For instance, runtime - `<exec_depend>`, testing - `<test_depend>`, and so on ..

## Description of how this change was tested

* The packages have been locally built using `bloom`, and the affected runtime dependency drop can be seen.

---

## Future work that may be required in bullet points
* N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
