### PR TITLE
[Collision Monitor/Detector] Add triggering points

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -61,12 +61,20 @@ public:
   void getPolygon(std::vector<Point> & poly) const override;
 
   /**
+   * @brief Tests whether a single point lies inside the circle (radius math).
+   */
+  bool isPointInside(const Point & point) const override;
+
+  /**
    * @brief Gets number of points inside circle
    * @param points Input array of points to be checked
+   * @param out_triggering_points Optional output vector receiving the points inside
    * @return Number of points inside circle. If there are no points,
    * returns zero value.
    */
-  int getPointsInside(const std::vector<Point> & points) const override;
+  int getPointsInside(
+    const std::vector<Point> & points,
+    std::vector<Point> * out_triggering_points = nullptr) const override;
 
   /**
    * @brief Returns true if circle radius is set.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -72,6 +72,17 @@ public:
     std::vector<Point> & out_triggering_points) const override;
 
   /**
+   * @brief Gets indices of points inside circle
+   * @param points Input array of points to be checked
+   * @param out_triggering_indices Output array of triggering points indices
+   * @return Number of points inside circle. If there are no points,
+   * returns zero value.
+   */
+  int getPointsInside(
+    const std::vector<Point> & points,
+    std::vector<std::size_t> & out_triggering_indices) const override;
+
+  /**
    * @brief Returns true if circle radius is set.
    * Otherwise, prints a warning and returns false.
    */

--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -61,20 +61,15 @@ public:
   void getPolygon(std::vector<Point> & poly) const override;
 
   /**
-   * @brief Tests whether a single point lies inside the circle (radius math).
-   */
-  bool isPointInside(const Point & point) const override;
-
-  /**
    * @brief Gets number of points inside circle
    * @param points Input array of points to be checked
-   * @param out_triggering_points Optional output vector receiving the points inside
+   * @param out_triggering_points Output array of triggering points
    * @return Number of points inside circle. If there are no points,
    * returns zero value.
    */
   int getPointsInside(
     const std::vector<Point> & points,
-    std::vector<Point> * out_triggering_points = nullptr) const override;
+    std::vector<Point> & out_triggering_points) const override;
 
   /**
    * @brief Returns true if circle radius is set.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -174,6 +174,8 @@ protected:
   double frequency_;
   /// @brief Whether to include z in the collision_points_marker
   bool collision_points_marker_3d_;
+  /// @brief Robot base frame ID
+  std::string base_frame_id_;
 };  // class CollisionDetector
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -139,12 +139,11 @@ protected:
 
   /**
    * @brief Publishes the points inside each detected polygon as markers,
-   * keyed by per-source. Caller should gate on subscriber count.
-   * @param all_triggering_points Map from polygon name to its per-source triggering points
+   * bucketed by polygon name and per-point source.
+   * @param all_triggering_points Map from polygon name to its triggering points.
    */
   void publishTriggeringPoints(
-    const std::unordered_map<std::string,
-    std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points);
+    const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points);
 
   // ----- Variables -----
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -144,7 +144,7 @@ protected:
    */
   void publishTriggeringPoints(
     const std::unordered_map<std::string,
-      std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points);
+    std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points);
 
   // ----- Variables -----
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -172,6 +172,8 @@ protected:
 
   /// @brief main loop frequency
   double frequency_;
+  /// @brief Whether to include z in the collision_points_marker
+  bool collision_points_marker_3d_;
 };  // class CollisionDetector
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -136,6 +137,15 @@ protected:
    */
   void publishPolygons() const;
 
+  /**
+   * @brief Publishes the points inside each detected polygon as markers,
+   * keyed by per-source. Caller should gate on subscriber count.
+   * @param all_triggering_points Map from polygon name to its per-source triggering points
+   */
+  void publishTriggeringPoints(
+    const std::unordered_map<std::string,
+      std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points);
+
   // ----- Variables -----
 
   /// @brief TF buffer
@@ -154,6 +164,9 @@ protected:
   /// @brief Collision points marker publisher
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_pub_;
+  /// @brief Triggering points marker publisher (points inside each detected polygon)
+  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+    triggering_points_pub_;
   /// @brief timer that runs actions
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -257,6 +257,9 @@ protected:
   /// @brief Whether to include z in the collision_points_marker
   bool collision_points_marker_3d_;
 
+  /// @brief Robot base frame ID
+  std::string base_frame_id_;
+
   /// @brief Whether collision monitor is enabled
   bool enabled_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -254,6 +254,9 @@ protected:
   /// @brief Enable/disable collision monitor service
   nav2::ServiceServer<nav2_msgs::srv::Toggle>::SharedPtr toggle_cm_service_;
 
+  /// @brief Whether to include z in the collision_points_marker
+  bool collision_points_marker_3d_;
+
   /// @brief Whether collision monitor is enabled
   bool enabled_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -203,6 +203,14 @@ protected:
   void publishPolygons() const;
 
   /**
+   * @brief Publishes the points responsible for the current collision-monitor action.
+   * Publish action.triggering_points (populated by processStopSlowdownLimit / processApproach),
+   * colour-coded by action type, as markers.
+   * @param action Current robot action
+   */
+  void publishTriggeringPoints(const Action & action);
+
+  /**
    * @brief Enable/disable collision monitor service callback
    * @param request Service request
    * @param response Service response
@@ -238,6 +246,10 @@ protected:
   /// @brief Collision points marker publisher
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_pub_;
+
+  /// @brief Triggering points marker publisher (points inside the active triggering zone)
+  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+    triggering_points_pub_;
 
   /// @brief Enable/disable collision monitor service
   nav2::ServiceServer<nav2_msgs::srv::Toggle>::SharedPtr toggle_cm_service_;

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/twist.hpp"
@@ -162,30 +161,28 @@ protected:
   /**
    * @brief Processes the polygon of STOP, SLOWDOWN and LIMIT action type
    * @param polygon Polygon to process
-   * @param sources_collision_points_map Map containing source name as key and
-   * array of source's 2D obstacle points as value
+   * @param collision_points Array of obstacle points with source name
    * @param velocity Desired robot velocity
    * @param robot_action Output processed robot action
    * @return True if returned action is caused by current polygon, otherwise false
    */
   bool processStopSlowdownLimit(
     const std::shared_ptr<Polygon> polygon,
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    const std::vector<Point> & collision_points,
     const Velocity & velocity,
     Action & robot_action) const;
 
   /**
    * @brief Processes APPROACH action type
    * @param polygon Polygon to process
-   * @param sources_collision_points_map Map containing source name as key and
-   * array of source's 2D obstacle points as value
+   * @param collision_points Array of obstacle points with source name
    * @param velocity Desired robot velocity
    * @param robot_action Output processed robot action
    * @return True if returned action is caused by current polygon, otherwise false
    */
   bool processApproach(
     const std::shared_ptr<Polygon> polygon,
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    const std::vector<Point> & collision_points,
     const Velocity & velocity,
     Action & robot_action) const;
 
@@ -203,9 +200,7 @@ protected:
   void publishPolygons() const;
 
   /**
-   * @brief Publishes the points responsible for the current collision-monitor action.
-   * Publish action.triggering_points (populated by processStopSlowdownLimit / processApproach),
-   * colour-coded by action type, as markers.
+   * @brief Publishes action.triggering_points as markers, colour-coded by action type.
    * @param action Current robot action
    */
   void publishTriggeringPoints(const Action & action);

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/twist.hpp"
@@ -161,28 +162,30 @@ protected:
   /**
    * @brief Processes the polygon of STOP, SLOWDOWN and LIMIT action type
    * @param polygon Polygon to process
-   * @param collision_points Array of obstacle points with source name
+   * @param sources_collision_points_map Map containing source name as key and
+   * array of source's 2D obstacle points as value
    * @param velocity Desired robot velocity
    * @param robot_action Output processed robot action
    * @return True if returned action is caused by current polygon, otherwise false
    */
   bool processStopSlowdownLimit(
     const std::shared_ptr<Polygon> polygon,
-    const std::vector<Point> & collision_points,
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
     const Velocity & velocity,
     Action & robot_action) const;
 
   /**
    * @brief Processes APPROACH action type
    * @param polygon Polygon to process
-   * @param collision_points Array of obstacle points with source name
+   * @param sources_collision_points_map Map containing source name as key and
+   * array of source's 2D obstacle points as value
    * @param velocity Desired robot velocity
    * @param robot_action Output processed robot action
    * @return True if returned action is caused by current polygon, otherwise false
    */
   bool processApproach(
     const std::shared_ptr<Polygon> polygon,
-    const std::vector<Point> & collision_points,
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
     const Velocity & velocity,
     Action & robot_action) const;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -176,7 +176,7 @@ public:
    * @brief Gets number of points inside given polygon
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's points to be checked as value
-    * @param out_triggering_points Output array of triggering points.
+   * @param out_triggering_points Output array of triggering points.
    * @return Number of points inside polygon,
    * for sources in map that are associated with current polygon.
    * If there are no points, returns zero value.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -101,12 +101,12 @@ public:
   /**
    * @brief Temporal debounce for min_points trigger.
    * @param points Input array of points to be checked.
-   * @param out_triggering_points Optional output vector receiving the triggering points.
+   * @param out_triggering_points Output array of triggering points.
    * @return true if trigger should be considered active after debounce/hold logic.
    */
   bool isTriggered(
-    const std::vector<Point> & points,
-    std::vector<Point> * out_triggering_points = nullptr);
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    std::vector<Point> & out_triggering_points);
 
   /**
    * @brief Reset temporal debounce state.
@@ -161,21 +161,29 @@ public:
   virtual void updatePolygon(const Velocity & /*cmd_vel_in*/);
 
   /**
-   * @brief Tests whether a single point lies inside the polygon shape.
-   * Subclasses override to use shape-specific math (e.g. Circle uses radius).
-   */
-  virtual bool isPointInside(const Point & point) const;
-
-  /**
    * @brief Gets number of points inside given polygon
    * @param points Input array of points to be checked
-   * @param out_triggering_points Optional output vector receiving the points inside
+   * @param out_triggering_points Output array of triggering points.
    * @return Number of points inside polygon. If there are no points,
    * returns zero value.
    */
   virtual int getPointsInside(
     const std::vector<Point> & points,
-    std::vector<Point> * out_triggering_points = nullptr) const;
+    std::vector<Point> & out_triggering_points) const;
+
+  /**
+   * @brief Gets number of points inside given polygon
+   * @param sources_collision_points_map Map containing source name as key,
+   * and input array of source's points to be checked as value
+    * @param out_triggering_points Output array of triggering points.
+   * @return Number of points inside polygon,
+   * for sources in map that are associated with current polygon.
+   * If there are no points, returns zero value.
+   */
+  virtual int getPointsInside(
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    std::vector<Point> & out_triggering_points) const;
+
 
   /**
    * @brief Obtains estimated (simulated) time before a collision.
@@ -188,7 +196,7 @@ public:
    * return value will be negative.
    */
   double getCollisionTime(
-    const std::vector<Point> & collision_points,
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
     const Velocity & velocity,
     std::vector<Point> & out_triggering_points) const;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/polygon_stamped.hpp"
@@ -102,23 +101,12 @@ public:
   /**
    * @brief Temporal debounce for min_points trigger.
    * @param points Input array of points to be checked.
-   * @return true if trigger should be considered active after debounce/hold logic.
-   */
-  bool isTriggered(const std::vector<Point> & points);
-
-  /**
-   * @brief Temporal debounce for min_points trigger. Optionally collects the in-polygon
-   * points in a single pass so callers can avoid a second scan via getPointsInside().
-   * @param sources_collision_points_map Map containing source name as key,
-   * and input array of source's points to be checked as value.
-   * @param out_triggering_points Optional output map from source name to the subset of
-   * points found inside the polygon. Populated regardless of debounce state; callers
-   * can consume it when the return value is true.
+   * @param out_triggering_points Optional output vector receiving the triggering points.
    * @return true if trigger should be considered active after debounce/hold logic.
    */
   bool isTriggered(
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-    std::unordered_map<std::string, std::vector<Point>> * out_triggering_points = nullptr);
+    const std::vector<Point> & points,
+    std::vector<Point> * out_triggering_points = nullptr);
 
   /**
    * @brief Reset temporal debounce state.
@@ -173,57 +161,36 @@ public:
   virtual void updatePolygon(const Velocity & /*cmd_vel_in*/);
 
   /**
+   * @brief Tests whether a single point lies inside the polygon shape.
+   * Subclasses override to use shape-specific math (e.g. Circle uses radius).
+   */
+  virtual bool isPointInside(const Point & point) const;
+
+  /**
    * @brief Gets number of points inside given polygon
    * @param points Input array of points to be checked
+   * @param out_triggering_points Optional output vector receiving the points inside
    * @return Number of points inside polygon. If there are no points,
    * returns zero value.
    */
-  virtual int getPointsInside(const std::vector<Point> & points) const;
-
-  /**
-   * @brief Gets number of points inside given polygon, optionally collecting them as triggering points.
-   * @param sources_collision_points_map Map containing source name as key,
-   * and input array of source's points to be checked as value
-   * @param out_triggering_points Optional output map from source name to the subset of points inside
-   * @return Number of points inside polygon,
-   * for sources in map that are associated with current polygon.
-   * If there are no points, returns zero value.
-   */
   virtual int getPointsInside(
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-    std::unordered_map<std::string, std::vector<Point>> * out_triggering_points = nullptr) const;
+    const std::vector<Point> & points,
+    std::vector<Point> * out_triggering_points = nullptr) const;
 
   /**
-   * @brief Gets number of points inside given polygon for APPROACH-model using the
-   * transformed_points, but also records the index-matched entry from original_points into
-   * out_triggering_points so visualization shows where the obstacle is.
-   * @param transformed_points Per-source points used for the in-polygon test.
-   * @param original_points Per-source points whose entries get recorded;
-   * index-parallel to transformed_points for each source name.
-   * @param out_triggering_points Output map; entries are pushed during the count, so
-   * callers should consume it only when the return value meets min_points_.
-   * @return Number of points inside polygon for sources associated with current polygon.
-   */
-  virtual int getPointsInsideApproach(
-    const std::unordered_map<std::string, std::vector<Point>> & transformed_points,
-    const std::unordered_map<std::string, std::vector<Point>> & original_points,
-    std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const;
-
-  /**
-   * @brief Obtains estimated (simulated) time before a collision and captures the triggering
-   * points at the collision step. Applicable for APPROACH model.
-   * @param sources_collision_points_map Map containing source name as key,
-   * and input array of source's 2D obstacle points as value
+   * @brief Obtains estimated (simulated) time before a collision.
+   * Applicable for APPROACH model.
+   * @param collision_points Input 2D obstacle points
    * @param velocity Simulated robot velocity
-   * @param out_triggering_points Output map for source name and the points responsible
-   * for the triggering points
+   * @param out_triggering_points Output vector receiving the original points
+   * responsible for the collision (populated only on a triggering step)
    * @return Estimated time before a collision. If there is no collision,
    * return value will be negative.
    */
   double getCollisionTime(
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    const std::vector<Point> & collision_points,
     const Velocity & velocity,
-    std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const;
+    std::vector<Point> & out_triggering_points) const;
 
   /**
    * @brief Publishes polygon message into a its own topic

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -107,13 +107,18 @@ public:
   bool isTriggered(const std::vector<Point> & points);
 
   /**
-   * @brief Temporal debounce for min_points trigger.
+   * @brief Temporal debounce for min_points trigger. Optionally collects the in-polygon
+   * points in a single pass so callers can avoid a second scan via getPointsInside().
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's points to be checked as value.
+   * @param out_triggering_points Optional output map from source name to the subset of
+   * points found inside the polygon. Populated regardless of debounce state; callers
+   * can consume it when the return value is true.
    * @return true if trigger should be considered active after debounce/hold logic.
    */
   bool isTriggered(
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map);
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    std::unordered_map<std::string, std::vector<Point>> * out_triggering_points = nullptr);
 
   /**
    * @brief Reset temporal debounce state.
@@ -176,28 +181,49 @@ public:
   virtual int getPointsInside(const std::vector<Point> & points) const;
 
   /**
-   * @brief Gets number of points inside given polygon
+   * @brief Gets number of points inside given polygon, optionally collecting them as triggering points.
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's points to be checked as value
+   * @param out_triggering_points Optional output map from source name to the subset of points inside
    * @return Number of points inside polygon,
    * for sources in map that are associated with current polygon.
    * If there are no points, returns zero value.
    */
   virtual int getPointsInside(
-    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map) const;
+    const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+    std::unordered_map<std::string, std::vector<Point>> * out_triggering_points = nullptr) const;
 
   /**
-   * @brief Obtains estimated (simulated) time before a collision.
-   * Applicable for APPROACH model.
+   * @brief Gets number of points inside given polygon for APPROACH-model using the
+   * transformed_points, but also records the index-matched entry from original_points into
+   * out_triggering_points so visualization shows where the obstacle is.
+   * @param transformed_points Per-source points used for the in-polygon test.
+   * @param original_points Per-source points whose entries get recorded;
+   * index-parallel to transformed_points for each source name.
+   * @param out_triggering_points Output map; entries are pushed during the count, so
+   * callers should consume it only when the return value meets min_points_.
+   * @return Number of points inside polygon for sources associated with current polygon.
+   */
+  virtual int getPointsInsideApproach(
+    const std::unordered_map<std::string, std::vector<Point>> & transformed_points,
+    const std::unordered_map<std::string, std::vector<Point>> & original_points,
+    std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const;
+
+  /**
+   * @brief Obtains estimated (simulated) time before a collision and captures the triggering
+   * points at the collision step. Applicable for APPROACH model.
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's 2D obstacle points as value
    * @param velocity Simulated robot velocity
+   * @param out_triggering_points Output map for source name and the points responsible 
+   * for the triggering points
    * @return Estimated time before a collision. If there is no collision,
    * return value will be negative.
    */
   double getCollisionTime(
     const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-    const Velocity & velocity) const;
+    const Velocity & velocity,
+    std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const;
 
   /**
    * @brief Publishes polygon message into a its own topic

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -215,7 +215,7 @@ public:
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's 2D obstacle points as value
    * @param velocity Simulated robot velocity
-   * @param out_triggering_points Output map for source name and the points responsible 
+   * @param out_triggering_points Output map for source name and the points responsible
    * for the triggering points
    * @return Estimated time before a collision. If there is no collision,
    * return value will be negative.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/polygon_stamped.hpp"

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -173,6 +173,17 @@ public:
     std::vector<Point> & out_triggering_points) const;
 
   /**
+   * @brief Gets indices of points inside given polygon
+   * @param points Input array of points to be checked
+   * @param out_triggering_indices Output array of triggering points indices
+   * @return Number of points inside polygon. If there are no points,
+   * returns zero value.
+   */
+  virtual int getPointsInside(
+    const std::vector<Point> & points,
+    std::vector<std::size_t> & out_triggering_indices) const;
+
+  /**
    * @brief Gets number of points inside given polygon
    * @param sources_collision_points_map Map containing source name as key,
    * and input array of source's points to be checked as value

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -16,6 +16,8 @@
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace nav2_collision_monitor
 {
@@ -46,11 +48,12 @@ struct Velocity
   }
 };
 
-/// @brief 2D point
+/// @brief Point with 2D collision-check coordinates and optional z from the source
 struct Point
 {
-  double x;  // x-coordinate of point
-  double y;  // y-coordinate of point
+  double x;        // x-coordinate of point
+  double y;        // y-coordinate of point
+  double z = 0.0;  // z-coordinate of point; 0 for inherently-2D sources (scan, range)
 };
 
 /// @brief 2D Pose
@@ -77,6 +80,8 @@ struct Action
   ActionType action_type;
   Velocity req_vel;
   std::string polygon_name;
+  /// @brief Points triggering polygon, keyed by sensor source name.
+  std::unordered_map<std::string, std::vector<Point>> triggering_points;
 };
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -16,7 +16,6 @@
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace nav2_collision_monitor
@@ -51,9 +50,10 @@ struct Velocity
 /// @brief Point with 2D collision-check coordinates and optional z from the source
 struct Point
 {
-  double x;        // x-coordinate of point
-  double y;        // y-coordinate of point
-  double z = 0.0;  // z-coordinate of point; 0 for inherently-2D sources (scan, range)
+  double x;  // x-coordinate of point
+  double y;  // y-coordinate of point
+  double z = 0.0;  // z-coordinate of point (0 for inherently-2D sources)
+  std::string source = "";  // name of the data source
 };
 
 /// @brief 2D Pose
@@ -80,8 +80,7 @@ struct Action
   ActionType action_type;
   Velocity req_vel;
   std::string polygon_name;
-  /// @brief Points triggering polygon, keyed by sensor source name.
-  std::unordered_map<std::string, std::vector<Point>> triggering_points;
+  std::vector<Point> triggering_points;
 };
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/src/circle.cpp
+++ b/nav2_collision_monitor/src/circle.cpp
@@ -58,11 +58,21 @@ void Circle::getPolygon(std::vector<Point> & poly) const
   }
 }
 
-int Circle::getPointsInside(const std::vector<Point> & points) const
+bool Circle::isPointInside(const Point & point) const
+{
+  return point.x * point.x + point.y * point.y < radius_squared_;
+}
+
+int Circle::getPointsInside(
+  const std::vector<Point> & points,
+  std::vector<Point> * out_triggering_points) const
 {
   int num = 0;
   for (Point point : points) {
     if (point.x * point.x + point.y * point.y < radius_squared_) {
+      if (out_triggering_points) {
+        out_triggering_points->push_back(point);
+      }
       num++;
     }
   }

--- a/nav2_collision_monitor/src/circle.cpp
+++ b/nav2_collision_monitor/src/circle.cpp
@@ -58,21 +58,14 @@ void Circle::getPolygon(std::vector<Point> & poly) const
   }
 }
 
-bool Circle::isPointInside(const Point & point) const
-{
-  return point.x * point.x + point.y * point.y < radius_squared_;
-}
-
 int Circle::getPointsInside(
   const std::vector<Point> & points,
-  std::vector<Point> * out_triggering_points) const
+  std::vector<Point> & out_triggering_points) const
 {
   int num = 0;
   for (Point point : points) {
     if (point.x * point.x + point.y * point.y < radius_squared_) {
-      if (out_triggering_points) {
-        out_triggering_points->push_back(point);
-      }
+      out_triggering_points.push_back(point);
       num++;
     }
   }

--- a/nav2_collision_monitor/src/circle.cpp
+++ b/nav2_collision_monitor/src/circle.cpp
@@ -73,6 +73,21 @@ int Circle::getPointsInside(
   return num;
 }
 
+int Circle::getPointsInside(
+  const std::vector<Point> & points,
+  std::vector<std::size_t> & out_triggering_indices) const
+{
+  int num = 0;
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    const Point & point = points[i];
+    if (point.x * point.x + point.y * point.y < radius_squared_) {
+      out_triggering_indices.push_back(i);
+      num++;
+    }
+  }
+  return num;
+}
+
 bool Circle::isShapeSet()
 {
   if (radius_squared_ == -1.0) {

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -314,18 +314,15 @@ void CollisionDetector::process()
   rclcpp::Time curr_time = this->now();
 
   // Points array collected from different data sources in a robot base frame
-  std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
+  std::vector<Point> collision_points;
 
   std::unique_ptr<nav2_msgs::msg::CollisionDetectorState> state_msg =
     std::make_unique<nav2_msgs::msg::CollisionDetectorState>();
 
-  // Fill collision_points map from different data sources
+  // Fill collision_points array from different data sources
   for (std::shared_ptr<Source> source : sources_) {
-    auto iter = sources_collision_points_map.insert(
-      {source->getSourceName(), std::vector<Point>()});
-
     if (source->getEnabled()) {
-      if (!source->getData(curr_time, iter.first->second) &&
+      if (!source->getData(curr_time, collision_points) &&
         source->getSourceTimeout().seconds() != 0.0)
       {
         RCLCPP_WARN(
@@ -355,30 +352,26 @@ void CollisionDetector::process()
     marker.lifetime = rclcpp::Duration(0, 0);
     marker.frame_locked = true;
 
-    for (const auto & [_, points] : sources_collision_points_map) {
-      for (const auto & point : points) {
-        geometry_msgs::msg::Point p;
-        p.x = point.x;
-        p.y = point.y;
-        p.z = collision_points_marker_3d_ ? point.z : 0.0;
-        marker.points.push_back(p);
-      }
+    for (const auto & point : collision_points) {
+      geometry_msgs::msg::Point p;
+      p.x = point.x;
+      p.y = point.y;
+      p.z = collision_points_marker_3d_ ? point.z : 0.0;
+      marker.points.push_back(p);
     }
     marker_array->markers.push_back(marker);
     collision_points_marker_pub_->publish(std::move(marker_array));
   }
 
   // Per-polygon triggering points; populated only for polygons that detect.
-  std::unordered_map<std::string,
-    std::unordered_map<std::string, std::vector<Point>>> all_triggering_points;
+  std::unordered_map<std::string, std::vector<Point>> all_triggering_points;
 
   for (std::shared_ptr<Polygon> polygon : polygons_) {
     if (!polygon->getEnabled()) {
       continue;
     }
-    // Single pass: count and collect inside points keyed by source.
-    std::unordered_map<std::string, std::vector<Point>> triggering_points;
-    const bool detected = polygon->isTriggered(sources_collision_points_map, &triggering_points);
+    std::vector<Point> triggering_points;
+    const bool detected = polygon->isTriggered(collision_points, &triggering_points);
     state_msg->polygons.push_back(polygon->getName());
     state_msg->detections.push_back(detected);
     if (detected) {
@@ -397,8 +390,7 @@ void CollisionDetector::process()
 }
 
 void CollisionDetector::publishTriggeringPoints(
-  const std::unordered_map<std::string,
-  std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points)
+  const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 
@@ -427,15 +419,15 @@ void CollisionDetector::publishTriggeringPoints(
       marker.frame_locked = true;
 
       if (has_triggering) {
-        const auto src_iter = poly_iter->second.find(source_name);
-        if (src_iter != poly_iter->second.end()) {
-          for (const auto & p : src_iter->second) {
-            geometry_msgs::msg::Point gp;
-            gp.x = p.x;
-            gp.y = p.y;
-            gp.z = p.z;
-            marker.points.push_back(gp);
+        for (const auto & p : poly_iter->second) {
+          if (p.source != source_name) {
+            continue;
           }
+          geometry_msgs::msg::Point gp;
+          gp.x = p.x;
+          gp.y = p.y;
+          gp.z = p.z;
+          marker.points.push_back(gp);
         }
       }
       marker_array->markers.push_back(marker);

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -58,6 +58,9 @@ CollisionDetector::on_configure(const rclcpp_lifecycle::State & state)
   collision_points_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/collision_points_marker");
 
+  triggering_points_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "~/triggering_points");
+
   // Obtaining ROS parameters
   if (!getParameters()) {
     on_cleanup(state);
@@ -75,6 +78,7 @@ CollisionDetector::on_activate(const rclcpp_lifecycle::State & /*state*/)
   // Activating lifecycle publisher
   state_pub_->on_activate();
   collision_points_marker_pub_->on_activate();
+  triggering_points_pub_->on_activate();
 
   // Activating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -103,6 +107,7 @@ CollisionDetector::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   // Deactivating lifecycle publishers
   state_pub_->on_deactivate();
   collision_points_marker_pub_->on_deactivate();
+  triggering_points_pub_->on_deactivate();
 
   // Deactivating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -122,6 +127,7 @@ CollisionDetector::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 
   state_pub_.reset();
   collision_points_marker_pub_.reset();
+  triggering_points_pub_.reset();
 
   polygons_.clear();
   sources_.clear();
@@ -307,15 +313,18 @@ void CollisionDetector::process()
   rclcpp::Time curr_time = this->now();
 
   // Points array collected from different data sources in a robot base frame
-  std::vector<Point> collision_points;
+  std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
 
   std::unique_ptr<nav2_msgs::msg::CollisionDetectorState> state_msg =
     std::make_unique<nav2_msgs::msg::CollisionDetectorState>();
 
-  // Fill collision_points array from different data sources
+  // Fill collision_points map from different data sources
   for (std::shared_ptr<Source> source : sources_) {
+    auto iter = sources_collision_points_map.insert(
+      {source->getSourceName(), std::vector<Point>()});
+
     if (source->getEnabled()) {
-      if (!source->getData(curr_time, collision_points) &&
+      if (!source->getData(curr_time, iter.first->second) &&
         source->getSourceTimeout().seconds() != 0.0)
       {
         RCLCPP_WARN(
@@ -345,29 +354,95 @@ void CollisionDetector::process()
     marker.lifetime = rclcpp::Duration(0, 0);
     marker.frame_locked = true;
 
-    for (const auto & point : collision_points) {
-      geometry_msgs::msg::Point p;
-      p.x = point.x;
-      p.y = point.y;
-      p.z = 0.0;
-      marker.points.push_back(p);
+    for (const auto & [_, points] : sources_collision_points_map) {
+      for (const auto & point : points) {
+        geometry_msgs::msg::Point p;
+        p.x = point.x;
+        p.y = point.y;
+        p.z = point.z;
+        marker.points.push_back(p);
+      }
     }
     marker_array->markers.push_back(marker);
     collision_points_marker_pub_->publish(std::move(marker_array));
   }
 
+  // Per-polygon triggering points; populated only for polygons that detect.
+  std::unordered_map<std::string,
+    std::unordered_map<std::string, std::vector<Point>>> all_triggering_points;
+
   for (std::shared_ptr<Polygon> polygon : polygons_) {
     if (!polygon->getEnabled()) {
       continue;
     }
+    // Single pass: count and collect inside points keyed by source.
+    std::unordered_map<std::string, std::vector<Point>> triggering_points;
+    const bool detected = polygon->isTriggered(sources_collision_points_map, &triggering_points);
     state_msg->polygons.push_back(polygon->getName());
-    state_msg->detections.push_back(polygon->isTriggered(collision_points));
+    state_msg->detections.push_back(detected);
+    if (detected) {
+      all_triggering_points[polygon->getName()] = std::move(triggering_points);
+    }
   }
 
   state_pub_->publish(std::move(state_msg));
 
+  if (triggering_points_pub_->get_subscription_count() > 0) {
+    publishTriggeringPoints(all_triggering_points);
+  }
+
   // Publish polygons for better visualization
   publishPolygons();
+}
+
+void CollisionDetector::publishTriggeringPoints(
+  const std::unordered_map<std::string,
+    std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points)
+{
+  auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
+  const std::string base_frame = get_parameter("base_frame_id").as_string();
+
+  // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
+  // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
+  // in RViz, clearing the inactive points.
+  for (const auto & polygon : polygons_) {
+    const std::string polygon_name = polygon->getName();
+    const auto poly_iter = all_triggering_points.find(polygon_name);
+    const bool has_triggering = (poly_iter != all_triggering_points.end());
+    for (const auto & source_name : polygon->getSourcesNames()) {
+      visualization_msgs::msg::Marker marker;
+      marker.header.frame_id = base_frame;
+      marker.header.stamp = rclcpp::Time(0, 0);
+      marker.ns = polygon_name + "/" + source_name;
+      marker.id = 0;
+      marker.type = visualization_msgs::msg::Marker::POINTS;
+      marker.action = visualization_msgs::msg::Marker::ADD;
+      marker.scale.x = 0.05;
+      marker.scale.y = 0.05;
+      marker.color.r = 1.0f;
+      marker.color.g = 0.0f;
+      marker.color.b = 0.0f;
+      marker.color.a = 1.0f;
+      marker.lifetime = rclcpp::Duration(0, 0);
+      marker.frame_locked = true;
+
+      if (has_triggering) {
+        const auto src_iter = poly_iter->second.find(source_name);
+        if (src_iter != poly_iter->second.end()) {
+          for (const auto & p : src_iter->second) {
+            geometry_msgs::msg::Point gp;
+            gp.x = p.x;
+            gp.y = p.y;
+            gp.z = p.z;
+            marker.points.push_back(gp);
+          }
+        }
+      }
+      marker_array->markers.push_back(marker);
+    }
+  }
+
+  triggering_points_pub_->publish(std::move(marker_array));
 }
 
 void CollisionDetector::publishPolygons() const

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -394,58 +394,51 @@ void CollisionDetector::process()
   publishPolygons();
 }
 
-void CollisionMonitor::publishTriggeringPoints(const Action & action)
+void CollisionDetector::publishTriggeringPoints(
+  const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 
-  // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
-  float r = 0.0f, g = 0.0f, b = 0.0f;
-  switch (action.action_type) {
-    case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
-    case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
-    case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
-    case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
-    default: break;
-  }
+  // Clear markers from previous cycle.
+  visualization_msgs::msg::Marker clear;
+  clear.action = visualization_msgs::msg::Marker::DELETEALL;
+  marker_array->markers.push_back(clear);
 
-  // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
-  // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
-  // in RViz, clearing the inactive points.
-  for (const auto & polygon : polygons_) {
-    const std::string polygon_name = polygon->getName();
-    const bool is_active_polygon = (polygon_name == action.polygon_name);
-    for (const auto & source_name : polygon->getSourcesNames()) {
-      visualization_msgs::msg::Marker marker;
-      marker.header.frame_id = base_frame_id_;
-      marker.header.stamp = rclcpp::Time(0, 0);
-      marker.ns = polygon_name + "/" + source_name;
-      marker.id = 0;
-      marker.type = visualization_msgs::msg::Marker::POINTS;
-      marker.action = visualization_msgs::msg::Marker::ADD;
-      marker.scale.x = 0.05;
-      marker.scale.y = 0.05;
-      marker.color.r = r;
-      marker.color.g = g;
-      marker.color.b = b;
-      marker.color.a = 1.0f;
-      marker.lifetime = rclcpp::Duration(0, 0);
-      marker.frame_locked = true;
+  std::unordered_map<std::string, size_t> marker_index;
+  for (const auto & [polygon_name, points] : all_triggering_points) {
+    for (const auto & p : points) {
+      const std::string key = polygon_name + "/" + p.source;
+      auto [it, new_source] = marker_index.try_emplace(key, marker_array->markers.size());
 
-      if (is_active_polygon) {
-        for (const auto & p : action.triggering_points) {
-          if (p.source != source_name) {
-            continue;
-          }
-          geometry_msgs::msg::Point gp;
-          gp.x = p.x;
-          gp.y = p.y;
-          gp.z = p.z;
-          marker.points.push_back(gp);
-        }
+      if (new_source) {
+        visualization_msgs::msg::Marker marker;
+        marker.header.frame_id = base_frame_id_;
+        marker.header.stamp = rclcpp::Time(0, 0);
+        marker.ns = key;
+        marker.id = 0;
+        marker.type = visualization_msgs::msg::Marker::POINTS;
+        marker.action = visualization_msgs::msg::Marker::ADD;
+        marker.scale.x = 0.05;
+        marker.scale.y = 0.05;
+        marker.color.r = 1.0f;
+        marker.color.g = 0.0f;
+        marker.color.b = 0.0f;
+        marker.color.a = 1.0f;
+        marker.lifetime = rclcpp::Duration(0, 0);
+        marker.frame_locked = true;
+        marker_array->markers.push_back(std::move(marker));
       }
-      marker_array->markers.push_back(marker);
+
+      geometry_msgs::msg::Point gp;
+      gp.x = p.x;
+      gp.y = p.y;
+      gp.z = p.z;
+      marker_array->markers[it->second].points.push_back(gp);
     }
   }
+
+  triggering_points_pub_->publish(std::move(marker_array));
+}
 
 void CollisionDetector::publishPolygons() const
 {

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -314,15 +314,18 @@ void CollisionDetector::process()
   rclcpp::Time curr_time = this->now();
 
   // Points array collected from different data sources in a robot base frame
-  std::vector<Point> collision_points;
+  std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
 
   std::unique_ptr<nav2_msgs::msg::CollisionDetectorState> state_msg =
     std::make_unique<nav2_msgs::msg::CollisionDetectorState>();
 
-  // Fill collision_points array from different data sources
+  // Fill collision_points map from different data sources
   for (std::shared_ptr<Source> source : sources_) {
+    auto iter = sources_collision_points_map.insert(
+      {source->getSourceName(), std::vector<Point>()});
+
     if (source->getEnabled()) {
-      if (!source->getData(curr_time, collision_points) &&
+      if (!source->getData(curr_time, iter.first->second) &&
         source->getSourceTimeout().seconds() != 0.0)
       {
         RCLCPP_WARN(
@@ -352,12 +355,14 @@ void CollisionDetector::process()
     marker.lifetime = rclcpp::Duration(0, 0);
     marker.frame_locked = true;
 
-    for (const auto & point : collision_points) {
-      geometry_msgs::msg::Point p;
-      p.x = point.x;
-      p.y = point.y;
-      p.z = collision_points_marker_3d_ ? point.z : 0.0;
-      marker.points.push_back(p);
+    for (const auto & [_, points] : sources_collision_points_map) {
+      for (const auto & point : points) {
+        geometry_msgs::msg::Point p;
+        p.x = point.x;
+        p.y = point.y;
+        p.z = collision_points_marker_3d_ ? point.z : 0.0;
+        marker.points.push_back(p);
+      }
     }
     marker_array->markers.push_back(marker);
     collision_points_marker_pub_->publish(std::move(marker_array));
@@ -371,7 +376,7 @@ void CollisionDetector::process()
       continue;
     }
     std::vector<Point> triggering_points;
-    const bool detected = polygon->isTriggered(collision_points, &triggering_points);
+    const bool detected = polygon->isTriggered(sources_collision_points_map, triggering_points);
     state_msg->polygons.push_back(polygon->getName());
     state_msg->detections.push_back(detected);
     if (detected) {
@@ -389,18 +394,26 @@ void CollisionDetector::process()
   publishPolygons();
 }
 
-void CollisionDetector::publishTriggeringPoints(
-  const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points)
+void CollisionMonitor::publishTriggeringPoints(const Action & action)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
+
+  // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
+  float r = 0.0f, g = 0.0f, b = 0.0f;
+  switch (action.action_type) {
+    case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
+    case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
+    case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
+    case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
+    default: break;
+  }
 
   // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
   // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
   // in RViz, clearing the inactive points.
   for (const auto & polygon : polygons_) {
     const std::string polygon_name = polygon->getName();
-    const auto poly_iter = all_triggering_points.find(polygon_name);
-    const bool has_triggering = (poly_iter != all_triggering_points.end());
+    const bool is_active_polygon = (polygon_name == action.polygon_name);
     for (const auto & source_name : polygon->getSourcesNames()) {
       visualization_msgs::msg::Marker marker;
       marker.header.frame_id = base_frame_id_;
@@ -411,15 +424,15 @@ void CollisionDetector::publishTriggeringPoints(
       marker.action = visualization_msgs::msg::Marker::ADD;
       marker.scale.x = 0.05;
       marker.scale.y = 0.05;
-      marker.color.r = 1.0f;
-      marker.color.g = 0.0f;
-      marker.color.b = 0.0f;
+      marker.color.r = r;
+      marker.color.g = g;
+      marker.color.b = b;
       marker.color.a = 1.0f;
       marker.lifetime = rclcpp::Duration(0, 0);
       marker.frame_locked = true;
 
-      if (has_triggering) {
-        for (const auto & p : poly_iter->second) {
+      if (is_active_polygon) {
+        for (const auto & p : action.triggering_points) {
           if (p.source != source_name) {
             continue;
           }
@@ -433,9 +446,6 @@ void CollisionDetector::publishTriggeringPoints(
       marker_array->markers.push_back(marker);
     }
   }
-
-  triggering_points_pub_->publish(std::move(marker_array));
-}
 
 void CollisionDetector::publishPolygons() const
 {

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -161,6 +161,7 @@ bool CollisionDetector::getParameters()
   source_timeout = rclcpp::Duration::from_seconds(
     node->declare_or_get_parameter("source_timeout", 2.0));
   const bool base_shift_correction = node->declare_or_get_parameter("base_shift_correction", true);
+  collision_points_marker_3d_ = node->declare_or_get_parameter("collision_points_marker_3d", false);
 
   if (!configureSources(
       base_frame_id, odom_frame_id, transform_tolerance, source_timeout,
@@ -359,7 +360,7 @@ void CollisionDetector::process()
         geometry_msgs::msg::Point p;
         p.x = point.x;
         p.y = point.y;
-        p.z = point.z;
+        p.z = collision_points_marker_3d_ ? point.z : 0.0;
         marker.points.push_back(p);
       }
     }

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -147,14 +147,14 @@ CollisionDetector::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 
 bool CollisionDetector::getParameters()
 {
-  std::string base_frame_id, odom_frame_id;
+  std::string odom_frame_id;
   tf2::Duration transform_tolerance;
   rclcpp::Duration source_timeout(2.0, 0.0);
 
   auto node = shared_from_this();
 
   frequency_ = node->declare_or_get_parameter("frequency", 10.0);
-  base_frame_id = node->declare_or_get_parameter("base_frame_id", std::string("base_footprint"));
+  base_frame_id_ = node->declare_or_get_parameter("base_frame_id", std::string("base_footprint"));
   odom_frame_id = node->declare_or_get_parameter("odom_frame_id", std::string("odom"));
   transform_tolerance = tf2::durationFromSec(
     node->declare_or_get_parameter("transform_tolerance", 0.1));
@@ -164,13 +164,13 @@ bool CollisionDetector::getParameters()
   collision_points_marker_3d_ = node->declare_or_get_parameter("collision_points_marker_3d", false);
 
   if (!configureSources(
-      base_frame_id, odom_frame_id, transform_tolerance, source_timeout,
+      base_frame_id_, odom_frame_id, transform_tolerance, source_timeout,
       base_shift_correction))
   {
     return false;
   }
 
-  if (!configurePolygons(base_frame_id, transform_tolerance)) {
+  if (!configurePolygons(base_frame_id_, transform_tolerance)) {
     return false;
   }
 
@@ -342,7 +342,7 @@ void CollisionDetector::process()
     // visualize collision points with markers
     auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
     visualization_msgs::msg::Marker marker;
-    marker.header.frame_id = get_parameter("base_frame_id").as_string();
+    marker.header.frame_id = base_frame_id_;
     marker.header.stamp = rclcpp::Time(0, 0);
     marker.ns = "collision_points";
     marker.id = 0;
@@ -401,7 +401,6 @@ void CollisionDetector::publishTriggeringPoints(
     std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
-  const std::string base_frame = get_parameter("base_frame_id").as_string();
 
   // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
   // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
@@ -412,7 +411,7 @@ void CollisionDetector::publishTriggeringPoints(
     const bool has_triggering = (poly_iter != all_triggering_points.end());
     for (const auto & source_name : polygon->getSourcesNames()) {
       visualization_msgs::msg::Marker marker;
-      marker.header.frame_id = base_frame;
+      marker.header.frame_id = base_frame_id_;
       marker.header.stamp = rclcpp::Time(0, 0);
       marker.ns = polygon_name + "/" + source_name;
       marker.id = 0;

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -398,7 +398,7 @@ void CollisionDetector::process()
 
 void CollisionDetector::publishTriggeringPoints(
   const std::unordered_map<std::string,
-    std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points)
+  std::unordered_map<std::string, std::vector<Point>>> & all_triggering_points)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -675,55 +675,51 @@ void CollisionMonitor::publishTriggeringPoints(const Action & action)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 
-  // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
-  float r = 0.0f, g = 0.0f, b = 0.0f;
-  switch (action.action_type) {
-    case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
-    case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
-    case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
-    case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
-    default: break;
-  }
+  // Clear markers from previous cycle.
+  visualization_msgs::msg::Marker clear;
+  clear.action = visualization_msgs::msg::Marker::DELETEALL;
+  marker_array->markers.push_back(clear);
 
-  // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
-  // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
-  // in RViz, clearing the inactive points.
-  for (const auto & polygon : polygons_) {
-    const std::string polygon_name = polygon->getName();
-    const bool is_active_polygon = (polygon_name == action.polygon_name);
-    for (const auto & source_name : polygon->getSourcesNames()) {
-      visualization_msgs::msg::Marker marker;
-      marker.header.frame_id = base_frame_id_;
-      marker.header.stamp = rclcpp::Time(0, 0);
-      marker.ns = polygon_name + "/" + source_name;
-      marker.id = 0;
-      marker.type = visualization_msgs::msg::Marker::POINTS;
-      marker.action = visualization_msgs::msg::Marker::ADD;
-      marker.scale.x = 0.05;
-      marker.scale.y = 0.05;
-      marker.color.r = r;
-      marker.color.g = g;
-      marker.color.b = b;
-      marker.color.a = 1.0f;
-      marker.lifetime = rclcpp::Duration(0, 0);
-      marker.frame_locked = true;
+  if (!action.triggering_points.empty()) {
+    // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
+    float r = 0.0f, g = 0.0f, b = 0.0f;
+    switch (action.action_type) {
+      case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
+      case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
+      case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
+      case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
+      default: break;
+    }
 
-      if (is_active_polygon) {
-        for (const auto & p : action.triggering_points) {
-          if (p.source != source_name) {
-            continue;
-          }
-          geometry_msgs::msg::Point gp;
-          gp.x = p.x;
-          gp.y = p.y;
-          gp.z = p.z;
-          marker.points.push_back(gp);
-        }
+    std::unordered_map<std::string, size_t> marker_index;
+    for (const auto & p : action.triggering_points) {
+      auto [it, new_source] = marker_index.try_emplace(p.source, marker_array->markers.size());
+
+      if (new_source) {
+        visualization_msgs::msg::Marker marker;
+        marker.header.frame_id = base_frame_id_;
+        marker.header.stamp = rclcpp::Time(0, 0);
+        marker.ns = action.polygon_name + "/" + p.source;
+        marker.id = 0;
+        marker.type = visualization_msgs::msg::Marker::POINTS;
+        marker.action = visualization_msgs::msg::Marker::ADD;
+        marker.scale.x = 0.05;
+        marker.scale.y = 0.05;
+        marker.color.r = r;
+        marker.color.g = g;
+        marker.color.b = b;
+        marker.color.a = 1.0f;
+        marker.lifetime = rclcpp::Duration(0, 0);
+        marker.frame_locked = true;
+        marker_array->markers.push_back(std::move(marker));
       }
-      marker_array->markers.push_back(marker);
+      geometry_msgs::msg::Point gp;
+      gp.x = p.x;
+      gp.y = p.y;
+      gp.z = p.z;
+      marker_array->markers[it->second].points.push_back(gp);
     }
   }
-
   triggering_points_pub_->publish(std::move(marker_array));
 }
 

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -34,7 +34,7 @@ namespace nav2_collision_monitor
 CollisionMonitor::CollisionMonitor(const rclcpp::NodeOptions & options)
 : nav2::LifecycleNode("collision_monitor", options),
   enabled_{true}, process_active_(false),
-  robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, "", {}},
+  robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, "", std::vector<Point>()},
   stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0)
 {
 }
@@ -155,7 +155,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   process_active_ = false;
 
   // Reset action type to default after worker deactivating
-  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, "", {}};
+  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, "", std::vector<Point>()};
 
   // Deactivating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -423,21 +423,18 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   }
 
   // Points array collected from different data sources in a robot base frame
-  std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
+  std::vector<Point> collision_points;
 
   // By default - there is no action
-  Action robot_action{DO_NOTHING, cmd_vel_in, "", {}};
+  Action robot_action{DO_NOTHING, cmd_vel_in, "", std::vector<Point>()};
   // Polygon causing robot action (if any)
   std::shared_ptr<Polygon> action_polygon;
 
   // Fill collision points array from different data sources
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
   for (std::shared_ptr<Source> source : sources_) {
-    auto iter = sources_collision_points_map.insert(
-      {source->getSourceName(), std::vector<Point>()});
-
     if (source->getEnabled()) {
-      if (!source->getData(curr_time, iter.first->second) &&
+      if (!source->getData(curr_time, collision_points) &&
         source->getSourceTimeout().seconds() != 0.0)
       {
         action_polygon = nullptr;
@@ -466,7 +463,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
       marker.lifetime = rclcpp::Duration(0, 0);
       marker.frame_locked = true;
 
-      for (const auto & point : iter.first->second) {
+      for (const auto & point : collision_points) {
         geometry_msgs::msg::Point p;
         p.x = point.x;
         p.y = point.y;
@@ -496,14 +493,12 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
     const ActionType at = polygon->getActionType();
     if (at == STOP || at == SLOWDOWN || at == LIMIT) {
       // Process STOP/SLOWDOWN for the selected polygon
-      if (processStopSlowdownLimit(
-          polygon, sources_collision_points_map, cmd_vel_in, robot_action))
-      {
+      if (processStopSlowdownLimit(polygon, collision_points, cmd_vel_in, robot_action)) {
         action_polygon = polygon;
       }
     } else if (at == APPROACH) {
       // Process APPROACH for the selected polygon
-      if (processApproach(polygon, sources_collision_points_map, cmd_vel_in, robot_action)) {
+      if (processApproach(polygon, collision_points, cmd_vel_in, robot_action)) {
         action_polygon = polygon;
       }
     }
@@ -529,7 +524,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
 
 bool CollisionMonitor::processStopSlowdownLimit(
   const std::shared_ptr<Polygon> polygon,
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  const std::vector<Point> & collision_points,
   const Velocity & velocity,
   Action & robot_action) const
 {
@@ -538,8 +533,8 @@ bool CollisionMonitor::processStopSlowdownLimit(
   }
 
   // Single pass: collect in-polygon points while isTriggered counts them.
-  std::unordered_map<std::string, std::vector<Point>> triggering_points;
-  if (polygon->isTriggered(sources_collision_points_map, &triggering_points)) {
+  std::vector<Point> triggering_points;
+  if (polygon->isTriggered(collision_points, &triggering_points)) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
       robot_action.polygon_name = polygon->getName();
@@ -593,7 +588,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
 
 bool CollisionMonitor::processApproach(
   const std::shared_ptr<Polygon> polygon,
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  const std::vector<Point> & collision_points,
   const Velocity & velocity,
   Action & robot_action) const
 {
@@ -602,12 +597,9 @@ bool CollisionMonitor::processApproach(
   }
 
   // Obtain time before a collision, capturing the responsible points at the collision step.
-  // getCollisionTime() only writes into the out map on the triggering step, so we can
-  // target robot_action.triggering_points directly — but write to a local first so a
-  // triggered call that loses the safe_vel comparison below doesn't corrupt a prior winner.
-  std::unordered_map<std::string, std::vector<Point>> triggering_points;
+  std::vector<Point> triggering_points;
   const double collision_time =
-    polygon->getCollisionTime(sources_collision_points_map, velocity, triggering_points);
+    polygon->getCollisionTime(collision_points, velocity, triggering_points);
   if (collision_time >= 0.0) {
     // If collision will occur, reduce robot speed
     const double change_ratio = collision_time / polygon->getTimeBeforeCollision();
@@ -712,15 +704,15 @@ void CollisionMonitor::publishTriggeringPoints(const Action & action)
       marker.frame_locked = true;
 
       if (is_active_polygon) {
-        const auto it = action.triggering_points.find(source_name);
-        if (it != action.triggering_points.end()) {
-          for (const auto & p : it->second) {
-            geometry_msgs::msg::Point gp;
-            gp.x = p.x;
-            gp.y = p.y;
-            gp.z = p.z;
-            marker.points.push_back(gp);
+        for (const auto & p : action.triggering_points) {
+          if (p.source != source_name) {
+            continue;
           }
+          geometry_msgs::msg::Point gp;
+          gp.x = p.x;
+          gp.y = p.y;
+          gp.z = p.z;
+          marker.points.push_back(gp);
         }
       }
       marker_array->markers.push_back(marker);

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -253,7 +253,7 @@ bool CollisionMonitor::getParameters(
   std::string & cmd_vel_out_topic,
   std::string & state_topic)
 {
-  std::string base_frame_id, odom_frame_id;
+  std::string odom_frame_id;
   tf2::Duration transform_tolerance;
   rclcpp::Duration source_timeout(2.0, 0.0);
 
@@ -265,7 +265,7 @@ bool CollisionMonitor::getParameters(
     "cmd_vel_out_topic", std::string("cmd_vel"));
   state_topic = node->declare_or_get_parameter("state_topic", std::string(""));
 
-  base_frame_id = node->declare_or_get_parameter(
+  base_frame_id_ = node->declare_or_get_parameter(
     "base_frame_id", std::string("base_footprint"));
   odom_frame_id = node->declare_or_get_parameter("odom_frame_id", std::string("odom"));
   transform_tolerance = tf2::durationFromSec(
@@ -280,12 +280,12 @@ bool CollisionMonitor::getParameters(
 
   if (
     !configureSources(
-      base_frame_id, odom_frame_id, transform_tolerance, source_timeout, base_shift_correction))
+        base_frame_id_, odom_frame_id, transform_tolerance, source_timeout, base_shift_correction))
   {
     return false;
   }
 
-  if (!configurePolygons(base_frame_id, transform_tolerance)) {
+  if (!configurePolygons(base_frame_id_, transform_tolerance)) {
     return false;
   }
 
@@ -453,7 +453,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
     if (collision_points_marker_pub_->get_subscription_count() > 0) {
       // visualize collision points with markers
       visualization_msgs::msg::Marker marker;
-      marker.header.frame_id = get_parameter("base_frame_id").as_string();
+      marker.header.frame_id = base_frame_id_;
       marker.header.stamp = rclcpp::Time(0, 0);
       marker.ns = "collision_points_" + source->getSourceName();
       marker.id = 0;
@@ -677,7 +677,6 @@ void CollisionMonitor::notifyActionState(
 void CollisionMonitor::publishTriggeringPoints(const Action & action)
 {
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
-  const std::string base_frame = get_parameter("base_frame_id").as_string();
 
   // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
   float r = 0.0f, g = 0.0f, b = 0.0f;
@@ -697,7 +696,7 @@ void CollisionMonitor::publishTriggeringPoints(const Action & action)
     const bool is_active_polygon = (polygon_name == action.polygon_name);
     for (const auto & source_name : polygon->getSourcesNames()) {
       visualization_msgs::msg::Marker marker;
-      marker.header.frame_id = base_frame;
+      marker.header.frame_id = base_frame_id_;
       marker.header.stamp = rclcpp::Time(0, 0);
       marker.ns = polygon_name + "/" + source_name;
       marker.id = 0;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -273,6 +273,7 @@ bool CollisionMonitor::getParameters(
   source_timeout = rclcpp::Duration::from_seconds(
     node->declare_or_get_parameter("source_timeout", 2.0));
   const bool base_shift_correction = node->declare_or_get_parameter("base_shift_correction", true);
+  collision_points_marker_3d_ = node->declare_or_get_parameter("collision_points_marker_3d", false);
 
   stop_pub_timeout_ = rclcpp::Duration::from_seconds(
     node->declare_or_get_parameter("stop_pub_timeout", 1.0));
@@ -469,7 +470,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
         geometry_msgs::msg::Point p;
         p.x = point.x;
         p.y = point.y;
-        p.z = point.z;
+        p.z = collision_points_marker_3d_ ? point.z : 0.0;
         marker.points.push_back(p);
       }
       marker_array->markers.push_back(marker);

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -423,7 +423,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   }
 
   // Points array collected from different data sources in a robot base frame
-  std::vector<Point> collision_points;
+  std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
 
   // By default - there is no action
   Action robot_action{DO_NOTHING, cmd_vel_in, "", std::vector<Point>()};
@@ -433,8 +433,11 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   // Fill collision points array from different data sources
   auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
   for (std::shared_ptr<Source> source : sources_) {
+    auto iter = sources_collision_points_map.insert(
+      {source->getSourceName(), std::vector<Point>()});
+
     if (source->getEnabled()) {
-      if (!source->getData(curr_time, collision_points) &&
+      if (!source->getData(curr_time, iter.first->second) &&
         source->getSourceTimeout().seconds() != 0.0)
       {
         action_polygon = nullptr;
@@ -463,7 +466,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
       marker.lifetime = rclcpp::Duration(0, 0);
       marker.frame_locked = true;
 
-      for (const auto & point : collision_points) {
+      for (const auto & point : iter.first->second) {
         geometry_msgs::msg::Point p;
         p.x = point.x;
         p.y = point.y;
@@ -493,12 +496,14 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
     const ActionType at = polygon->getActionType();
     if (at == STOP || at == SLOWDOWN || at == LIMIT) {
       // Process STOP/SLOWDOWN for the selected polygon
-      if (processStopSlowdownLimit(polygon, collision_points, cmd_vel_in, robot_action)) {
+      if (processStopSlowdownLimit(
+          polygon, sources_collision_points_map, cmd_vel_in, robot_action))
+      {
         action_polygon = polygon;
       }
     } else if (at == APPROACH) {
       // Process APPROACH for the selected polygon
-      if (processApproach(polygon, collision_points, cmd_vel_in, robot_action)) {
+      if (processApproach(polygon, sources_collision_points_map, cmd_vel_in, robot_action)) {
         action_polygon = polygon;
       }
     }
@@ -524,7 +529,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
 
 bool CollisionMonitor::processStopSlowdownLimit(
   const std::shared_ptr<Polygon> polygon,
-  const std::vector<Point> & collision_points,
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
   const Velocity & velocity,
   Action & robot_action) const
 {
@@ -534,7 +539,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
 
   // Single pass: collect in-polygon points while isTriggered counts them.
   std::vector<Point> triggering_points;
-  if (polygon->isTriggered(collision_points, &triggering_points)) {
+  if (polygon->isTriggered(sources_collision_points_map, triggering_points)) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
       robot_action.polygon_name = polygon->getName();
@@ -588,7 +593,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
 
 bool CollisionMonitor::processApproach(
   const std::shared_ptr<Polygon> polygon,
-  const std::vector<Point> & collision_points,
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
   const Velocity & velocity,
   Action & robot_action) const
 {
@@ -598,8 +603,8 @@ bool CollisionMonitor::processApproach(
 
   // Obtain time before a collision, capturing the responsible points at the collision step.
   std::vector<Point> triggering_points;
-  const double collision_time =
-    polygon->getCollisionTime(collision_points, velocity, triggering_points);
+  const double collision_time = polygon->getCollisionTime(sources_collision_points_map, velocity,
+      triggering_points);
   if (collision_time >= 0.0) {
     // If collision will occur, reduce robot speed
     const double change_ratio = collision_time / polygon->getTimeBeforeCollision();

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -14,6 +14,7 @@
 
 #include "nav2_collision_monitor/collision_monitor_node.hpp"
 
+#include <algorithm>
 #include <exception>
 #include <utility>
 #include <functional>
@@ -32,7 +33,8 @@ namespace nav2_collision_monitor
 
 CollisionMonitor::CollisionMonitor(const rclcpp::NodeOptions & options)
 : nav2::LifecycleNode("collision_monitor", options),
-  enabled_{true}, process_active_(false), robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, ""},
+  enabled_{true}, process_active_(false),
+  robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, "", {}},
   stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0)
 {
 }
@@ -83,6 +85,9 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
   collision_points_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/collision_points_marker");
 
+  triggering_points_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "~/triggering_points");
+
   // Toggle service initialization
   toggle_cm_service_ = create_service<nav2_msgs::srv::Toggle>(
     "~/toggle",
@@ -121,6 +126,7 @@ CollisionMonitor::on_activate(const rclcpp_lifecycle::State & /*state*/)
     state_pub_->on_activate();
   }
   collision_points_marker_pub_->on_activate();
+  triggering_points_pub_->on_activate();
 
   // Activating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -149,7 +155,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   process_active_ = false;
 
   // Reset action type to default after worker deactivating
-  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, ""};
+  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, "", {}};
 
   // Deactivating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -162,6 +168,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
     state_pub_->on_deactivate();
   }
   collision_points_marker_pub_->on_deactivate();
+  triggering_points_pub_->on_deactivate();
 
   // Destroying bond connection
   destroyBond();
@@ -178,6 +185,7 @@ CollisionMonitor::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   cmd_vel_out_pub_.reset();
   state_pub_.reset();
   collision_points_marker_pub_.reset();
+  triggering_points_pub_.reset();
 
   polygons_.clear();
   sources_.clear();
@@ -417,7 +425,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   std::unordered_map<std::string, std::vector<Point>> sources_collision_points_map;
 
   // By default - there is no action
-  Action robot_action{DO_NOTHING, cmd_vel_in, ""};
+  Action robot_action{DO_NOTHING, cmd_vel_in, "", {}};
   // Polygon causing robot action (if any)
   std::shared_ptr<Polygon> action_polygon;
 
@@ -461,7 +469,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
         geometry_msgs::msg::Point p;
         p.x = point.x;
         p.y = point.y;
-        p.z = 0.0;
+        p.z = point.z;
         marker.points.push_back(p);
       }
       marker_array->markers.push_back(marker);
@@ -500,6 +508,10 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
     }
   }
 
+  if (triggering_points_pub_->get_subscription_count() > 0) {
+    publishTriggeringPoints(robot_action);
+  }
+
   if ((robot_action.polygon_name != robot_action_prev_.polygon_name) && enabled_) {
     // Report changed robot behavior
     notifyActionState(robot_action, action_polygon);
@@ -524,7 +536,9 @@ bool CollisionMonitor::processStopSlowdownLimit(
     return false;
   }
 
-  if (polygon->isTriggered(sources_collision_points_map)) {
+  // Single pass: collect in-polygon points while isTriggered counts them.
+  std::unordered_map<std::string, std::vector<Point>> triggering_points;
+  if (polygon->isTriggered(sources_collision_points_map, &triggering_points)) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
       robot_action.polygon_name = polygon->getName();
@@ -532,6 +546,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
       robot_action.req_vel.x = 0.0;
       robot_action.req_vel.y = 0.0;
       robot_action.req_vel.tw = 0.0;
+      robot_action.triggering_points = std::move(triggering_points);
       return true;
     } else if (polygon->getActionType() == SLOWDOWN) {
       const Velocity safe_vel = velocity * polygon->getSlowdownRatio();
@@ -541,6 +556,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
         robot_action.polygon_name = polygon->getName();
         robot_action.action_type = SLOWDOWN;
         robot_action.req_vel = safe_vel;
+        robot_action.triggering_points = std::move(triggering_points);
         return true;
       }
     } else {  // Limit
@@ -565,6 +581,7 @@ bool CollisionMonitor::processStopSlowdownLimit(
         robot_action.polygon_name = polygon->getName();
         robot_action.action_type = LIMIT;
         robot_action.req_vel = safe_vel;
+        robot_action.triggering_points = std::move(triggering_points);
         return true;
       }
     }
@@ -583,8 +600,13 @@ bool CollisionMonitor::processApproach(
     return false;
   }
 
-  // Obtain time before a collision
-  const double collision_time = polygon->getCollisionTime(sources_collision_points_map, velocity);
+  // Obtain time before a collision, capturing the responsible points at the collision step.
+  // getCollisionTime() only writes into the out map on the triggering step, so we can
+  // target robot_action.triggering_points directly — but write to a local first so a
+  // triggered call that loses the safe_vel comparison below doesn't corrupt a prior winner.
+  std::unordered_map<std::string, std::vector<Point>> triggering_points;
+  const double collision_time =
+    polygon->getCollisionTime(sources_collision_points_map, velocity, triggering_points);
   if (collision_time >= 0.0) {
     // If collision will occur, reduce robot speed
     const double change_ratio = collision_time / polygon->getTimeBeforeCollision();
@@ -595,6 +617,7 @@ bool CollisionMonitor::processApproach(
       robot_action.polygon_name = polygon->getName();
       robot_action.action_type = APPROACH;
       robot_action.req_vel = safe_vel;
+      robot_action.triggering_points = std::move(triggering_points);
       return true;
     }
   }
@@ -648,6 +671,63 @@ void CollisionMonitor::notifyActionState(
 
     state_pub_->publish(std::move(state_msg));
   }
+}
+
+void CollisionMonitor::publishTriggeringPoints(const Action & action)
+{
+  auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
+  const std::string base_frame = get_parameter("base_frame_id").as_string();
+
+  // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
+  float r = 0.0f, g = 0.0f, b = 0.0f;
+  switch (action.action_type) {
+    case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
+    case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
+    case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
+    case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
+    default: break;
+  }
+
+  // Iterate the static (polygon, source) pair set so every namespace we ever emit gets an
+  // ADD marker every cycle. Empty `points` on inactive pairs overwrites any prior ADD
+  // in RViz, clearing the inactive points.
+  for (const auto & polygon : polygons_) {
+    const std::string polygon_name = polygon->getName();
+    const bool is_active_polygon = (polygon_name == action.polygon_name);
+    for (const auto & source_name : polygon->getSourcesNames()) {
+      visualization_msgs::msg::Marker marker;
+      marker.header.frame_id = base_frame;
+      marker.header.stamp = rclcpp::Time(0, 0);
+      marker.ns = polygon_name + "/" + source_name;
+      marker.id = 0;
+      marker.type = visualization_msgs::msg::Marker::POINTS;
+      marker.action = visualization_msgs::msg::Marker::ADD;
+      marker.scale.x = 0.05;
+      marker.scale.y = 0.05;
+      marker.color.r = r;
+      marker.color.g = g;
+      marker.color.b = b;
+      marker.color.a = 1.0f;
+      marker.lifetime = rclcpp::Duration(0, 0);
+      marker.frame_locked = true;
+
+      if (is_active_polygon) {
+        const auto it = action.triggering_points.find(source_name);
+        if (it != action.triggering_points.end()) {
+          for (const auto & p : it->second) {
+            geometry_msgs::msg::Point gp;
+            gp.x = p.x;
+            gp.y = p.y;
+            gp.z = p.z;
+            marker.points.push_back(gp);
+          }
+        }
+      }
+      marker_array->markers.push_back(marker);
+    }
+  }
+
+  triggering_points_pub_->publish(std::move(marker_array));
 }
 
 void CollisionMonitor::publishPolygons() const

--- a/nav2_collision_monitor/src/costmap.cpp
+++ b/nav2_collision_monitor/src/costmap.cpp
@@ -103,7 +103,7 @@ bool CostmapSource::getData(
         const double wy = meta.origin.position.y + (y + 0.5) * meta.resolution;
         tf2::Vector3 p_v3_s(wx, wy, 0.0);
         tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
-        data.push_back({p_v3_b.x(), p_v3_b.y()});
+        data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
         RCLCPP_DEBUG_THROTTLE(
           logger_, *node->get_clock(), 2000 /*ms*/,
           "[%s] Found obstacles in costmap", source_name_.c_str());

--- a/nav2_collision_monitor/src/costmap.cpp
+++ b/nav2_collision_monitor/src/costmap.cpp
@@ -103,7 +103,7 @@ bool CostmapSource::getData(
         const double wy = meta.origin.position.y + (y + 0.5) * meta.resolution;
         tf2::Vector3 p_v3_s(wx, wy, 0.0);
         tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
-        data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
+        data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z(), source_name_});
         RCLCPP_DEBUG_THROTTLE(
           logger_, *node->get_clock(), 2000 /*ms*/,
           "[%s] Found obstacles in costmap", source_name_.c_str());

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -167,7 +167,7 @@ bool PointCloud::getData(
 
     // Refill data array
     if (data_height >= min_height_ && data_height <= max_height_) {
-      data.push_back({p_v3_b.x(), p_v3_b.y()});
+      data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z()});
     }
   }
   return true;

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -167,7 +167,7 @@ bool PointCloud::getData(
 
     // Refill data array
     if (data_height >= min_height_ && data_height <= max_height_) {
-      data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z()});
+      data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z(), source_name_});
     }
   }
   return true;

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -300,6 +300,20 @@ int Polygon::getPointsInside(
 }
 
 int Polygon::getPointsInside(
+  const std::vector<Point> & points,
+  std::vector<std::size_t> & out_triggering_indices) const
+{
+  int num = 0;
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    if (nav2_util::geometry_utils::isPointInsidePolygon(points[i].x, points[i].y, poly_)) {
+      out_triggering_indices.push_back(i);
+      num++;
+    }
+  }
+  return num;
+}
+
+int Polygon::getPointsInside(
   const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
   std::vector<Point> & out_triggering_points) const
 {
@@ -345,7 +359,6 @@ double Polygon::getCollisionTime(
     return 0.0;
   }
 
-  // TODO(nelson): Follow up on how to get the non-transformed triggering points
   // Robot movement simulation
   for (double time = 0.0; time <= time_before_collision_; time += simulation_time_step_) {
     // Shift the robot pose towards to the vel during simulation_time_step_ time interval
@@ -356,7 +369,11 @@ double Polygon::getCollisionTime(
     transformPoints(pose, points_transformed);
     // If the collision occurred on this stage, return the actual time before a collision
     // as if robot was moved with given velocity
-    if (getPointsInside(points_transformed, out_triggering_points) >= min_points_) {
+    std::vector<std::size_t> triggering_indices;
+    if (getPointsInside(points_transformed, triggering_indices) >= min_points_) {
+      for (std::size_t i : triggering_indices) {
+        out_triggering_points.push_back(collision_points[i]);
+      }
       return time;
     }
   }

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -159,10 +159,10 @@ int Polygon::getMinPoints() const
 }
 
 bool Polygon::isTriggered(
-  const std::vector<Point> & points,
-  std::vector<Point> * out_triggering_points)
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  std::vector<Point> & out_triggering_points)
 {
-  const int points_inside = getPointsInside(points, out_triggering_points);
+  const int points_inside = getPointsInside(sources_collision_points_map, out_triggering_points);
   return isTriggeredInternal(points_inside);
 }
 
@@ -285,34 +285,40 @@ void Polygon::updatePolygon(const Velocity & /*cmd_vel_in*/)
   }
 }
 
-bool Polygon::isPointInside(const Point & point) const
-{
-  return nav2_util::geometry_utils::isPointInsidePolygon(point.x, point.y, poly_);
-}
-
 int Polygon::getPointsInside(
   const std::vector<Point> & points,
-  std::vector<Point> * out_triggering_points) const
+  std::vector<Point> & out_triggering_points) const
 {
   int num = 0;
-  for (const Point & p : points) {
-    if (std::find(sources_names_.begin(), sources_names_.end(), p.source) ==
-      sources_names_.end())
-    {
-      continue;
-    }
-    if (isPointInside(p)) {
-      if (out_triggering_points) {
-        out_triggering_points->push_back(p);
-      }
+  for (const Point & point : points) {
+    if (nav2_util::geometry_utils::isPointInsidePolygon(point.x, point.y, poly_)) {
+      out_triggering_points.push_back(point);
       num++;
     }
   }
   return num;
 }
 
+int Polygon::getPointsInside(
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  std::vector<Point> & out_triggering_points) const
+{
+  int num = 0;
+  std::vector<std::string> polygon_sources_names = getSourcesNames();
+
+  // Sum the number of points from all sources associated with current polygon
+  for (const auto & source_name : polygon_sources_names) {
+    const auto & iter = sources_collision_points_map.find(source_name);
+    if (iter != sources_collision_points_map.end()) {
+      num += getPointsInside(iter->second, out_triggering_points);
+    }
+  }
+
+  return num;
+}
+
 double Polygon::getCollisionTime(
-  const std::vector<Point> & collision_points,
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
   const Velocity & velocity,
   std::vector<Point> & out_triggering_points) const
 {
@@ -320,16 +326,26 @@ double Polygon::getCollisionTime(
   Pose pose = {0.0, 0.0, 0.0};
   Velocity vel = velocity;
 
+  std::vector<std::string> polygon_sources_names = getSourcesNames();
+  std::vector<Point> collision_points;
+
+  // Save all points coming from the sources associated with current polygon
+  for (const auto & source_name : polygon_sources_names) {
+    const auto & iter = sources_collision_points_map.find(source_name);
+    if (iter != sources_collision_points_map.end()) {
+      collision_points.insert(collision_points.end(), iter->second.begin(), iter->second.end());
+    }
+  }
+
   // Array of points transformed to the frame concerned with pose on each simulation step
   std::vector<Point> points_transformed = collision_points;
-  std::vector<Point> triggering_points;
 
   // Check static polygon
-  if (getPointsInside(collision_points, &triggering_points) >= min_points_) {
-    out_triggering_points = std::move(triggering_points);
+  if (getPointsInside(collision_points, out_triggering_points) >= min_points_) {
     return 0.0;
   }
 
+  // TODO(nelson): Follow up on how to get the non-transformed triggering points
   // Robot movement simulation
   for (double time = 0.0; time <= time_before_collision_; time += simulation_time_step_) {
     // Shift the robot pose towards to the vel during simulation_time_step_ time interval
@@ -339,24 +355,8 @@ double Polygon::getCollisionTime(
     points_transformed = collision_points;
     transformPoints(pose, points_transformed);
     // If the collision occurred on this stage, return the actual time before a collision
-    // as if robot was moved with given velocity. The original (untransformed) points
-    // are recorded as triggering points.
-    triggering_points.clear();
-    int num = 0;
-    for (std::size_t i = 0; i < points_transformed.size(); ++i) {
-      const Point & tp = points_transformed[i];
-      if (std::find(sources_names_.begin(), sources_names_.end(), tp.source) ==
-        sources_names_.end())
-      {
-        continue;
-      }
-      if (isPointInside(tp)) {
-        triggering_points.push_back(collision_points[i]);
-        num++;
-      }
-    }
-    if (num >= min_points_) {
-      out_triggering_points = std::move(triggering_points);
+    // as if robot was moved with given velocity
+    if (getPointsInside(points_transformed, out_triggering_points) >= min_points_) {
       return time;
     }
   }

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -165,9 +165,10 @@ bool Polygon::isTriggered(const std::vector<Point> & points)
 }
 
 bool Polygon::isTriggered(
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map)
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  std::unordered_map<std::string, std::vector<Point>> * out_triggering_points)
 {
-  const int points_inside = getPointsInside(sources_collision_points_map);
+  const int points_inside = getPointsInside(sources_collision_points_map, out_triggering_points);
   return isTriggeredInternal(points_inside);
 }
 
@@ -302,8 +303,8 @@ int Polygon::getPointsInside(const std::vector<Point> & points) const
 }
 
 int Polygon::getPointsInside(
-  const std::unordered_map<std::string,
-  std::vector<Point>> & sources_collision_points_map) const
+  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  std::unordered_map<std::string, std::vector<Point>> * out_triggering_points) const
 {
   int num = 0;
   std::vector<std::string> polygon_sources_names = getSourcesNames();
@@ -311,38 +312,75 @@ int Polygon::getPointsInside(
   // Sum the number of points from all sources associated with current polygon
   for (const auto & source_name : polygon_sources_names) {
     const auto & iter = sources_collision_points_map.find(source_name);
-    if (iter != sources_collision_points_map.end()) {
-      num += getPointsInside(iter->second);
+    if (iter == sources_collision_points_map.end()) {
+      continue;
+    }
+    for (const Point & p : iter->second) {
+      if (nav2_util::geometry_utils::isPointInsidePolygon(p.x, p.y, poly_)) {
+        if (out_triggering_points) {
+          (*out_triggering_points)[source_name].push_back(p);
+        }
+        num++;
+      }
     }
   }
 
   return num;
 }
 
+int Polygon::getPointsInsideApproach(
+  const std::unordered_map<std::string, std::vector<Point>> & transformed_points,
+  const std::unordered_map<std::string, std::vector<Point>> & original_points,
+  std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const
+{
+  int num = 0;
+  for (const auto & source_name : getSourcesNames()) {
+    const auto t_iter = transformed_points.find(source_name);
+    const auto o_iter = original_points.find(source_name);
+    if (t_iter == transformed_points.end() || o_iter == original_points.end()) {
+      continue;
+    }
+    const auto & t_pts = t_iter->second;
+    const auto & o_pts = o_iter->second;
+    for (std::size_t i = 0; i < t_pts.size(); ++i) {
+      if (nav2_util::geometry_utils::isPointInsidePolygon(t_pts[i].x, t_pts[i].y, poly_)) {
+        out_triggering_points[source_name].push_back(o_pts[i]);
+        num++;
+      }
+    }
+  }
+  return num;
+}
+
 double Polygon::getCollisionTime(
   const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-  const Velocity & velocity) const
+  const Velocity & velocity,
+  std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const
 {
   // Initial robot pose is {0,0} in base_footprint coordinates
   Pose pose = {0.0, 0.0, 0.0};
   Velocity vel = velocity;
 
   std::vector<std::string> polygon_sources_names = getSourcesNames();
-  std::vector<Point> collision_points;
+  std::unordered_map<std::string, std::vector<Point>> collision_points;
 
   // Save all points coming from the sources associated with current polygon
   for (const auto & source_name : polygon_sources_names) {
     const auto & iter = sources_collision_points_map.find(source_name);
     if (iter != sources_collision_points_map.end()) {
-      collision_points.insert(collision_points.end(), iter->second.begin(), iter->second.end());
+      collision_points[source_name] = iter->second;
     }
   }
 
-  // Array of points transformed to the frame concerned with pose on each simulation step
-  std::vector<Point> points_transformed = collision_points;
+  // Per-source map of points transformed to the frame concerned with pose on each simulation step
+  std::unordered_map<std::string, std::vector<Point>> points_transformed = collision_points;
+
+  // Local triggering-points buffer; moved into out_triggering_points on a trigger.
+  std::unordered_map<std::string, std::vector<Point>> triggering_points;
 
   // Check static polygon
-  if (getPointsInside(collision_points) >= min_points_) {
+  if (getPointsInside(collision_points, &triggering_points) >= min_points_) {
+    out_triggering_points = std::move(triggering_points);
     return 0.0;
   }
 
@@ -353,10 +391,17 @@ double Polygon::getCollisionTime(
     projectState(simulation_time_step_, pose, vel);
     // Transform collision_points to the frame concerned with current robot pose
     points_transformed = collision_points;
-    transformPoints(pose, points_transformed);
+    for (auto & kv : points_transformed) {
+      transformPoints(pose, kv.second);
+    }
     // If the collision occurred on this stage, return the actual time before a collision
-    // as if robot was moved with given velocity
-    if (getPointsInside(points_transformed) >= min_points_) {
+    // as if robot was moved with given velocity. The original triggering points are passed 
+    // to out_triggering_points for visualization.
+    triggering_points.clear();
+    if (getPointsInsideApproach(
+        points_transformed, collision_points, triggering_points) >= min_points_)
+    {
+      out_triggering_points = std::move(triggering_points);
       return time;
     }
   }

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -158,17 +158,11 @@ int Polygon::getMinPoints() const
   return min_points_;
 }
 
-bool Polygon::isTriggered(const std::vector<Point> & points)
-{
-  const int points_inside = getPointsInside(points);
-  return isTriggeredInternal(points_inside);
-}
-
 bool Polygon::isTriggered(
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-  std::unordered_map<std::string, std::vector<Point>> * out_triggering_points)
+  const std::vector<Point> & points,
+  std::vector<Point> * out_triggering_points)
 {
-  const int points_inside = getPointsInside(sources_collision_points_map, out_triggering_points);
+  const int points_inside = getPointsInside(points, out_triggering_points);
   return isTriggeredInternal(points_inside);
 }
 
@@ -291,92 +285,44 @@ void Polygon::updatePolygon(const Velocity & /*cmd_vel_in*/)
   }
 }
 
-int Polygon::getPointsInside(const std::vector<Point> & points) const
+bool Polygon::isPointInside(const Point & point) const
+{
+  return nav2_util::geometry_utils::isPointInsidePolygon(point.x, point.y, poly_);
+}
+
+int Polygon::getPointsInside(
+  const std::vector<Point> & points,
+  std::vector<Point> * out_triggering_points) const
 {
   int num = 0;
-  for (const Point & point : points) {
-    if (nav2_util::geometry_utils::isPointInsidePolygon(point.x, point.y, poly_)) {
+  for (const Point & p : points) {
+    if (std::find(sources_names_.begin(), sources_names_.end(), p.source) ==
+      sources_names_.end())
+    {
+      continue;
+    }
+    if (isPointInside(p)) {
+      if (out_triggering_points) {
+        out_triggering_points->push_back(p);
+      }
       num++;
     }
   }
   return num;
 }
 
-int Polygon::getPointsInside(
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
-  std::unordered_map<std::string, std::vector<Point>> * out_triggering_points) const
-{
-  int num = 0;
-  std::vector<std::string> polygon_sources_names = getSourcesNames();
-
-  // Sum the number of points from all sources associated with current polygon
-  for (const auto & source_name : polygon_sources_names) {
-    const auto & iter = sources_collision_points_map.find(source_name);
-    if (iter == sources_collision_points_map.end()) {
-      continue;
-    }
-    for (const Point & p : iter->second) {
-      if (nav2_util::geometry_utils::isPointInsidePolygon(p.x, p.y, poly_)) {
-        if (out_triggering_points) {
-          (*out_triggering_points)[source_name].push_back(p);
-        }
-        num++;
-      }
-    }
-  }
-
-  return num;
-}
-
-int Polygon::getPointsInsideApproach(
-  const std::unordered_map<std::string, std::vector<Point>> & transformed_points,
-  const std::unordered_map<std::string, std::vector<Point>> & original_points,
-  std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const
-{
-  int num = 0;
-  for (const auto & source_name : getSourcesNames()) {
-    const auto t_iter = transformed_points.find(source_name);
-    const auto o_iter = original_points.find(source_name);
-    if (t_iter == transformed_points.end() || o_iter == original_points.end()) {
-      continue;
-    }
-    const auto & t_pts = t_iter->second;
-    const auto & o_pts = o_iter->second;
-    for (std::size_t i = 0; i < t_pts.size(); ++i) {
-      if (nav2_util::geometry_utils::isPointInsidePolygon(t_pts[i].x, t_pts[i].y, poly_)) {
-        out_triggering_points[source_name].push_back(o_pts[i]);
-        num++;
-      }
-    }
-  }
-  return num;
-}
-
 double Polygon::getCollisionTime(
-  const std::unordered_map<std::string, std::vector<Point>> & sources_collision_points_map,
+  const std::vector<Point> & collision_points,
   const Velocity & velocity,
-  std::unordered_map<std::string, std::vector<Point>> & out_triggering_points) const
+  std::vector<Point> & out_triggering_points) const
 {
   // Initial robot pose is {0,0} in base_footprint coordinates
   Pose pose = {0.0, 0.0, 0.0};
   Velocity vel = velocity;
 
-  std::vector<std::string> polygon_sources_names = getSourcesNames();
-  std::unordered_map<std::string, std::vector<Point>> collision_points;
-
-  // Save all points coming from the sources associated with current polygon
-  for (const auto & source_name : polygon_sources_names) {
-    const auto & iter = sources_collision_points_map.find(source_name);
-    if (iter != sources_collision_points_map.end()) {
-      collision_points[source_name] = iter->second;
-    }
-  }
-
-  // Per-source map of points transformed to the frame concerned with pose on each simulation step
-  std::unordered_map<std::string, std::vector<Point>> points_transformed = collision_points;
-
-  // Local triggering-points buffer; moved into out_triggering_points on a trigger.
-  std::unordered_map<std::string, std::vector<Point>> triggering_points;
+  // Array of points transformed to the frame concerned with pose on each simulation step
+  std::vector<Point> points_transformed = collision_points;
+  std::vector<Point> triggering_points;
 
   // Check static polygon
   if (getPointsInside(collision_points, &triggering_points) >= min_points_) {
@@ -391,16 +337,25 @@ double Polygon::getCollisionTime(
     projectState(simulation_time_step_, pose, vel);
     // Transform collision_points to the frame concerned with current robot pose
     points_transformed = collision_points;
-    for (auto & kv : points_transformed) {
-      transformPoints(pose, kv.second);
-    }
+    transformPoints(pose, points_transformed);
     // If the collision occurred on this stage, return the actual time before a collision
-    // as if robot was moved with given velocity. The original triggering points are passed
-    // to out_triggering_points for visualization.
+    // as if robot was moved with given velocity. The original (untransformed) points
+    // are recorded as triggering points.
     triggering_points.clear();
-    if (getPointsInsideApproach(
-        points_transformed, collision_points, triggering_points) >= min_points_)
-    {
+    int num = 0;
+    for (std::size_t i = 0; i < points_transformed.size(); ++i) {
+      const Point & tp = points_transformed[i];
+      if (std::find(sources_names_.begin(), sources_names_.end(), tp.source) ==
+        sources_names_.end())
+      {
+        continue;
+      }
+      if (isPointInside(tp)) {
+        triggering_points.push_back(collision_points[i]);
+        num++;
+      }
+    }
+    if (num >= min_points_) {
       out_triggering_points = std::move(triggering_points);
       return time;
     }

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -395,7 +395,7 @@ double Polygon::getCollisionTime(
       transformPoints(pose, kv.second);
     }
     // If the collision occurred on this stage, return the actual time before a collision
-    // as if robot was moved with given velocity. The original triggering points are passed 
+    // as if robot was moved with given velocity. The original triggering points are passed
     // to out_triggering_points for visualization.
     triggering_points.clear();
     if (getPointsInsideApproach(

--- a/nav2_collision_monitor/src/polygon_source.cpp
+++ b/nav2_collision_monitor/src/polygon_source.cpp
@@ -146,6 +146,7 @@ void PolygonSource::convertPolygonStampedToPoints(
       Point p;
       p.x = current_point.x + j * dx;
       p.y = current_point.y + j * dy;
+      p.source = source_name_;
       data.push_back(p);
     }
   }

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -109,7 +109,7 @@ bool Range::getData(
     tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
     // Refill data array
-    data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
+    data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z(), source_name_});
   }
 
   // Make sure that last (field_of_view / 2) point will be in the data array
@@ -123,7 +123,7 @@ bool Range::getData(
   tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
   // Refill data array
-  data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
+  data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z(), source_name_});
 
   return true;
 }

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -109,7 +109,7 @@ bool Range::getData(
     tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
     // Refill data array
-    data.push_back({p_v3_b.x(), p_v3_b.y()});
+    data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
   }
 
   // Make sure that last (field_of_view / 2) point will be in the data array
@@ -123,7 +123,7 @@ bool Range::getData(
   tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
   // Refill data array
-  data.push_back({p_v3_b.x(), p_v3_b.y()});
+  data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
 
   return true;
 }

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -96,7 +96,7 @@ bool Scan::getData(
       tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
       // Refill data array
-      data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
+      data.push_back({p_v3_b.x(), p_v3_b.y(), p_v3_b.z(), source_name_});
     }
     angle += data_->angle_increment;
   }

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -96,7 +96,7 @@ bool Scan::getData(
       tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
       // Refill data array
-      data.push_back({p_v3_b.x(), p_v3_b.y()});
+      data.push_back({p_v3_b.x(), p_v3_b.y(), 0.0, source_name_});
     }
     angle += data_->angle_increment;
   }

--- a/nav2_collision_monitor/test/collision_detector_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_detector_node_test.cpp
@@ -55,6 +55,7 @@ static const char POLYGON_NAME[]{"Polygon"};
 static const char COSTMAP_NAME[]{"Costmap"};
 static const char STATE_TOPIC[]{"collision_detector_state"};
 static const char COLLISION_POINTS_MARKERS_TOPIC[]{"/collision_detector/collision_points_marker"};
+static const char TRIGGERING_POINTS_TOPIC[]{"/collision_detector/triggering_points"};
 static const int MIN_POINTS{1};
 static const double SIMULATION_TIME_STEP{0.01};
 static const double TRANSFORM_TOLERANCE{0.5};
@@ -156,6 +157,8 @@ public:
   void stateCallback(nav2_msgs::msg::CollisionDetectorState::ConstSharedPtr msg);
   bool waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout);
   void collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
+  bool waitTriggeringPoints(const std::chrono::nanoseconds & timeout);
+  void triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
 
 protected:
   // CollisionDetector node
@@ -181,6 +184,11 @@ protected:
   nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_sub_;
   visualization_msgs::msg::MarkerArray::ConstSharedPtr collision_points_marker_msg_;
+
+  // CollisionDetector triggering points markers
+  nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
+    triggering_points_sub_;
+  visualization_msgs::msg::MarkerArray::ConstSharedPtr triggering_points_msg_;
 };  // Tester
 
 Tester::Tester()
@@ -212,6 +220,10 @@ Tester::Tester()
   collision_points_marker_sub_ = cd_->create_subscription<visualization_msgs::msg::MarkerArray>(
     COLLISION_POINTS_MARKERS_TOPIC,
     std::bind(&Tester::collisionPointsMarkerCallback, this, std::placeholders::_1));
+
+  triggering_points_sub_ = cd_->create_subscription<visualization_msgs::msg::MarkerArray>(
+    TRIGGERING_POINTS_TOPIC,
+    std::bind(&Tester::triggeringPointsCallback, this, std::placeholders::_1));
 }
 
 Tester::~Tester()
@@ -226,6 +238,7 @@ Tester::~Tester()
   costmap_pub_->on_deactivate();
   costmap_pub_.reset();
   collision_points_marker_sub_.reset();
+  triggering_points_sub_.reset();
 
   cd_.reset();
   executor_.reset();
@@ -258,6 +271,20 @@ bool Tester::waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout)
   return false;
 }
 
+bool Tester::waitTriggeringPoints(const std::chrono::nanoseconds & timeout)
+{
+  triggering_points_msg_ = nullptr;
+  rclcpp::Time start_time = cd_->now();
+  while (rclcpp::ok() && cd_->now() - start_time <= rclcpp::Duration(timeout)) {
+    if (triggering_points_msg_) {
+      return true;
+    }
+    executor_->spin_some();
+    std::this_thread::sleep_for(10ms);
+  }
+  return false;
+}
+
 void Tester::stateCallback(nav2_msgs::msg::CollisionDetectorState::ConstSharedPtr msg)
 {
   state_msg_ = msg;
@@ -266,6 +293,11 @@ void Tester::stateCallback(nav2_msgs::msg::CollisionDetectorState::ConstSharedPt
 void Tester::collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
 {
   collision_points_marker_msg_ = msg;
+}
+
+void Tester::triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
+{
+  triggering_points_msg_ = msg;
 }
 
 void Tester::setCommonParameters()
@@ -858,6 +890,60 @@ TEST_F(Tester, testCollisionPointsMarkers)
   ASSERT_TRUE(waitCollisionPointsMarker(500ms));
   ASSERT_NE(collision_points_marker_msg_->markers[0].points.size(), 0u);
   // Stop Collision Monitor node
+  cd_->stop();
+}
+
+TEST_F(Tester, testTriggeringPointsMarkers)
+{
+  rclcpp::Time curr_time = cd_->now();
+
+  // Detection polygon of half-size 1.0 around base_link, single scan source.
+  setCommonParameters();
+  addPolygon("DetectionRegion", POLYGON, 1.0, "none");
+  addSource(SCAN_NAME, SCAN);
+  setVectors({"DetectionRegion"}, {SCAN_NAME});
+
+  cd_->start();
+  sendTransforms(curr_time);
+
+  // No obstacle: nothing detected, marker array contains only the DELETEALL clear marker.
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  ASSERT_EQ(triggering_points_msg_->markers.size(), 1u);
+  EXPECT_EQ(
+    triggering_points_msg_->markers[0].action,
+    visualization_msgs::msg::Marker::DELETEALL);
+
+  // Obstacle inside the detection polygon: marker array must contain the
+  // clear marker plus one POINTS marker for the Scan source.
+  publishScan(0.5, curr_time);
+  ASSERT_TRUE(waitData(0.5, 500ms, curr_time));
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  ASSERT_TRUE(waitState(500ms));
+  ASSERT_NE(state_msg_->detections.size(), 0u);
+  ASSERT_EQ(state_msg_->detections[0], true);
+
+  ASSERT_EQ(triggering_points_msg_->markers.size(), 2u);
+  EXPECT_EQ(
+    triggering_points_msg_->markers[0].action,
+    visualization_msgs::msg::Marker::DELETEALL);
+
+  const auto & points_marker = triggering_points_msg_->markers[1];
+  EXPECT_EQ(points_marker.type, visualization_msgs::msg::Marker::POINTS);
+  EXPECT_EQ(points_marker.action, visualization_msgs::msg::Marker::ADD);
+  EXPECT_EQ(points_marker.ns, std::string("DetectionRegion/") + SCAN_NAME);
+  EXPECT_EQ(points_marker.header.frame_id, BASE_FRAME_ID);
+  EXPECT_TRUE(points_marker.frame_locked);
+  EXPECT_FLOAT_EQ(points_marker.color.r, 1.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.g, 0.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.b, 0.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.a, 1.0f);
+
+  ASSERT_FALSE(points_marker.points.empty());
+  for (const auto & p : points_marker.points) {
+    EXPECT_LE(std::abs(p.x), 1.0 + EPSILON);
+    EXPECT_LE(std::abs(p.y), 1.0 + EPSILON);
+  }
+
   cd_->stop();
 }
 

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -50,6 +50,7 @@ static const char CMD_VEL_IN_TOPIC[]{"cmd_vel_in"};
 static const char CMD_VEL_OUT_TOPIC[]{"cmd_vel_out"};
 static const char STATE_TOPIC[]{"collision_monitor_state"};
 static const char COLLISION_POINTS_MARKERS_TOPIC[]{"/collision_monitor/collision_points_marker"};
+static const char TRIGGERING_POINTS_TOPIC[]{"/collision_monitor/triggering_points"};
 static const char FOOTPRINT_TOPIC[]{"footprint"};
 static const char SCAN_NAME[]{"Scan"};
 static const char POINTCLOUD_NAME[]{"PointCloud"};
@@ -189,6 +190,7 @@ public:
     const std::chrono::nanoseconds & timeout);
   bool waitActionState(const std::chrono::nanoseconds & timeout);
   bool waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout);
+  bool waitTriggeringPoints(const std::chrono::nanoseconds & timeout);
   bool waitToggle(
     rclcpp::Client<nav2_msgs::srv::Toggle>::SharedFuture result_future,
     const std::chrono::nanoseconds & timeout);
@@ -197,6 +199,7 @@ protected:
   void cmdVelOutCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
   void actionStateCallback(nav2_msgs::msg::CollisionMonitorState::ConstSharedPtr msg);
   void collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
+  void triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
 
   // CollisionMonitor node
   std::shared_ptr<CollisionMonitorWrapper> cm_;
@@ -227,6 +230,11 @@ protected:
   nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_sub_;
   visualization_msgs::msg::MarkerArray::ConstSharedPtr collision_points_marker_msg_;
+
+  // CollisionMonitor triggering points markers
+  nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
+    triggering_points_sub_;
+  visualization_msgs::msg::MarkerArray::ConstSharedPtr triggering_points_msg_;
 
   // Service client for setting CollisionMonitor parameters
   nav2::ServiceClient<rcl_interfaces::srv::SetParameters>::SharedPtr parameters_client_;
@@ -272,6 +280,9 @@ Tester::Tester()
   collision_points_marker_sub_ = cm_->create_subscription<visualization_msgs::msg::MarkerArray>(
     COLLISION_POINTS_MARKERS_TOPIC,
     std::bind(&Tester::collisionPointsMarkerCallback, this, std::placeholders::_1));
+  triggering_points_sub_ = cm_->create_subscription<visualization_msgs::msg::MarkerArray>(
+    TRIGGERING_POINTS_TOPIC,
+    std::bind(&Tester::triggeringPointsCallback, this, std::placeholders::_1));
   parameters_client_ =
     cm_->create_client<rcl_interfaces::srv::SetParameters>(
     std::string(
@@ -299,6 +310,7 @@ Tester::~Tester()
 
   action_state_sub_.reset();
   collision_points_marker_sub_.reset();
+  triggering_points_sub_.reset();
 
   cm_.reset();
   executor_.reset();
@@ -688,6 +700,7 @@ void Tester::publishCmdVel(const double x, const double y, const double tw)
   cmd_vel_out_ = nullptr;
   action_state_ = nullptr;
   collision_points_marker_msg_ = nullptr;
+  triggering_points_msg_ = nullptr;
 
   std::unique_ptr<geometry_msgs::msg::Twist> msg =
     std::make_unique<geometry_msgs::msg::Twist>();
@@ -786,6 +799,19 @@ bool Tester::waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout)
   return false;
 }
 
+bool Tester::waitTriggeringPoints(const std::chrono::nanoseconds & timeout)
+{
+  rclcpp::Time start_time = cm_->now();
+  while (rclcpp::ok() && cm_->now() - start_time <= rclcpp::Duration(timeout)) {
+    if (triggering_points_msg_) {
+      return true;
+    }
+    executor_->spin_some();
+    std::this_thread::sleep_for(10ms);
+  }
+  return false;
+}
+
 void Tester::cmdVelOutCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg)
 {
   cmd_vel_out_ = msg;
@@ -799,6 +825,11 @@ void Tester::actionStateCallback(nav2_msgs::msg::CollisionMonitorState::ConstSha
 void Tester::collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
 {
   collision_points_marker_msg_ = msg;
+}
+
+void Tester::triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
+{
+  triggering_points_msg_ = msg;
 }
 
 TEST_F(Tester, testToggleService)
@@ -1578,6 +1609,62 @@ TEST_F(Tester, testCollisionPointsMarkers)
   ASSERT_TRUE(waitCollisionPointsMarker(500ms));
   ASSERT_NE(collision_points_marker_msg_->markers[0].points.size(), 0u);
   // Stop Collision Monitor node
+  cm_->stop();
+}
+
+TEST_F(Tester, testTriggeringPointsMarkers)
+{
+  rclcpp::Time curr_time = cm_->now();
+
+  // Stop polygon of half-size 1.0 around base_link, single scan source.
+  setCommonParameters();
+  addPolygon("Stop", POLYGON, 1.0, "stop");
+  addSource(SCAN_NAME, SCAN);
+  setVectors({"Stop"}, {SCAN_NAME});
+
+  cm_->start();
+  sendTransforms(curr_time);
+
+  // No obstacle: triggering_points should contain only the DELETEALL clear marker.
+  publishCmdVel(0.5, 0.0, 0.0);
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  ASSERT_EQ(triggering_points_msg_->markers.size(), 1u);
+  EXPECT_EQ(
+    triggering_points_msg_->markers[0].action,
+    visualization_msgs::msg::Marker::DELETEALL);
+
+  // Obstacle inside the Stop polygon: STOP action triggers, marker array must
+  // contain the clear marker plus one POINTS marker for the Scan source.
+  publishScan(0.5, curr_time);
+  ASSERT_TRUE(waitData(0.5, 500ms, curr_time));
+  publishCmdVel(0.5, 0.0, 0.0);
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  ASSERT_TRUE(waitActionState(500ms));
+  ASSERT_EQ(action_state_->action_type, STOP);
+
+  ASSERT_EQ(triggering_points_msg_->markers.size(), 2u);
+  EXPECT_EQ(
+    triggering_points_msg_->markers[0].action,
+    visualization_msgs::msg::Marker::DELETEALL);
+
+  const auto & points_marker = triggering_points_msg_->markers[1];
+  EXPECT_EQ(points_marker.type, visualization_msgs::msg::Marker::POINTS);
+  EXPECT_EQ(points_marker.action, visualization_msgs::msg::Marker::ADD);
+  EXPECT_EQ(points_marker.ns, std::string("Stop/") + SCAN_NAME);
+  EXPECT_EQ(points_marker.header.frame_id, BASE_FRAME_ID);
+  EXPECT_TRUE(points_marker.frame_locked);
+  // STOP colour: red.
+  EXPECT_FLOAT_EQ(points_marker.color.r, 1.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.g, 0.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.b, 0.0f);
+  EXPECT_FLOAT_EQ(points_marker.color.a, 1.0f);
+
+  ASSERT_FALSE(points_marker.points.empty());
+  for (const auto & p : points_marker.points) {
+    EXPECT_LE(std::abs(p.x), 1.0 + EPSILON);
+    EXPECT_LE(std::abs(p.y), 1.0 + EPSILON);
+  }
+
   cm_->stop();
 }
 

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -866,6 +866,46 @@ TEST_F(Tester, testCircleGetPointsInside)
   EXPECT_NEAR(triggering_points[0].y, 0.3, EPSILON);
 }
 
+TEST_F(Tester, testPolygonGetPointsInsideIndices)
+{
+  createPolygon("stop", true);
+
+  std::vector<nav2_collision_monitor::Point> points;
+  std::vector<std::size_t> triggering_indices;
+
+  // Out of boundaries points
+  points.push_back({1.0, 0.0});
+  points.push_back({0.0, 1.0});
+  points.push_back({-1.0, 0.0});
+  points.push_back({0.0, -1.0});
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_indices), 0);
+  ASSERT_EQ(triggering_indices.size(), 0u);
+
+  // Add one point inside
+  points.push_back({-0.1, 0.3});
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_indices), 1);
+  ASSERT_EQ(triggering_indices.size(), 1u);
+  EXPECT_EQ(triggering_indices[0], 4u);
+}
+
+TEST_F(Tester, testCircleGetPointsInsideIndices)
+{
+  createCircle("stop", true);
+
+  std::vector<nav2_collision_monitor::Point> points;
+  std::vector<std::size_t> triggering_indices;
+  // Point out of radius
+  points.push_back({1.0, 0.0});
+  ASSERT_EQ(circle_->getPointsInside(points, triggering_indices), 0);
+  ASSERT_EQ(triggering_indices.size(), 0u);
+
+  // Add one point inside
+  points.push_back({-0.1, 0.3});
+  ASSERT_EQ(circle_->getPointsInside(points, triggering_indices), 1);
+  ASSERT_EQ(triggering_indices.size(), 1u);
+  EXPECT_EQ(triggering_indices[0], 1u);
+}
+
 TEST_F(Tester, testPolygonGetCollisionTime)
 {
   createPolygon("approach", false);
@@ -917,26 +957,40 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   //     -----------
   //          '
   points_map.clear();
+  triggering_points.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.49, -0.01}, {0.49, 0.01}}});
   // Collision is expected to be in ~= 45 degrees * M_PI / (180 degrees * 1.0 rad/s) seconds
   double exp_res = 45 / 180 * M_PI;
   EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), exp_res, EPSILON);
+  ASSERT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(triggering_points[0].x, 0.49, EPSILON);
+  EXPECT_NEAR(triggering_points[0].y, -0.01, EPSILON);
+  EXPECT_NEAR(triggering_points[1].x, 0.49, EPSILON);
+  EXPECT_NEAR(triggering_points[1].y, 0.01, EPSILON);
 
   // Two points are already inside footprint
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points inside
   points_map.clear();
+  triggering_points.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.1, -0.01}, {0.1, 0.01}}});
   // Collision already appeared: collision time should be 0
   EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0, EPSILON);
+  ASSERT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(triggering_points[0].x, 0.1, EPSILON);
+  EXPECT_NEAR(triggering_points[0].y, -0.01, EPSILON);
+  EXPECT_NEAR(triggering_points[1].x, 0.1, EPSILON);
+  EXPECT_NEAR(triggering_points[1].y, 0.01, EPSILON);
 
   // All points are out of simulation prediction
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.6 m ahead the footprint (0.5 m)
   points_map.clear();
+  triggering_points.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{1.1, -0.01}, {1.1, 0.01}}});
   // There is no collision: return value should be negative
   EXPECT_LT(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0);
+  EXPECT_TRUE(triggering_points.empty());
 }
 
 TEST_F(Tester, testPolygonPublish)

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -870,24 +870,35 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   // Two points 0.2 m ahead the footprint (0.5 m)
   std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.7, -0.01}, {0.7, 0.01}}});
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> triggering_points;
   // Collision is expected to be ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
+  // On trigger, triggering_points holds only the points responsible for the collision
+  EXPECT_EQ(triggering_points.size(), 1u);
+  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
 
   // Backward movement check
   vel = {-0.5, 0.0, 0.0};  // 0.5 m/s backward movement
   // Two points 0.2 m behind the footprint (0.5 m)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.7, -0.01}, {-0.7, 0.01}}});
+  triggering_points.clear();
   // Collision is expected to be in ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
 
   // Sideway movement check
   vel = {0.0, 0.5, 0.0};  // 0.5 m/s sideway movement
   // Two points 0.1 m ahead the footprint (0.5 m)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.01, 0.6}, {0.01, 0.6}}});
+  triggering_points.clear();
   // Collision is expected to be in ~= 0.1 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.2, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.2, SIMULATION_TIME_STEP);
+  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
 
   // Rotation check
   vel = {0.0, 0.0, 1.0};  // 1.0 rad/s rotation
@@ -903,25 +914,32 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   //          '
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.49, -0.01}, {0.49, 0.01}}});
+  triggering_points.clear();
   // Collision is expected to be in ~= 45 degrees * M_PI / (180 degrees * 1.0 rad/s) seconds
   double exp_res = 45 / 180 * M_PI;
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), exp_res, EPSILON);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), exp_res, EPSILON);
+  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
 
   // Two points are already inside footprint
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points inside
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.1, -0.01}, {0.1, 0.01}}});
+  triggering_points.clear();
   // Collision already appeared: collision time should be 0
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.0, EPSILON);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0, EPSILON);
+  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
 
   // All points are out of simulation prediction
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.6 m ahead the footprint (0.5 m)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{1.1, -0.01}, {1.1, 0.01}}});
-  // There is no collision: return value should be negative
-  EXPECT_LT(polygon_->getCollisionTime(points_map, vel), 0.0);
+  triggering_points.clear();
+  // There is no collision: return value should be negative and no triggering points reported
+  EXPECT_LT(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0);
+  EXPECT_TRUE(triggering_points.empty());
 }
 
 TEST_F(Tester, testPolygonPublish)

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -799,17 +799,18 @@ TEST_F(Tester, testPolygonGetPointsInside)
 {
   createPolygon("stop", true);
 
+  // Each point must carry the source field so it passes the polygon's source filter.
   std::vector<nav2_collision_monitor::Point> points;
 
   // Out of boundaries points
-  points.push_back({1.0, 0.0});
-  points.push_back({0.0, 1.0});
-  points.push_back({-1.0, 0.0});
-  points.push_back({0.0, -1.0});
+  points.push_back({1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({0.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({0.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(polygon_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({-0.1, 0.3});
+  points.push_back({-0.1, 0.3, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(polygon_->getPointsInside(points), 1);
 }
 
@@ -828,16 +829,16 @@ TEST_F(Tester, testPolygonGetPointsInsideEdge)
   std::vector<nav2_collision_monitor::Point> points;
 
   // Out of boundaries points
-  points.push_back({-2.0, -1.0});
-  points.push_back({-2.0, 0.0});
-  points.push_back({-2.0, 1.0});
-  points.push_back({3.0, -1.0});
-  points.push_back({3.0, 0.0});
-  points.push_back({3.0, 1.0});
+  points.push_back({-2.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-2.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-2.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({3.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({3.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({3.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(polygon_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({0.0, 0.0});
+  points.push_back({0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(polygon_->getPointsInside(points), 1);
 }
 
@@ -847,11 +848,11 @@ TEST_F(Tester, testCircleGetPointsInside)
 
   std::vector<nav2_collision_monitor::Point> points;
   // Point out of radius
-  points.push_back({1.0, 0.0});
+  points.push_back({1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(circle_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({-0.1, 0.3});
+  points.push_back({-0.1, 0.3, 0.0, OBSERVATION_SOURCE_NAME});
   ASSERT_EQ(circle_->getPointsInside(points), 1);
 }
 
@@ -865,40 +866,43 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   ASSERT_TRUE(waitFootprint(500ms, footprint));
   ASSERT_EQ(footprint.size(), 4u);
 
+  // Helper: build a vector of two source-tagged points.
+  auto makePts = [](double x1, double y1, double x2, double y2) {
+      return std::vector<nav2_collision_monitor::Point>{
+      {x1, y1, 0.0, OBSERVATION_SOURCE_NAME},
+      {x2, y2, 0.0, OBSERVATION_SOURCE_NAME}};
+    };
+
   // Forward movement check
   nav2_collision_monitor::Velocity vel{0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.2 m ahead the footprint (0.5 m)
-  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.7, -0.01}, {0.7, 0.01}}});
-  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> triggering_points;
+  auto points = makePts(0.7, -0.01, 0.7, 0.01);
+  std::vector<nav2_collision_monitor::Point> triggering_points;
   // Collision is expected to be ~= 0.2 m / 0.5 m/s seconds
   EXPECT_NEAR(
-    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
+    polygon_->getCollisionTime(points, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
   // On trigger, triggering_points holds only the points responsible for the collision
-  EXPECT_EQ(triggering_points.size(), 1u);
-  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
+  EXPECT_EQ(triggering_points.size(), 2u);
 
   // Backward movement check
   vel = {-0.5, 0.0, 0.0};  // 0.5 m/s backward movement
   // Two points 0.2 m behind the footprint (0.5 m)
-  points_map.clear();
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.7, -0.01}, {-0.7, 0.01}}});
+  points = makePts(-0.7, -0.01, -0.7, 0.01);
   triggering_points.clear();
   // Collision is expected to be in ~= 0.2 m / 0.5 m/s seconds
   EXPECT_NEAR(
-    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
-  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
+    polygon_->getCollisionTime(points, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_EQ(triggering_points.size(), 2u);
 
   // Sideway movement check
   vel = {0.0, 0.5, 0.0};  // 0.5 m/s sideway movement
   // Two points 0.1 m ahead the footprint (0.5 m)
-  points_map.clear();
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.01, 0.6}, {0.01, 0.6}}});
+  points = makePts(-0.01, 0.6, 0.01, 0.6);
   triggering_points.clear();
   // Collision is expected to be in ~= 0.1 m / 0.5 m/s seconds
   EXPECT_NEAR(
-    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.2, SIMULATION_TIME_STEP);
-  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
+    polygon_->getCollisionTime(points, vel, triggering_points), 0.2, SIMULATION_TIME_STEP);
+  EXPECT_EQ(triggering_points.size(), 2u);
 
   // Rotation check
   vel = {0.0, 0.0, 1.0};  // 1.0 rad/s rotation
@@ -912,33 +916,30 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   //     |    '    |
   //     -----------
   //          '
-  points_map.clear();
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.49, -0.01}, {0.49, 0.01}}});
+  points = makePts(0.49, -0.01, 0.49, 0.01);
   triggering_points.clear();
   // Collision is expected to be in ~= 45 degrees * M_PI / (180 degrees * 1.0 rad/s) seconds
   double exp_res = 45 / 180 * M_PI;
   EXPECT_NEAR(
-    polygon_->getCollisionTime(points_map, vel, triggering_points), exp_res, EPSILON);
-  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
+    polygon_->getCollisionTime(points, vel, triggering_points), exp_res, EPSILON);
+  EXPECT_EQ(triggering_points.size(), 2u);
 
   // Two points are already inside footprint
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points inside
-  points_map.clear();
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.1, -0.01}, {0.1, 0.01}}});
+  points = makePts(0.1, -0.01, 0.1, 0.01);
   triggering_points.clear();
   // Collision already appeared: collision time should be 0
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0, EPSILON);
-  EXPECT_EQ(triggering_points[OBSERVATION_SOURCE_NAME].size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points, vel, triggering_points), 0.0, EPSILON);
+  EXPECT_EQ(triggering_points.size(), 2u);
 
   // All points are out of simulation prediction
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.6 m ahead the footprint (0.5 m)
-  points_map.clear();
-  points_map.insert({OBSERVATION_SOURCE_NAME, {{1.1, -0.01}, {1.1, 0.01}}});
+  points = makePts(1.1, -0.01, 1.1, 0.01);
   triggering_points.clear();
   // There is no collision: return value should be negative and no triggering points reported
-  EXPECT_LT(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0);
+  EXPECT_LT(polygon_->getCollisionTime(points, vel, triggering_points), 0.0);
   EXPECT_TRUE(triggering_points.empty());
 }
 
@@ -1045,7 +1046,7 @@ TEST_F(Tester, testPolygonDebounceDefaultBehavior)
       std::vector<nav2_collision_monitor::Point> points;
       points.reserve(count);
       for (int i = 0; i < count; ++i) {
-        points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
+        points.push_back(nav2_collision_monitor::Point{0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
       }
       return points;
     };
@@ -1070,7 +1071,7 @@ TEST_F(Tester, testPolygonDebounceConsecutiveTriggerRelease)
       std::vector<nav2_collision_monitor::Point> points;
       points.reserve(count);
       for (int i = 0; i < count; ++i) {
-        points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
+        points.push_back(nav2_collision_monitor::Point{0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
       }
       return points;
     };

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -799,18 +799,17 @@ TEST_F(Tester, testPolygonGetPointsInside)
 {
   createPolygon("stop", true);
 
-  // Each point must carry the source field so it passes the polygon's source filter.
   std::vector<nav2_collision_monitor::Point> points;
 
   // Out of boundaries points
-  points.push_back({1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({0.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({-1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({0.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({1.0, 0.0});
+  points.push_back({0.0, 1.0});
+  points.push_back({-1.0, 0.0});
+  points.push_back({0.0, -1.0});
   ASSERT_EQ(polygon_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({-0.1, 0.3, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-0.1, 0.3});
   ASSERT_EQ(polygon_->getPointsInside(points), 1);
 }
 
@@ -829,16 +828,16 @@ TEST_F(Tester, testPolygonGetPointsInsideEdge)
   std::vector<nav2_collision_monitor::Point> points;
 
   // Out of boundaries points
-  points.push_back({-2.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({-2.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({-2.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({3.0, -1.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({3.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
-  points.push_back({3.0, 1.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-2.0, -1.0});
+  points.push_back({-2.0, 0.0});
+  points.push_back({-2.0, 1.0});
+  points.push_back({3.0, -1.0});
+  points.push_back({3.0, 0.0});
+  points.push_back({3.0, 1.0});
   ASSERT_EQ(polygon_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({0.0, 0.0});
   ASSERT_EQ(polygon_->getPointsInside(points), 1);
 }
 
@@ -848,11 +847,11 @@ TEST_F(Tester, testCircleGetPointsInside)
 
   std::vector<nav2_collision_monitor::Point> points;
   // Point out of radius
-  points.push_back({1.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({1.0, 0.0});
   ASSERT_EQ(circle_->getPointsInside(points), 0);
 
   // Add one point inside
-  points.push_back({-0.1, 0.3, 0.0, OBSERVATION_SOURCE_NAME});
+  points.push_back({-0.1, 0.3});
   ASSERT_EQ(circle_->getPointsInside(points), 1);
 }
 
@@ -866,43 +865,29 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   ASSERT_TRUE(waitFootprint(500ms, footprint));
   ASSERT_EQ(footprint.size(), 4u);
 
-  // Helper: build a vector of two source-tagged points.
-  auto makePts = [](double x1, double y1, double x2, double y2) {
-      return std::vector<nav2_collision_monitor::Point>{
-      {x1, y1, 0.0, OBSERVATION_SOURCE_NAME},
-      {x2, y2, 0.0, OBSERVATION_SOURCE_NAME}};
-    };
-
   // Forward movement check
   nav2_collision_monitor::Velocity vel{0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.2 m ahead the footprint (0.5 m)
-  auto points = makePts(0.7, -0.01, 0.7, 0.01);
-  std::vector<nav2_collision_monitor::Point> triggering_points;
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.7, -0.01}, {0.7, 0.01}}});
   // Collision is expected to be ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(
-    polygon_->getCollisionTime(points, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
-  // On trigger, triggering_points holds only the points responsible for the collision
-  EXPECT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
 
   // Backward movement check
   vel = {-0.5, 0.0, 0.0};  // 0.5 m/s backward movement
   // Two points 0.2 m behind the footprint (0.5 m)
-  points = makePts(-0.7, -0.01, -0.7, 0.01);
-  triggering_points.clear();
+  points_map.clear();
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.7, -0.01}, {-0.7, 0.01}}});
   // Collision is expected to be in ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(
-    polygon_->getCollisionTime(points, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
-  EXPECT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
 
   // Sideway movement check
   vel = {0.0, 0.5, 0.0};  // 0.5 m/s sideway movement
   // Two points 0.1 m ahead the footprint (0.5 m)
-  points = makePts(-0.01, 0.6, 0.01, 0.6);
-  triggering_points.clear();
+  points_map.clear();
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.01, 0.6}, {0.01, 0.6}}});
   // Collision is expected to be in ~= 0.1 m / 0.5 m/s seconds
-  EXPECT_NEAR(
-    polygon_->getCollisionTime(points, vel, triggering_points), 0.2, SIMULATION_TIME_STEP);
-  EXPECT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.2, SIMULATION_TIME_STEP);
 
   // Rotation check
   vel = {0.0, 0.0, 1.0};  // 1.0 rad/s rotation
@@ -916,31 +901,27 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   //     |    '    |
   //     -----------
   //          '
-  points = makePts(0.49, -0.01, 0.49, 0.01);
-  triggering_points.clear();
+  points_map.clear();
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.49, -0.01}, {0.49, 0.01}}});
   // Collision is expected to be in ~= 45 degrees * M_PI / (180 degrees * 1.0 rad/s) seconds
   double exp_res = 45 / 180 * M_PI;
-  EXPECT_NEAR(
-    polygon_->getCollisionTime(points, vel, triggering_points), exp_res, EPSILON);
-  EXPECT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), exp_res, EPSILON);
 
   // Two points are already inside footprint
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points inside
-  points = makePts(0.1, -0.01, 0.1, 0.01);
-  triggering_points.clear();
+  points_map.clear();
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{0.1, -0.01}, {0.1, 0.01}}});
   // Collision already appeared: collision time should be 0
-  EXPECT_NEAR(polygon_->getCollisionTime(points, vel, triggering_points), 0.0, EPSILON);
-  EXPECT_EQ(triggering_points.size(), 2u);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.0, EPSILON);
 
   // All points are out of simulation prediction
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.6 m ahead the footprint (0.5 m)
-  points = makePts(1.1, -0.01, 1.1, 0.01);
-  triggering_points.clear();
-  // There is no collision: return value should be negative and no triggering points reported
-  EXPECT_LT(polygon_->getCollisionTime(points, vel, triggering_points), 0.0);
-  EXPECT_TRUE(triggering_points.empty());
+  points_map.clear();
+  points_map.insert({OBSERVATION_SOURCE_NAME, {{1.1, -0.01}, {1.1, 0.01}}});
+  // There is no collision: return value should be negative
+  EXPECT_LT(polygon_->getCollisionTime(points_map, vel), 0.0);
 }
 
 TEST_F(Tester, testPolygonPublish)
@@ -1046,7 +1027,7 @@ TEST_F(Tester, testPolygonDebounceDefaultBehavior)
       std::vector<nav2_collision_monitor::Point> points;
       points.reserve(count);
       for (int i = 0; i < count; ++i) {
-        points.push_back(nav2_collision_monitor::Point{0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+        points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
       }
       return points;
     };
@@ -1071,7 +1052,7 @@ TEST_F(Tester, testPolygonDebounceConsecutiveTriggerRelease)
       std::vector<nav2_collision_monitor::Point> points;
       points.reserve(count);
       for (int i = 0; i < count; ++i) {
-        points.push_back(nav2_collision_monitor::Point{0.0, 0.0, 0.0, OBSERVATION_SOURCE_NAME});
+        points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
       }
       return points;
     };

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -800,17 +800,18 @@ TEST_F(Tester, testPolygonGetPointsInside)
   createPolygon("stop", true);
 
   std::vector<nav2_collision_monitor::Point> points;
+  std::vector<nav2_collision_monitor::Point> triggering_points;
 
   // Out of boundaries points
   points.push_back({1.0, 0.0});
   points.push_back({0.0, 1.0});
   points.push_back({-1.0, 0.0});
   points.push_back({0.0, -1.0});
-  ASSERT_EQ(polygon_->getPointsInside(points), 0);
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 0);
 
   // Add one point inside
   points.push_back({-0.1, 0.3});
-  ASSERT_EQ(polygon_->getPointsInside(points), 1);
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 1);
 }
 
 TEST_F(Tester, testPolygonGetPointsInsideEdge)
@@ -826,6 +827,7 @@ TEST_F(Tester, testPolygonGetPointsInsideEdge)
   ASSERT_TRUE(polygon_->configure());
 
   std::vector<nav2_collision_monitor::Point> points;
+  std::vector<nav2_collision_monitor::Point> triggering_points;
 
   // Out of boundaries points
   points.push_back({-2.0, -1.0});
@@ -834,11 +836,11 @@ TEST_F(Tester, testPolygonGetPointsInsideEdge)
   points.push_back({3.0, -1.0});
   points.push_back({3.0, 0.0});
   points.push_back({3.0, 1.0});
-  ASSERT_EQ(polygon_->getPointsInside(points), 0);
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 0);
 
   // Add one point inside
   points.push_back({0.0, 0.0});
-  ASSERT_EQ(polygon_->getPointsInside(points), 1);
+  ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 1);
 }
 
 TEST_F(Tester, testCircleGetPointsInside)
@@ -846,13 +848,14 @@ TEST_F(Tester, testCircleGetPointsInside)
   createCircle("stop", true);
 
   std::vector<nav2_collision_monitor::Point> points;
+  std::vector<nav2_collision_monitor::Point> triggering_points;
   // Point out of radius
   points.push_back({1.0, 0.0});
-  ASSERT_EQ(circle_->getPointsInside(points), 0);
+  ASSERT_EQ(circle_->getPointsInside(points, triggering_points), 0);
 
   // Add one point inside
   points.push_back({-0.1, 0.3});
-  ASSERT_EQ(circle_->getPointsInside(points), 1);
+  ASSERT_EQ(circle_->getPointsInside(points, triggering_points), 1);
 }
 
 TEST_F(Tester, testPolygonGetCollisionTime)
@@ -869,9 +872,11 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   nav2_collision_monitor::Velocity vel{0.5, 0.0, 0.0};  // 0.5 m/s forward movement
   // Two points 0.2 m ahead the footprint (0.5 m)
   std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
+  std::vector<nav2_collision_monitor::Point> triggering_points;
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.7, -0.01}, {0.7, 0.01}}});
   // Collision is expected to be ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
 
   // Backward movement check
   vel = {-0.5, 0.0, 0.0};  // 0.5 m/s backward movement
@@ -879,7 +884,8 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.7, -0.01}, {-0.7, 0.01}}});
   // Collision is expected to be in ~= 0.2 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.4, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.4, SIMULATION_TIME_STEP);
 
   // Sideway movement check
   vel = {0.0, 0.5, 0.0};  // 0.5 m/s sideway movement
@@ -887,7 +893,8 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{-0.01, 0.6}, {0.01, 0.6}}});
   // Collision is expected to be in ~= 0.1 m / 0.5 m/s seconds
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.2, SIMULATION_TIME_STEP);
+  EXPECT_NEAR(
+    polygon_->getCollisionTime(points_map, vel, triggering_points), 0.2, SIMULATION_TIME_STEP);
 
   // Rotation check
   vel = {0.0, 0.0, 1.0};  // 1.0 rad/s rotation
@@ -905,7 +912,7 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.49, -0.01}, {0.49, 0.01}}});
   // Collision is expected to be in ~= 45 degrees * M_PI / (180 degrees * 1.0 rad/s) seconds
   double exp_res = 45 / 180 * M_PI;
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), exp_res, EPSILON);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), exp_res, EPSILON);
 
   // Two points are already inside footprint
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
@@ -913,7 +920,7 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{0.1, -0.01}, {0.1, 0.01}}});
   // Collision already appeared: collision time should be 0
-  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel), 0.0, EPSILON);
+  EXPECT_NEAR(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0, EPSILON);
 
   // All points are out of simulation prediction
   vel = {0.5, 0.0, 0.0};  // 0.5 m/s forward movement
@@ -921,7 +928,7 @@ TEST_F(Tester, testPolygonGetCollisionTime)
   points_map.clear();
   points_map.insert({OBSERVATION_SOURCE_NAME, {{1.1, -0.01}, {1.1, 0.01}}});
   // There is no collision: return value should be negative
-  EXPECT_LT(polygon_->getCollisionTime(points_map, vel), 0.0);
+  EXPECT_LT(polygon_->getCollisionTime(points_map, vel, triggering_points), 0.0);
 }
 
 TEST_F(Tester, testPolygonPublish)
@@ -1029,12 +1036,15 @@ TEST_F(Tester, testPolygonDebounceDefaultBehavior)
       for (int i = 0; i < count; ++i) {
         points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
       }
-      return points;
+      std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
+      points_map.insert({OBSERVATION_SOURCE_NAME, std::move(points)});
+      return points_map;
     };
 
-  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1)));
-  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS)));
-  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1)));
+  std::vector<nav2_collision_monitor::Point> triggering_points;
+  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1), triggering_points));
+  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS), triggering_points));
+  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1), triggering_points));
 }
 
 TEST_F(Tester, testPolygonDebounceConsecutiveTriggerRelease)
@@ -1054,16 +1064,19 @@ TEST_F(Tester, testPolygonDebounceConsecutiveTriggerRelease)
       for (int i = 0; i < count; ++i) {
         points.push_back(nav2_collision_monitor::Point{0.0, 0.0});
       }
-      return points;
+      std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> points_map;
+      points_map.insert({OBSERVATION_SOURCE_NAME, std::move(points)});
+      return points_map;
     };
 
-  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS)));
-  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS)));
-  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS)));
+  std::vector<nav2_collision_monitor::Point> triggering_points;
+  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS), triggering_points));
+  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS), triggering_points));
+  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS), triggering_points));
 
-  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS - 1)));
-  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS - 1)));
-  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1)));
+  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS - 1), triggering_points));
+  EXPECT_TRUE(polygon_->isTriggered(makePoints(MIN_POINTS - 1), triggering_points));
+  EXPECT_FALSE(polygon_->isTriggered(makePoints(MIN_POINTS - 1), triggering_points));
 }
 
 TEST_F(Tester, testPolygonDebounceRejectsInvalidConfiguredTriggerParameter)

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -808,10 +808,14 @@ TEST_F(Tester, testPolygonGetPointsInside)
   points.push_back({-1.0, 0.0});
   points.push_back({0.0, -1.0});
   ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 0);
+  ASSERT_EQ(triggering_points.size(), 0u);
 
   // Add one point inside
   points.push_back({-0.1, 0.3});
   ASSERT_EQ(polygon_->getPointsInside(points, triggering_points), 1);
+  ASSERT_EQ(triggering_points.size(), 1u);
+  EXPECT_NEAR(triggering_points[0].x, -0.1, EPSILON);
+  EXPECT_NEAR(triggering_points[0].y, 0.3, EPSILON);
 }
 
 TEST_F(Tester, testPolygonGetPointsInsideEdge)
@@ -852,10 +856,14 @@ TEST_F(Tester, testCircleGetPointsInside)
   // Point out of radius
   points.push_back({1.0, 0.0});
   ASSERT_EQ(circle_->getPointsInside(points, triggering_points), 0);
+  ASSERT_EQ(triggering_points.size(), 0u);
 
   // Add one point inside
   points.push_back({-0.1, 0.3});
   ASSERT_EQ(circle_->getPointsInside(points, triggering_points), 1);
+  ASSERT_EQ(triggering_points.size(), 1u);
+  EXPECT_NEAR(triggering_points[0].x, -0.1, EPSILON);
+  EXPECT_NEAR(triggering_points[0].y, 0.3, EPSILON);
 }
 
 TEST_F(Tester, testPolygonGetCollisionTime)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |Dexory Robot |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

I added this feature to visualise the triggering points (the obstacle points that are actively causing the robot to slow down or stop) in the collision monitor, enabling faster debugging of which sensors/points are slowing/stopping the robot.

### 1. Add `z` field to `Point` struct

`types.hpp`: Extended the `Point` struct with an optional `z` coordinate (defaults to `0.0`).

- Inherently 2D sources (laser scan, range) continue to produce `z = 0.0` with no behaviour change.
- 3D sources (pointcloud) now propagate the actual `z` value from the transformed point into the struct.
- The existing `collision_points_marker` topic retains `z = 0.0` for all points by default, preserving existing RViz visualisation behaviour. A new parameter `collision_points_marker_3d` (default `false`) can be set to `true` to opt in to 3D rendering of that marker.

### 2. Triggering points visualisation via single-pass `getPointsInside`

- `polygon.hpp / polygon.cpp`: Extended `getPointsInside` (and the new `getPointsInsideApproach`) to accept an optional `out_triggering_points` output parameter — an `unordered_map<string, vector<Point>>` keyed by source name.
- `polygon->isTriggered(sources_collision_points_map, &triggering_points)` performs **a single pass** — pass from `isTriggered()` all the way to `getPointsInside()`  to check for points inside the polygon and collecting the triggering subset simultaneously, avoiding any double iteration on processing the points
- Detected triggering points are published on `~/triggering_points` as a `visualization_msgs/MarkerArray`, namespaced per `polygon/source` pair, so RViz can show exactly which points in which zone are causing the action. 
- Publishing is skipped when there are no subscribers (`get_subscription_count() == 0`).

`collision_detector_node.cpp`:
- Source data is now collected into `unordered_map<string, vector<Point>> sources_collision_points_map` (previously a flat `vector<Point>`), preserving per-source identity throughout the pipeline (similar with collision monitor).

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Unit tests updated.
- Tested with dexory simulation + real robot



---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
