### PR TITLE
Fix bugs that were uncovered by enabling `-Wconversion`

### DIFF
--- a/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
@@ -45,10 +45,10 @@ public:
     nav_msgs::msg::Goals fake_poses;
     config_->blackboard->set("goals", fake_poses);  // NOLINT
 
-    config_->input_ports["min_rate"] = 0.1;
-    config_->input_ports["max_rate"] = 1.0;
-    config_->input_ports["min_speed"] = 0.0;
-    config_->input_ports["max_speed"] = 0.5;
+    config_->input_ports["min_rate"] = "0.1";
+    config_->input_ports["max_rate"] = "1.0";
+    config_->input_ports["min_speed"] = "0.0";
+    config_->input_ports["max_speed"] = "0.5";
     config_->input_ports["goals"] = "";
     config_->input_ports["goal"] = "";
 

--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -139,7 +139,7 @@ bool GridCollisionChecker::inCollision(
     // Use precomputed oriented footprints are done on initialization,
     // offset by translation value to collision check
     double wx, wy;
-    costmap_->mapToWorld(static_cast<double>(x), static_cast<double>(y), wx, wy);
+    costmap_->mapToWorld(static_cast<unsigned int>(x), static_cast<unsigned int>(y), wx, wy);
     geometry_msgs::msg::Point new_pt;
     const nav2_costmap_2d::Footprint & oriented_footprint = oriented_footprints_[angle_bin];
     nav2_costmap_2d::Footprint current_footprint;

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <iostream>
 #include <chrono>
+#include <thread>
 #include <sstream>
 #include <iomanip>
 
@@ -348,7 +349,7 @@ bool PlannerTester::defaultPlannerRandomTests(
     "Tested with %u tests. Planner failed on %u. Test time %ld ms",
     number_tests, num_fail, elapsed.count());
 
-  if ((num_fail / number_tests) > acceptable_fail_ratio) {
+  if ((static_cast<float>(num_fail) / static_cast<float>(number_tests)) > acceptable_fail_ratio) {
     return false;
   }
 
@@ -364,7 +365,7 @@ bool PlannerTester::plannerTest(
 
   // First make available the current robot position for the planner to take as starting point
   updateRobotPosition(robot_position);
-  sleep(0.05);
+  std::this_thread::sleep_for(50ms);
 
   // Then request to compute a path
   TaskStatus status = createPlan(goal, path);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Partial work of #6135  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Devcontainer |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

The following bugs were uncovered by enabling `-Wconversion`:

| File | Bug |
|------|-----|
| [`nav2_system_tests/src/planning/planner_tester.cpp`](https://github.com/ros-navigation/navigation2/blob/main/nav2_system_tests/src/planning/planner_tester.cpp#L351C8-L351C16) | `num_fail / number_tests` performs unsigned integer division, so the result is always `0` when `num_fail < number_tests`, making the failure ratio check ineffective. Fixed by casting both operands to `float` before dividing. |
| [`nav2_system_tests/src/planning/planner_tester.cpp`](https://github.com/ros-navigation/navigation2/blob/main/nav2_system_tests/src/planning/planner_tester.cpp#L368) | `sleep(0.05)` passes a `double` to a function that takes `unsigned int` seconds, so `0.05` was truncated to `0`, resulting in no sleep at all. Fixed by replacing with `std::this_thread::sleep_for(std::chrono::milliseconds(50))`. |
| [`nav2_smac_planner/src/collision_checker.cpp`](https://github.com/ros-navigation/navigation2/blob/main/nav2_smac_planner/src/collision_checker.cpp#L142) | `mapToWorld(static_cast<double>(x), ...)` truncated float coordinates, causing a round-down. Fixed by changing to `static_cast<unsigned int>(x + 0.5f)` to round to the nearest cell, matching the same logic used for [`center_cost_`](https://github.com/ros-navigation/navigation2/blob/main/nav2_smac_planner/src/collision_checker.cpp#L118). |
| [`nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp`](https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp#L48-L51) | `config_->input_ports["min_rate"] = 0.1` assigned `double` literals to `PortsRemapping` (`std::unordered_map<std::string, std::string>`), causing a narrowing `double->char->std::string` conversion that stores `'\x01'` instead of `"1.0"`. |

## Description of documentation updates required from your changes

* N/A

## Description of how this change was tested

* Performed linting validation using `pre-commit run --all`. 
* Tested all the packages using `colcon test`.
---

## Future work that may be required in bullet points

* N/A


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
