### PR TITLE
[nav2_rotation_shim_controller] Add `max_cost_threshold` parameter for rotation shim

### DIFF
--- a/nav2_rotation_shim_controller/README.md
+++ b/nav2_rotation_shim_controller/README.md
@@ -37,6 +37,7 @@ See its [Configuration Guide Page](https://docs.nav2.org/configuration/packages/
 | `rotate_to_heading_angular_vel` | Angular rotational velocity, in rad/s, to rotate to the path heading |
 | `primary_controller` | Internal controller plugin to use for actual control behavior after rotating to heading |
 | `max_angular_accel` | Maximum angular acceleration for rotation to heading |
+| `max_cost_threshold` | Maximum footprint cost threshold to detect a collision. Defaults to 254.0 i.e., LETHAL_OBSTACLE.
 | `simulate_ahead_time` | Time in seconds to forward simulate a rotation command to check for collisions. If a collision is found, forwards control back to the primary controller plugin. |
 | `rotate_to_goal_heading` | If true, the rotationShimController will take back control of the robot when in XY tolerance of the goal and start rotating to the goal heading |
 | `rotate_to_goal_heading_once` | If true, the rotationShimController will only rotate to heading once on a new goal, not each time a path is set. |
@@ -72,6 +73,7 @@ controller_server:
       angular_disengage_threshold: 0.3925
       rotate_to_heading_angular_vel: 1.8
       max_angular_accel: 3.2
+      max_cost_threshold: 254.0
       simulate_ahead_time: 1.0
       rotate_to_goal_heading: false
 

--- a/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/parameter_handler.hpp
+++ b/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/parameter_handler.hpp
@@ -36,6 +36,7 @@ struct Parameters
   double angular_disengage_threshold;
   double rotate_to_heading_angular_vel;
   double max_angular_accel;
+  double max_cost_threshold;
   double simulate_ahead_time;
   double control_duration;
   bool rotate_to_goal_heading;

--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -318,7 +318,7 @@ void RotationShimController::isCollisionFree(
               "RotationShimController detected a potential collision ahead!");
     }
 
-    if (footprint_cost >= static_cast<double>(LETHAL_OBSTACLE)) {
+    if (footprint_cost >= params_->max_cost_threshold) {
       throw nav2_core::NoValidControl("RotationShimController detected collision ahead!");
     }
   }

--- a/nav2_rotation_shim_controller/src/parameter_handler.cpp
+++ b/nav2_rotation_shim_controller/src/parameter_handler.cpp
@@ -21,6 +21,7 @@
 
 #include "nav2_rotation_shim_controller/parameter_handler.hpp"
 #include "nav2_core/controller_exceptions.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
 
 namespace nav2_rotation_shim_controller
 {
@@ -45,6 +46,8 @@ ParameterHandler::ParameterHandler(
     ".rotate_to_heading_angular_vel", 1.8);
   params_.max_angular_accel = node->declare_or_get_parameter(plugin_name_ + ".max_angular_accel",
     3.2);
+  params_.max_cost_threshold = node->declare_or_get_parameter(plugin_name_ + ".max_cost_threshold",
+      static_cast<double>(nav2_costmap_2d::LETHAL_OBSTACLE));
   params_.simulate_ahead_time = node->declare_or_get_parameter(plugin_name_ +
     ".simulate_ahead_time", 1.0);
   try {
@@ -126,6 +129,8 @@ ParameterHandler::updateParametersCallback(
         params_.rotate_to_heading_angular_vel = parameter.as_double();
       } else if (param_name == plugin_name_ + ".max_angular_accel") {
         params_.max_angular_accel = parameter.as_double();
+      } else if (param_name == plugin_name_ + ".max_cost_threshold") {
+        params_.max_cost_threshold = parameter.as_double();
       } else if (param_name == plugin_name_ + ".simulate_ahead_time") {
         params_.simulate_ahead_time = parameter.as_double();
       }

--- a/nav2_rotation_shim_controller/test/test_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/test/test_shim_controller.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_controller/plugins/simple_goal_checker.hpp"
 #include "nav2_controller/plugins/feasible_path_handler.hpp"
@@ -622,6 +623,8 @@ TEST(RotationShimControllerTest, testDynamicParameter)
       rclcpp::Parameter("test.forward_sampling_distance", 7.0),
       rclcpp::Parameter("test.rotate_to_heading_angular_vel", 7.0),
       rclcpp::Parameter("test.max_angular_accel", 7.0),
+      rclcpp::Parameter("test.max_cost_threshold",
+      static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)),
       rclcpp::Parameter("test.simulate_ahead_time", 7.0),
       rclcpp::Parameter("test.primary_controller.plugin", std::string("HI")),
       rclcpp::Parameter("test.rotate_to_goal_heading", true),
@@ -637,6 +640,8 @@ TEST(RotationShimControllerTest, testDynamicParameter)
   EXPECT_EQ(node->get_parameter("test.forward_sampling_distance").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("test.rotate_to_heading_angular_vel").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("test.max_angular_accel").as_double(), 7.0);
+  EXPECT_EQ(node->get_parameter("test.max_cost_threshold").as_double(),
+    static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE));
   EXPECT_EQ(node->get_parameter("test.simulate_ahead_time").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("test.rotate_to_goal_heading").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.rotate_to_heading_once").as_bool(), true);
@@ -662,6 +667,38 @@ TEST(RotationShimControllerTest, testDynamicParameter)
     results);
 
   EXPECT_EQ(node->get_parameter("test.simulate_ahead_time").as_double(), 7.0);
+}
+
+TEST(RotationShimControllerTest, maxCostThresholdTest)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
+  std::string name = "test";
+  auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
+  costmap->configure();
+  // set a valid primary controller so we can do lifecycle
+  node->declare_parameter(
+    "test.primary_controller.plugin",
+    std::string("nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"));
+  node->declare_parameter("controller_frequency", 20.0);
+  node->declare_parameter("test.max_cost_threshold",
+    static_cast<double>(nav2_costmap_2d::FREE_SPACE));
+  auto controller = std::make_shared<RotationShimShim>();
+  controller->configure(node, name, tf, costmap);
+  controller->activate();
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "base_link";
+  path.poses.resize(4);
+  path.poses[1].pose.position.x = 0.15;
+  path.poses[1].pose.position.y = 0.15;
+  path.poses[2].pose.position.x = 1.0;
+  path.poses[2].pose.position.y = 1.0;
+  controller->newPathReceived(path);
+  const geometry_msgs::msg::Twist velocity;
+  // With max_cost_threshold=0, even FREE_SPACE cells should trigger collision
+  EXPECT_THROW(
+    controller->computeRotateToHeadingCommandWrapper(1.5, path.poses[1], velocity),
+    nav2_core::NoValidControl);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Hi,

Currently rotation shim compares `footprint_cost` only to `LETHAL_OBSTACLE`. If the primary controller has a different costmap critic then there would be inconsistent behavior against obstacles. For example, my primary controller controller tries to avoid `INSCRIBED_INFLATED_OBSTACLE` while the rotation shim not. To avoid this kind of inconsistency, I thought making `max_cost_threshold` parameter would give the freedom to change it if needed. I have set the default to `LETHAL_OBSTACLE` for backward compatibility.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
