### PR TITLE
Skip testing and related dependencies to speed up CI builds.

### DIFF
--- a/.github/workflows/build_main_against_distros.yml
+++ b/.github/workflows/build_main_against_distros.yml
@@ -23,7 +23,9 @@ jobs:
       run: |
         mkdir -p /tmp/docker_context/ws/src
         cp -r . /tmp/docker_context/ws/src
-        echo 'FROM ghcr.io/ros-navigation/nav2_docker:${{ matrix.ros_distro }}-nightly-standard
+        cat > /tmp/docker_context/Dockerfile << 'EOF'
+
+        FROM ghcr.io/ros-navigation/nav2_docker:${{ matrix.ros_distro }}-nightly-standard
 
         RUN apt-get update && apt-get install -y \
           python3-pip \
@@ -41,9 +43,24 @@ jobs:
 
         RUN apt-get update && rosdep update && \
           rosdep install --from-paths src --ignore-src -r -y \
-          --skip-keys=slam_toolbox
+            -t build \
+            -t buildtool \
+            -t build_export \
+            -t buildtool_export \
+            -t exec \
+            --skip-keys=slam_toolbox
 
-        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && colcon build --packages-skip nav2_system_tests nav2_bringup nav2_simple_commander nav2_loopback_sim navigation2' > /tmp/docker_context/Dockerfile
+        RUN . /opt/ros/${{ matrix.ros_distro }}/setup.sh && \
+          colcon build \
+            --packages-skip \
+              nav2_system_tests \
+              nav2_bringup \
+              nav2_simple_commander \
+              nav2_loopback_sim \
+              navigation2 \
+            --cmake-args -DBUILD_TESTING=OFF
+
+        EOF
 
 
     - name: Build Docker image


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Inspired from https://github.com/ros-navigation/nav2_docker/pull/28  |
| Primary OS tested on | N/A |
| Robotic platform tested on |N/A |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Removed installation of test dependencies and building of tests, since we are not running tests in this pipeline.
* The motivation is to speed up the build against past distros.

## Description of documentation updates required from your changes

* N/A

## Description of how this change was tested

* The testing here should just be clarifying whether the CI builds for `kilted` and `jazzy`.

---

## Future work that may be required in bullet points
* N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
