### PR TITLE
feat(Smac Hybrid planner): prefer forward motion on high reverse penalty

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -53,6 +53,7 @@ struct SearchInfo
   bool allow_primitive_interpolation{false};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
+  bool prefer_forward_expansions{false};
 };
 
 /**

--- a/nav2_smac_planner/src/analytic_expansion.cpp
+++ b/nav2_smac_planner/src/analytic_expansion.cpp
@@ -411,6 +411,38 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
     }
   }
 
+  // When prefer_forward_expansions is set and the motion model is Reeds-Shepp,
+  // also attempt a Dubins (forward-only) expansion over the same range of turning
+  // radii and prefer it if it scores below the ReedsShepp score multiplied by reverse_penalty.
+  if (_search_info.prefer_forward_expansions &&
+    _ctx->motion_table.motion_model == MotionModel::REEDS_SHEPP)
+  {
+    AnalyticExpansionNodes dubins_nodes;
+    float best_dubins_score = std::numeric_limits<float>::max();
+    float dubins_min_turn_rad = _ctx->motion_table.min_turning_radius;
+    const float dubins_max_turn_rad = 4.0 * dubins_min_turn_rad;
+
+    while (dubins_min_turn_rad < dubins_max_turn_rad) {
+      dubins_min_turn_rad += 0.5;
+      ompl::base::StateSpacePtr dubins_space =
+        std::make_shared<ompl::base::DubinsStateSpace>(dubins_min_turn_rad);
+      AnalyticExpansionNodes dubins_refined_nodes =
+        getAnalyticPath(node, goal_node, getter, dubins_space);
+      float dubins_score = scoringFn(dubins_refined_nodes);
+
+      if (dubins_score < best_dubins_score) {
+        dubins_nodes = dubins_refined_nodes;
+        best_dubins_score = dubins_score;
+      }
+    }
+
+    // Penalise the ReedsShepp score to bias toward the forward-only Dubins result
+    if (best_dubins_score < best_score * _search_info.reverse_penalty) {
+      analytic_nodes = dubins_nodes;
+      best_score = best_dubins_score;
+    }
+  }
+
   return best_score;
 }
 

--- a/nav2_smac_planner/src/analytic_expansion.cpp
+++ b/nav2_smac_planner/src/analytic_expansion.cpp
@@ -413,7 +413,7 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
 
   // When prefer_forward_expansions is set and the motion model is Reeds-Shepp,
   // also attempt a Dubins (forward-only) expansion over the same range of turning
-  // radii and prefer it if it scores below the ReedsShepp score multiplied by reverse_penalty.
+  // radii and prefer it if it achieves a lower score than the Reeds-Shepp result.
   if (_search_info.prefer_forward_expansions &&
     _ctx->motion_table.motion_model == MotionModel::REEDS_SHEPP)
   {
@@ -436,8 +436,7 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
       }
     }
 
-    // Penalise the ReedsShepp score to bias toward the forward-only Dubins result
-    if (best_dubins_score < best_score * _search_info.reverse_penalty) {
+    if (best_dubins_score < best_score) {
       analytic_nodes = dubins_nodes;
       best_score = best_dubins_score;
     }

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -110,6 +110,8 @@ void SmacPlannerHybrid::configure(
     node->declare_or_get_parameter(name + ".use_quadratic_cost_penalty", false);
   _search_info.downsample_obstacle_heuristic =
     node->declare_or_get_parameter(name + ".downsample_obstacle_heuristic", true);
+  _search_info.prefer_forward_expansions =
+    node->declare_or_get_parameter(name + ".prefer_forward_expansions", false);
 
   analytic_expansion_max_length_m =
     node->declare_or_get_parameter(name + ".analytic_expansion_max_length", 3.0);
@@ -756,6 +758,9 @@ SmacPlannerHybrid::updateParametersCallback(const std::vector<rclcpp::Parameter>
         }
       } else if (param_name == _name + ".analytic_expansion_max_cost_override") {
         _search_info.analytic_expansion_max_cost_override = parameter.as_bool();
+        reinit_a_star = true;
+      } else if (param_name == _name + ".prefer_forward_expansions") {
+        _search_info.prefer_forward_expansions = parameter.as_bool();
         reinit_a_star = true;
       }
     } else if (param_type == ParameterType::PARAMETER_INTEGER) {

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -105,6 +105,8 @@ void SmacPlannerLattice::configure(
     node->declare_or_get_parameter(name + ".use_quadratic_cost_penalty", false);
   _search_info.downsample_obstacle_heuristic =
     node->declare_or_get_parameter(name + ".downsample_obstacle_heuristic", true);
+  _search_info.prefer_forward_expansions =
+    node->declare_or_get_parameter(name + ".prefer_forward_expansions", false);
 
   _max_planning_time = node->declare_or_get_parameter(name + ".max_planning_time", 5.0);
   _lookup_table_size = node->declare_or_get_parameter(name + ".lookup_table_size", 20.0);
@@ -666,6 +668,9 @@ SmacPlannerLattice::updateParametersCallback(const std::vector<rclcpp::Parameter
         }
       } else if (param_name == _name + ".analytic_expansion_max_cost_override") {
         _search_info.analytic_expansion_max_cost_override = parameter.as_bool();
+        reinit_a_star = true;
+      } else if (param_name == _name + ".prefer_forward_expansions") {
+        _search_info.prefer_forward_expansions = parameter.as_bool();
         reinit_a_star = true;
       }
     } else if (param_type == ParameterType::PARAMETER_INTEGER) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Closes #6075 |
| Primary OS tested on | Ubuntu 24.04.4 LTS |
| Robotic platform tested on | Gazebo TB3/4 |
| Does this PR contain AI generated software? |No|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
