### PR TITLE
fix: standardize plugin names to snake_case in nav2_params.yaml

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -99,8 +99,8 @@ controller_server:
     failure_tolerance: 0.3
     progress_checker_plugins: ["progress_checker"]
     goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
-    controller_plugins: ["FollowPath"]
-    path_handler_plugins: ["PathHandler"]
+    controller_plugins: ["follow_path"]
+    path_handler_plugins: ["path_handler"]
     use_realtime_priority: false
     speed_limit_topic: "speed_limit"
 
@@ -121,7 +121,7 @@ controller_server:
       xy_goal_tolerance: 0.25
       yaw_goal_tolerance: 0.25
       path_length_tolerance: 1.0
-    PathHandler:
+    path_handler:
       plugin: "nav2_controller::FeasiblePathHandler"
       prune_distance: 2.0
       enforce_path_inversion: false
@@ -130,7 +130,7 @@ controller_server:
       inversion_yaw_tolerance: 0.4
       minimum_rotation_angle: 0.785
       reject_unit_path: false
-    FollowPath:
+    follow_path:
       plugin: "nav2_mppi_controller::MPPIController"
       time_steps: 56
       model_dt: 0.05
@@ -388,10 +388,10 @@ planner_server:
   ros__parameters:
     allow_partial_planning: false
     expected_planner_frequency: 20.0
-    planner_plugins: ["GridBased"]
+    planner_plugins: ["grid_based"]
     costmap_update_timeout: 1.0
     introspection_mode: "disabled"
-    GridBased:
+    grid_based:
       plugin: "nav2_navfn_planner::NavfnPlanner"
       tolerance: 0.5
       use_astar: false


### PR DESCRIPTION
## Summary

Fixes #5696 — plugin identifiers in `nav2_bringup/params/nav2_params.yaml` were using inconsistent PascalCase names alongside snake_case names.

- `FollowPath` → `follow_path`
- `PathHandler` → `path_handler`
- `GridBased` → `grid_based`

ROS convention uses snake_case for plugin names since they become topic/service/action names. All other plugins in the same file already follow this convention.

## Notes

- C++ class names inside plugin strings (e.g. `nav2_controller::FeasiblePathHandler`) are **unchanged** — pluginlib requires these to match the registered class name exactly.
- MPPI/DWB critic plugins are also unchanged for the same reason.

## Test plan

- [ ] Verify `nav2_bringup` launches correctly with the renamed plugin identifiers
- [ ] Confirm no regressions in controller, path handler, or planner behaviour