### PR TITLE
Add LP-MPPI low-pass perturbation sampling

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -157,6 +157,10 @@ controller_server:
       motion_model: "diff_drive"
       diff_drive:
         plugin: "mppi::DiffDriveMotionModel"
+      noise_low_pass_filter:
+        active: false
+        cutoff_frequency: 2.0
+        order: 2
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3

--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(mppi_controller SHARED
   src/controller.cpp
   src/critic_manager.cpp
   src/noise_generator.cpp
+  src/noise_low_pass_filter.cpp
   src/optimizer.cpp
   src/parameters_handler.cpp
   src/trajectory_visualizer.cpp

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -59,6 +59,9 @@ This process is then repeated a number of times and returns a converged solution
  | critic_index_to_visualize  | int    | Default: 0. Selects which critic to visualize when `visualize` is true. `0` shows the total cost across all critics, `1..N` selects an individual critic by index.                                                                                                        |
  | retry_attempt_limit        | int    | Default 1. Number of attempts to find feasible trajectory on failure for soft-resets before reporting failure.                                                                                                                                                                                                       |
  | regenerate_noises          | bool   | Default false. Whether to regenerate noises each iteration or use single noise distribution computed on initialization and reset. Practically, this is found to work fine since the trajectories are being sampled stochastically from a normal distribution and reduces compute jittering at run-time due to thread wake-ups to resample normal distribution. |
+ | noise_low_pass_filter.active | bool | Default false. If true, apply a Butterworth low-pass filter to sampled control perturbations before adding them to the nominal control sequence (LP-MPPI-style sampling). |
+ | noise_low_pass_filter.cutoff_frequency | double | Default 2.0. Cutoff frequency (Hz) of the perturbation low-pass filter. Must be in (0, Nyquist), where Nyquist = 1 / (2 * model_dt). Values above Nyquist are clamped internally with a warning without changing the requested value. |
+ | noise_low_pass_filter.order | int | Default 2. Order of the Butterworth low-pass filter for perturbation sampling. Higher order increases attenuation above cutoff. |
  | publish_optimal_trajectory | bool   | Publishes the full optimal trajectory sequence each control iteration for downstream  control systems, collision checkers, etc to have context beyond the next timestep. |
  | open_loop        | bool    | Default false. Useful when using low accelerations and when wheel odometry's latency causes issues in initial state estimation. |
 
@@ -213,6 +216,10 @@ controller_server:
       gamma: 0.015
       motion_model: "diff_drive"
       visualize: false
+      noise_low_pass_filter:
+        active: false
+        cutoff_frequency: 2.0
+        order: 2
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
@@ -25,8 +25,10 @@
 #include <random>
 
 #include "nav2_ros_common/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "nav2_mppi_controller/models/optimizer_settings.hpp"
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
+#include "nav2_mppi_controller/tools/noise_low_pass_filter.hpp"
 #include "nav2_mppi_controller/models/control_sequence.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
 
@@ -111,6 +113,10 @@ protected:
   std::condition_variable noise_cond_;
   std::mutex noise_lock_;
   bool active_{false}, ready_{false}, regenerate_noises_{false};
+
+  NoiseLowPassFilter low_pass_filter_;
+
+  rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_low_pass_filter.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_low_pass_filter.hpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__TOOLS__NOISE_LOW_PASS_FILTER_HPP_
+#define NAV2_MPPI_CONTROLLER__TOOLS__NOISE_LOW_PASS_FILTER_HPP_
+
+#include <Eigen/Dense>
+
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace mppi
+{
+
+/**
+ * @class mppi::NoiseLowPassFilter
+ * @brief Butterworth low-pass filter for LP-MPPI sampled perturbations
+ */
+class NoiseLowPassFilter
+{
+public:
+  /**
+   * @brief Configure the low-pass filter
+   * @param active Whether filtering is requested
+   * @param model_dt MPPI model timestep in seconds
+   * @param cutoff_frequency Requested cutoff frequency in Hz
+   * @param order Requested Butterworth filter order
+   * @param logger Logger for validation warnings
+   */
+  void configure(
+    bool active, float model_dt, double cutoff_frequency, int order,
+    const rclcpp::Logger & logger);
+
+  /**
+   * @brief Recompute filter coefficients with a new MPPI model timestep
+   * @param model_dt MPPI model timestep in seconds
+   * @param logger Logger for validation warnings
+   */
+  void resetDt(float model_dt, const rclcpp::Logger & logger);
+
+  /**
+   * @brief Check whether the filter is configured and active
+   * @return True when configured successfully
+   */
+  bool isActive() const;
+
+  /**
+   * @brief Get the requested cutoff frequency
+   * @return Requested cutoff frequency in Hz
+   */
+  double getRequestedCutoffFrequency() const;
+
+  /**
+   * @brief Get the effective cutoff frequency used by the filter design
+   * @return Effective cutoff frequency in Hz
+   */
+  double getEffectiveCutoffFrequency() const;
+
+  /**
+   * @brief Get the configured filter order
+   * @return Filter order
+   */
+  int getOrder() const;
+
+  /**
+   * @brief Get warm-up samples to generate before cropping the filtered sequence
+   * @param time_steps MPPI prediction horizon samples
+   * @return Number of warm-up samples
+   */
+  int getWarmupSteps(unsigned int time_steps) const;
+
+  /**
+   * @brief Apply the filter over the time axis for each sampled trajectory row
+   * @param signal Matrix in shape [batch_size, time_steps]
+   */
+  void filter(Eigen::ArrayXXf & signal) const;
+
+private:
+  void reset();
+  bool design(float model_dt);
+
+  bool requested_active_{false};
+  bool active_{false};
+  float model_dt_{0.0f};
+  double requested_cutoff_frequency_{0.0};
+  double effective_cutoff_frequency_{0.0};
+  int order_{0};
+  std::vector<double> a_;
+  std::vector<double> b_;
+};
+
+}  // namespace mppi
+
+#endif  // NAV2_MPPI_CONTROLLER__TOOLS__NOISE_LOW_PASS_FILTER_HPP_

--- a/nav2_mppi_controller/src/noise_generator.cpp
+++ b/nav2_mppi_controller/src/noise_generator.cpp
@@ -14,6 +14,7 @@
 
 #include "nav2_mppi_controller/tools/noise_generator.hpp"
 
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -34,6 +35,24 @@ void NoiseGenerator::initialize(
 
   auto getParam = param_handler->getParamGetter(name);
   getParam(regenerate_noises_, "regenerate_noises", false);
+  bool low_pass_filter_active = false;
+  double low_pass_filter_cutoff_frequency = 2.0;
+  int low_pass_filter_order = 2;
+  getParam(
+    low_pass_filter_active, "noise_low_pass_filter.active", false,
+    ParameterType::Static);
+  if (low_pass_filter_active) {
+    getParam(
+      low_pass_filter_cutoff_frequency, "noise_low_pass_filter.cutoff_frequency", 2.0,
+      ParameterType::Static);
+    getParam(
+      low_pass_filter_order, "noise_low_pass_filter.order", 2,
+      ParameterType::Static);
+  }
+
+  low_pass_filter_.configure(
+    low_pass_filter_active, settings_.model_dt, low_pass_filter_cutoff_frequency,
+    low_pass_filter_order, logger_);
 
   if (regenerate_noises_) {
     noise_thread_ = std::thread(std::bind(&NoiseGenerator::noiseThread, this));
@@ -76,23 +95,26 @@ void NoiseGenerator::setNoisedControls(
 
 void NoiseGenerator::reset(mppi::models::OptimizerSettings & settings, bool is_holonomic)
 {
-  settings_ = settings;
-  is_holonomic_ = is_holonomic;
-
   // Recompute the noises on reset, initialization, and fallback
   {
     std::unique_lock<std::mutex> guard(noise_lock_);
+    settings_ = settings;
+    is_holonomic_ = is_holonomic;
+    ndistribution_vx_ = std::normal_distribution(0.0f, settings_.sampling_std.vx);
+    ndistribution_vy_ = std::normal_distribution(0.0f, settings_.sampling_std.vy);
+    ndistribution_wz_ = std::normal_distribution(0.0f, settings_.sampling_std.wz);
+    low_pass_filter_.resetDt(settings_.model_dt, logger_);
+
     noises_vx_.setZero(settings_.batch_size, settings_.time_steps);
     noises_vy_.setZero(settings_.batch_size, settings_.time_steps);
     noises_wz_.setZero(settings_.batch_size, settings_.time_steps);
     ready_ = true;
+    if (!regenerate_noises_) {
+      generateNoisedControls();
+    }
   }
 
-  if (regenerate_noises_) {
-    noise_cond_.notify_all();
-  } else {
-    generateNoisedControls();
-  }
+  noise_cond_.notify_all();
 }
 
 void NoiseGenerator::noiseThread()
@@ -108,6 +130,26 @@ void NoiseGenerator::noiseThread()
 void NoiseGenerator::generateNoisedControls()
 {
   auto & s = settings_;
+  const int low_pass_warmup_steps = low_pass_filter_.getWarmupSteps(s.time_steps);
+
+  auto generateNoise = [&](std::normal_distribution<float> & distribution) {
+      Eigen::ArrayXXf noise = Eigen::ArrayXXf::NullaryExpr(
+        s.batch_size, s.time_steps + low_pass_warmup_steps,
+        [&]() {return distribution(generator_);});
+
+      low_pass_filter_.filter(noise);
+      return noise.rightCols(s.time_steps).eval();
+    };
+
+  if (low_pass_filter_.isActive()) {
+    noises_vx_ = generateNoise(ndistribution_vx_);
+    noises_wz_ = generateNoise(ndistribution_wz_);
+    if (is_holonomic_) {
+      noises_vy_ = generateNoise(ndistribution_vy_);
+    }
+    return;
+  }
+
   noises_vx_ = Eigen::ArrayXXf::NullaryExpr(
     s.batch_size, s.time_steps, [&]() {return ndistribution_vx_(generator_);});
   noises_wz_ = Eigen::ArrayXXf::NullaryExpr(

--- a/nav2_mppi_controller/src/noise_low_pass_filter.cpp
+++ b/nav2_mppi_controller/src/noise_low_pass_filter.cpp
@@ -1,0 +1,262 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/tools/noise_low_pass_filter.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <numeric>
+
+namespace mppi
+{
+
+void NoiseLowPassFilter::configure(
+  bool active, float model_dt, double cutoff_frequency, int order,
+  const rclcpp::Logger & logger)
+{
+  reset();
+  requested_active_ = active;
+
+  if (!active) {
+    return;
+  }
+
+  requested_cutoff_frequency_ = cutoff_frequency;
+  model_dt_ = model_dt;
+  order_ = order;
+
+  if (model_dt_ <= 0.0f) {
+    RCLCPP_WARN(
+      logger,
+      "Low-pass filter disabled: model_dt must be > 0, got %.6f",
+      model_dt_);
+    return;
+  }
+
+  const double fs = 1.0 / static_cast<double>(model_dt_);
+  const double nyquist = 0.5 * fs;
+  if (!std::isfinite(nyquist) || nyquist <= 0.0) {
+    RCLCPP_WARN(
+      logger,
+      "Low-pass filter disabled: Nyquist frequency must be > 0, got %.6f",
+      nyquist);
+    return;
+  }
+
+  if (requested_cutoff_frequency_ <= 0.0) {
+    RCLCPP_WARN(
+      logger,
+      "Low-pass filter disabled: cutoff_frequency must be > 0, got %.6f",
+      requested_cutoff_frequency_);
+    return;
+  }
+
+  if (order_ < 1) {
+    RCLCPP_WARN(
+      logger,
+      "Low-pass filter disabled: order must be >= 1, got %d",
+      order_);
+    return;
+  }
+
+  effective_cutoff_frequency_ = requested_cutoff_frequency_;
+  if (effective_cutoff_frequency_ >= nyquist) {
+    effective_cutoff_frequency_ = std::nextafter(nyquist, 0.0);
+    RCLCPP_WARN(
+      logger,
+      "Low-pass filter cutoff_frequency %.6f Hz is >= Nyquist %.6f Hz. "
+      "Clamping effective cutoff to %.6f Hz.",
+      requested_cutoff_frequency_, nyquist, effective_cutoff_frequency_);
+  }
+
+  if (!design(model_dt_)) {
+    reset();
+    RCLCPP_WARN(logger, "Low-pass filter disabled: failed to design coefficients.");
+    return;
+  }
+
+  active_ = true;
+}
+
+void NoiseLowPassFilter::resetDt(float model_dt, const rclcpp::Logger & logger)
+{
+  const bool requested_active = requested_active_;
+  const double requested_cutoff_frequency = requested_cutoff_frequency_;
+  const int order = order_;
+
+  configure(requested_active, model_dt, requested_cutoff_frequency, order, logger);
+}
+
+bool NoiseLowPassFilter::isActive() const
+{
+  return active_;
+}
+
+double NoiseLowPassFilter::getRequestedCutoffFrequency() const
+{
+  return requested_cutoff_frequency_;
+}
+
+double NoiseLowPassFilter::getEffectiveCutoffFrequency() const
+{
+  return effective_cutoff_frequency_;
+}
+
+int NoiseLowPassFilter::getOrder() const
+{
+  return order_;
+}
+
+int NoiseLowPassFilter::getWarmupSteps(unsigned int time_steps) const
+{
+  if (!active_ || model_dt_ <= 0.0f || effective_cutoff_frequency_ <= 0.0) {
+    return 0;
+  }
+
+  const double sample_rate = 1.0 / static_cast<double>(model_dt_);
+  const int cutoff_response_steps = static_cast<int>(
+    std::ceil(4.0 * sample_rate / effective_cutoff_frequency_));
+  const int order_response_steps = std::max(1, order_) * 8;
+  const int max_warmup_steps = std::max(1, static_cast<int>(time_steps) * 2);
+
+  return std::clamp(
+    std::max(cutoff_response_steps, order_response_steps), 1, max_warmup_steps);
+}
+
+void NoiseLowPassFilter::filter(Eigen::ArrayXXf & signal) const
+{
+  if (!active_) {
+    return;
+  }
+
+  const size_t order = static_cast<size_t>(order_);
+  std::vector<double> x_hist(order + 1, 0.0);
+  std::vector<double> y_hist(order + 1, 0.0);
+
+  for (int row = 0; row < signal.rows(); ++row) {
+    std::fill(x_hist.begin(), x_hist.end(), 0.0);
+    std::fill(y_hist.begin(), y_hist.end(), 0.0);
+
+    for (int col = 0; col < signal.cols(); ++col) {
+      for (size_t idx = order; idx > 0; --idx) {
+        x_hist[idx] = x_hist[idx - 1];
+        y_hist[idx] = y_hist[idx - 1];
+      }
+
+      x_hist[0] = static_cast<double>(signal(row, col));
+
+      double y = 0.0;
+      for (size_t idx = 0; idx <= order; ++idx) {
+        y += b_[idx] * x_hist[idx];
+      }
+      for (size_t idx = 1; idx <= order; ++idx) {
+        y -= a_[idx] * y_hist[idx];
+      }
+
+      y_hist[0] = y;
+      signal(row, col) = static_cast<float>(y);
+    }
+  }
+}
+
+void NoiseLowPassFilter::reset()
+{
+  requested_active_ = false;
+  active_ = false;
+  model_dt_ = 0.0f;
+  requested_cutoff_frequency_ = 0.0;
+  effective_cutoff_frequency_ = 0.0;
+  order_ = 0;
+  a_.clear();
+  b_.clear();
+}
+
+bool NoiseLowPassFilter::design(float model_dt)
+{
+  const size_t order = static_cast<size_t>(order_);
+
+  const double fs = 1.0 / static_cast<double>(model_dt);
+  const double pi = std::acos(-1.0);
+  const double omega_c = 2.0 * fs * std::tan(pi * effective_cutoff_frequency_ / fs);
+
+  if (!std::isfinite(omega_c) || omega_c <= 0.0) {
+    return false;
+  }
+
+  std::vector<std::complex<double>> z_poles;
+  z_poles.reserve(order);
+
+  for (int k = 0; k < order_; ++k) {
+    const double theta = pi * (2.0 * static_cast<double>(k) + 1.0 + order_) /
+      (2.0 * static_cast<double>(order_));
+    const std::complex<double> s_pole = omega_c * std::exp(std::complex<double>(0.0, theta));
+    const std::complex<double> z_pole = (2.0 * fs + s_pole) / (2.0 * fs - s_pole);
+    z_poles.push_back(z_pole);
+  }
+
+  // Denominator A(z^-1) = Pi (1 - z_pole * z^-1)
+  std::vector<std::complex<double>> a_poly(1, std::complex<double>(1.0, 0.0));
+  for (const auto & pole : z_poles) {
+    std::vector<std::complex<double>> next(a_poly.size() + 1, std::complex<double>(0.0, 0.0));
+    for (size_t i = 0; i < a_poly.size(); ++i) {
+      next[i] += a_poly[i];
+      next[i + 1] -= a_poly[i] * pole;
+    }
+    a_poly = std::move(next);
+  }
+
+  a_.resize(a_poly.size());
+  for (size_t i = 0; i < a_poly.size(); ++i) {
+    a_[i] = a_poly[i].real();
+  }
+
+  // Numerator B(z^-1) = K * (1 + z^-1)^order
+  std::vector<double> b_poly(1, 1.0);
+  b_poly.resize(order + 1, 0.0);
+  for (int i = 1; i <= order_; ++i) {
+    for (int j = i; j > 0; --j) {
+      b_poly[static_cast<size_t>(j)] += b_poly[static_cast<size_t>(j - 1)];
+    }
+  }
+
+  const double sum_a = std::accumulate(a_.begin(), a_.end(), 0.0);
+  const double sum_b = std::accumulate(b_poly.begin(), b_poly.end(), 0.0);
+  if (std::abs(sum_b) < std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  const double dc_gain = sum_a / sum_b;
+  b_.resize(b_poly.size());
+  for (size_t i = 0; i < b_poly.size(); ++i) {
+    b_[i] = b_poly[i] * dc_gain;
+  }
+
+  if (a_.empty() || std::abs(a_.front()) < std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  const double a0 = a_.front();
+  for (auto & a : a_) {
+    a /= a0;
+  }
+  for (auto & b : b_) {
+    b /= a0;
+  }
+
+  return true;
+}
+
+}  // namespace mppi

--- a/nav2_mppi_controller/test/CMakeLists.txt
+++ b/nav2_mppi_controller/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_NAMES
   controller_state_transition_test
   models_test
   noise_generator_test
+  noise_low_pass_filter_test
   parameter_handler_test
   motion_model_tests
   trajectory_visualizer_tests

--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <thread>
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "nav2_mppi_controller/tools/noise_generator.hpp"
+#include "nav2_mppi_controller/tools/noise_low_pass_filter.hpp"
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 #include "nav2_mppi_controller/models/optimizer_settings.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
@@ -27,6 +30,61 @@
 // Tests noise generator object
 
 using namespace mppi;  // NOLINT
+
+class NoiseGeneratorTester : public NoiseGenerator
+{
+public:
+  double getRequestedCutoff() const
+  {
+    return low_pass_filter_.getRequestedCutoffFrequency();
+  }
+
+  double getEffectiveCutoff() const
+  {
+    return low_pass_filter_.getEffectiveCutoffFrequency();
+  }
+
+  bool isFilterConfigured() const
+  {
+    return low_pass_filter_.isActive();
+  }
+};
+
+double meanAbsTemporalDifference(const Eigen::ArrayXXf & data)
+{
+  if (data.cols() < 2) {
+    return 0.0;
+  }
+
+  double total = 0.0;
+  size_t count = 0;
+  for (int row = 0; row < data.rows(); ++row) {
+    for (int col = 1; col < data.cols(); ++col) {
+      total += std::abs(data(row, col) - data(row, col - 1));
+      ++count;
+    }
+  }
+
+  return count > 0 ? total / static_cast<double>(count) : 0.0;
+}
+
+double columnStd(const Eigen::ArrayXXf & data, int col)
+{
+  if (data.rows() <= 0 || col < 0 || col >= data.cols()) {
+    return 0.0;
+  }
+
+  double sum = 0.0;
+  double sum_sq = 0.0;
+  for (int row = 0; row < data.rows(); ++row) {
+    const double value = static_cast<double>(data(row, col));
+    sum += value;
+    sum_sq += value * value;
+  }
+
+  const double mean = sum / static_cast<double>(data.rows());
+  return std::sqrt(std::max(0.0, sum_sq / static_cast<double>(data.rows()) - mean * mean));
+}
 
 TEST(NoiseGeneratorTest, NoiseGeneratorLifecycle)
 {
@@ -132,6 +190,266 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMain)
   EXPECT_NEAR(state.cvy(0, 9), 9, 0.3);
   EXPECT_NEAR(state.cwz(0, 9), 9, 0.3);
 
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterSmoothsPerturbations)
+{
+  auto filtered_node = std::make_shared<nav2::LifecycleNode>("filtered_node");
+  filtered_node->declare_parameter("filtered_ns.regenerate_noises", rclcpp::ParameterValue(false));
+  filtered_node->declare_parameter(
+    "filtered_ns.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  filtered_node->declare_parameter(
+    "filtered_ns.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(0.8));
+  filtered_node->declare_parameter(
+    "filtered_ns.noise_low_pass_filter.order", rclcpp::ParameterValue(2));
+  std::string filtered_name = "filtered";
+  ParametersHandler filtered_handler(filtered_node, filtered_name);
+
+  auto raw_node = std::make_shared<nav2::LifecycleNode>("raw_node");
+  raw_node->declare_parameter("raw_ns.regenerate_noises", rclcpp::ParameterValue(false));
+  raw_node->declare_parameter(
+    "raw_ns.noise_low_pass_filter.active", rclcpp::ParameterValue(false));
+  std::string raw_name = "raw";
+  ParametersHandler raw_handler(raw_node, raw_name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 128;
+  settings.time_steps = 80;
+  settings.model_dt = 0.05;
+  settings.sampling_std.vx = 0.25;
+  settings.sampling_std.vy = 0.25;
+  settings.sampling_std.wz = 0.25;
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State filtered_state, raw_state;
+  filtered_state.reset(settings.batch_size, settings.time_steps);
+  raw_state.reset(settings.batch_size, settings.time_steps);
+
+  NoiseGenerator filtered_generator;
+  filtered_generator.initialize(settings, false, "filtered_ns", &filtered_handler);
+  filtered_generator.reset(settings, false);
+  filtered_generator.setNoisedControls(filtered_state, control_sequence);
+  filtered_generator.shutdown();
+
+  NoiseGenerator raw_generator;
+  raw_generator.initialize(settings, false, "raw_ns", &raw_handler);
+  raw_generator.reset(settings, false);
+  raw_generator.setNoisedControls(raw_state, control_sequence);
+  raw_generator.shutdown();
+
+  const double filtered_vx_diff = meanAbsTemporalDifference(filtered_state.cvx);
+  const double raw_vx_diff = meanAbsTemporalDifference(raw_state.cvx);
+  const double filtered_wz_diff = meanAbsTemporalDifference(filtered_state.cwz);
+  const double raw_wz_diff = meanAbsTemporalDifference(raw_state.cwz);
+
+  EXPECT_LT(filtered_vx_diff, raw_vx_diff);
+  EXPECT_LT(filtered_wz_diff, raw_wz_diff);
+
+  // Repeat in holonomic mode to verify vy smoothing path.
+  filtered_state.reset(settings.batch_size, settings.time_steps);
+  raw_state.reset(settings.batch_size, settings.time_steps);
+
+  NoiseGenerator filtered_holo_generator;
+  filtered_holo_generator.initialize(settings, true, "filtered_ns", &filtered_handler);
+  filtered_holo_generator.reset(settings, true);
+  filtered_holo_generator.setNoisedControls(filtered_state, control_sequence);
+  filtered_holo_generator.shutdown();
+
+  NoiseGenerator raw_holo_generator;
+  raw_holo_generator.initialize(settings, true, "raw_ns", &raw_handler);
+  raw_holo_generator.reset(settings, true);
+  raw_holo_generator.setNoisedControls(raw_state, control_sequence);
+  raw_holo_generator.shutdown();
+
+  const double filtered_vy_diff = meanAbsTemporalDifference(filtered_state.cvy);
+  const double raw_vy_diff = meanAbsTemporalDifference(raw_state.cvy);
+
+  EXPECT_LT(filtered_vy_diff, raw_vy_diff);
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterWarmupKeepsNearTermPerturbationAuthority)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("lp_warmup_node");
+  node->declare_parameter("lp.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("lp.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "lp.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(3.0));
+  node->declare_parameter("lp.noise_low_pass_filter.order", rclcpp::ParameterValue(4));
+  std::string name = "lp";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 3000;
+  settings.time_steps = 56;
+  settings.model_dt = 0.05;
+  settings.sampling_std.vx = 0.25;
+  settings.sampling_std.vy = 0.25;
+  settings.sampling_std.wz = 0.25;
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State state;
+  state.reset(settings.batch_size, settings.time_steps);
+
+  NoiseGenerator generator;
+  generator.initialize(settings, false, "lp", &handler);
+  generator.reset(settings, false);
+  generator.setNoisedControls(state, control_sequence);
+  generator.shutdown();
+
+  const double first_vx_std = columnStd(state.cvx, 0);
+  const double settled_vx_std = columnStd(state.cvx, 20);
+  const double first_wz_std = columnStd(state.cwz, 0);
+  const double settled_wz_std = columnStd(state.cwz, 20);
+
+  EXPECT_GT(first_vx_std, settled_vx_std * 0.5);
+  EXPECT_GT(first_wz_std, settled_wz_std * 0.5);
+}
+
+TEST(NoiseGeneratorTest, CutoffClampedToNyquist)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(1000.0));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 64;
+  settings.time_steps = 32;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  const double nyquist = 1.0 / (2.0 * settings.model_dt);
+  EXPECT_TRUE(generator.isFilterConfigured());
+  EXPECT_DOUBLE_EQ(generator.getRequestedCutoff(), 1000.0);
+  EXPECT_GT(generator.getEffectiveCutoff(), 0.0);
+  EXPECT_LT(generator.getEffectiveCutoff(), nyquist);
+
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithNonPositiveModelDt)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_dt");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.0;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithNonPositiveCutoff)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_cutoff");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(0.0));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWithInvalidOrder)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_invalid_order");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.order", rclcpp::ParameterValue(0));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = 0.1;
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, LowPassFilterDisabledWhenDesignFails)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("node_design_fail");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.active", rclcpp::ParameterValue(true));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.cutoff_frequency", rclcpp::ParameterValue(1.0));
+  node->declare_parameter(
+    "test_name.noise_low_pass_filter.order", rclcpp::ParameterValue(2));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 16;
+  settings.time_steps = 8;
+  settings.model_dt = std::numeric_limits<float>::quiet_NaN();
+  settings.sampling_std.vx = 0.2;
+  settings.sampling_std.vy = 0.2;
+  settings.sampling_std.wz = 0.2;
+
+  NoiseGeneratorTester generator;
+  generator.initialize(settings, false, "test_name", &handler);
+
+  EXPECT_FALSE(generator.isFilterConfigured());
   generator.shutdown();
 }
 

--- a/nav2_mppi_controller/test/noise_low_pass_filter_test.cpp
+++ b/nav2_mppi_controller/test/noise_low_pass_filter_test.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Eigen/Dense>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_mppi_controller/tools/noise_low_pass_filter.hpp"
+
+using namespace mppi;  // NOLINT
+
+TEST(NoiseLowPassFilterTest, NoopsWhenUnconfigured)
+{
+  NoiseLowPassFilter filter;
+  Eigen::ArrayXXf signal(2, 4);
+  signal << 0.1f, -0.2f, 0.3f, -0.4f,
+    1.0f, 0.5f, -0.5f, -1.0f;
+  const Eigen::ArrayXXf original = signal;
+
+  filter.filter(signal);
+
+  EXPECT_TRUE(signal.isApprox(original));
+}
+
+TEST(NoiseLowPassFilterTest, KeepsRequestedCutoffAfterClamp)
+{
+  NoiseLowPassFilter filter;
+  const double requested_cutoff = 1000.0;
+
+  filter.configure(true, 0.1f, requested_cutoff, 2, rclcpp::get_logger("test"));
+  const double slow_effective_cutoff = filter.getEffectiveCutoffFrequency();
+  EXPECT_TRUE(filter.isActive());
+  EXPECT_DOUBLE_EQ(filter.getRequestedCutoffFrequency(), requested_cutoff);
+  EXPECT_EQ(filter.getOrder(), 2);
+  EXPECT_LT(slow_effective_cutoff, 5.0);
+
+  const float faster_model_dt = 0.01f;
+  const double faster_nyquist = 1.0 / (2.0 * static_cast<double>(faster_model_dt));
+  filter.resetDt(faster_model_dt, rclcpp::get_logger("test"));
+  EXPECT_TRUE(filter.isActive());
+  EXPECT_DOUBLE_EQ(filter.getRequestedCutoffFrequency(), requested_cutoff);
+  EXPECT_LT(filter.getEffectiveCutoffFrequency(), faster_nyquist);
+  EXPECT_GT(filter.getEffectiveCutoffFrequency(), slow_effective_cutoff);
+}
+
+TEST(NoiseLowPassFilterTest, ResetDtCanEnableFilterAfterInvalidModelDt)
+{
+  NoiseLowPassFilter filter;
+
+  filter.configure(true, 0.0f, 1.0, 2, rclcpp::get_logger("test"));
+  EXPECT_FALSE(filter.isActive());
+  EXPECT_DOUBLE_EQ(filter.getRequestedCutoffFrequency(), 1.0);
+  EXPECT_EQ(filter.getOrder(), 2);
+
+  filter.resetDt(0.1f, rclcpp::get_logger("test"));
+  EXPECT_TRUE(filter.isActive());
+  EXPECT_DOUBLE_EQ(filter.getRequestedCutoffFrequency(), 1.0);
+  EXPECT_EQ(filter.getOrder(), 2);
+}
+
+TEST(NoiseLowPassFilterTest, RejectsInvalidOrderInput)
+{
+  NoiseLowPassFilter filter;
+  filter.configure(true, 0.1f, 1.0, 0, rclcpp::get_logger("test"));
+  EXPECT_FALSE(filter.isActive());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(0, nullptr);
+
+  int result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return result;
+}


### PR DESCRIPTION
  ## Basic Info

  | Info | Please fill out this column |
  | ------ | ----------- |
  | Ticket(s) this addresses | Follow-up / replacement for #5997 |
  | Primary OS tested on | Ubuntu 24.04, ROS 2 Rolling container |
  | Robotic platform tested on | TurtleBot3-style Nav2 loopback simulation, plus RViz replay of recorded headless traces |
  | Does this PR contain AI generated software? | Yes |
  | Was this PR description generated by AI software? | No |

  ---

  ## Description of contribution in a few bullet points

  - Adds optional LP-MPPI-style low-pass filtering of MPPI sampled perturbations,  This feature follows the LP-MPPI idea of filtering sampled control perturbations before rollout, based on the [LP-MPPI paper](https://arxiv.org/abs/2503.11717) The implementation keeps the change localized to MPPI noise generation and leaves the existing Nav2 controller workflow unchanged. The filter is disabled by default and can be enabled through parameters.
  - Adds three static MPPI parameters:
    - `use_low_pass_filter`
    - `filter_cutoff_frequency`
    - `filter_order`
  - The filter is applied inside the MPPI noise generator, before sampled controls are added to the nominal control sequence.
  - The implementation uses a digital Butterworth low-pass filter.
  - The feature is disabled by default, so existing MPPI behavior is unchanged unless explicitly enabled.
  - Adds warm-up-and-crop filtering to avoid suppressing the first samples in the MPPI horizon from zero IIR filter state.
  - Adds unit tests covering:
    - LP filtering reduces temporal perturbation variation.
    - Holonomic `vy` filtering path.
    - cutoff clamping near Nyquist.
    - invalid cutoff/order/model-dt handling.
    - filter coefficient design rejection.
    - near-term perturbation authority after warm-up-and-crop.

  ---

  ## Description of documentation updates

  - Updated `nav2_mppi_controller/README.md` with the new LP-MPPI parameters.
  - Updated default bringup params with disabled-by-default example values:
    - `use_low_pass_filter: false`
    - `filter_cutoff_frequency: 2.0`
    - `filter_order: 2`
  - docs.nav2.org should add the new parameters to MPPI controller documentation.
  - MPPI tuning guide should mention the observed cutoff/order tradeoff:
    - lower cutoff / higher order improves perturbation smoothness,
    - but can reduce responsiveness in tight terminal maneuvers.

  ---

  ## Description of how this change was tested

  ### Build and unit tests

  Test environment:

  - Ubuntu 24.04 host.
  - ROS 2 Rolling container.

  Commands used:

  ```bash
  source /opt/ros/rolling/setup.bash
  source /opt/overlay_ws/install/setup.bash

  MAKEFLAGS=-j1 CMAKE_BUILD_PARALLEL_LEVEL=1 \
  colcon build \
    --packages-select nav2_mppi_controller \
    --executor sequential \
    --parallel-workers 1 \
    --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
```
  Unit test results:

  noise_generator_test: 11/11 passed
  optimizer_unit_tests: 16/16 passed

  Additional repository checks:

  diff --check passed
  no conflict markers found

  ### Simulation / benchmark method

  I used Nav2 loopback simulation rather than live RViz for benchmark numbers.

  Reason:

  - Live RViz was too heavy on the test laptop and changed runtime behavior.
  - For metrics, Nav2 was run headless so controller timing was less affected by visualization.
  - Visual proof was generated by replaying saved traces in RViz after the headless run.

  Benchmark workflow:

  1. Launch Nav2 loopback simulation headlessly.
  2. Run a scenario/profile pair.
  3. Record:
      - final result JSON,
      - launch/evaluator logs,
      - command samples,
      - odometry samples,
      - optimal trajectory samples where available,
      - critic summaries where available.
  4. Compute metrics from recorded outputs.
  5. Replay saved trace in RViz only for visualization/screencast.

  This means benchmark numbers come from headless runs, while videos are visual replays of the exact saved traces.

  ### Scenarios tested

  Final selected matrix scenarios:

  - tb3_open_straight
  - tb3_turning_route
  - tb3_tight_s_turn
  - tb3_near_obstacle_crossing

  These were chosen to cover:

  - simple path following,
  - turning behavior,
  - tight terminal turning / progress-checking stress,
  - near-obstacle route following.

  Profiles in final selected matrix:

  - vanilla_sgf
  - lp_sgf_c4p0_o1
  - lp_sgf_c0p8_o1
  - related low-frequency profiles for comparison only, not included in this PR.

  | Profile | Meaning |
  |---|---|
  | `vanilla_sgf` | Baseline Nav2 MPPI with existing Savitzky-Golay smoothing only |
  | `lp_sgf_c4p0_o1` | LP-MPPI + Savitzky-Golay, cutoff `4.0 Hz`, order `1` |
  | `lp_sgf_c0p8_o1` | LP-MPPI + Savitzky-Golay, cutoff `0.8 Hz`, order `1` |

  Repeats:

  - 2 repeats per scenario/profile in the final selected matrix.

  ### Metrics computed

  The benchmark recorded and compared:

  - success count,
  - final distance to goal,
  - path length,
  - path efficiency,
  - command sample rate,
  - pose sample rate,
  - optimal trajectory sample rate,
  - mean/rms command deltas,
  - total variation,
  - acceleration metrics,
  - high-frequency energy ratio,
  - MSSD / MSGFD-style smoothness metrics,
  - inter-iteration perturbation/control variation,
  - critic summary statistics.

  The most relevant LP-MPPI metrics were:

  - optimal trajectory mean absolute dvx,
  - optimal trajectory mean absolute dwz,
  - inter-iteration dvx/dwz,
  - success rate,
  - final distance,
  - runtime / optimal trajectory publication rate.

  ### Final selected matrix result

  | Profile | Success | Mean final dist | Opt dvx | Opt dwz | Inter dvx | Inter dwz | Opt rate |
  |---|---:|---:|---:|---:|---:|---:|---:|
  | vanilla_sgf | 8/8 | 0.189 | 0.009025 | 0.008219 | 0.004821 | 0.010605 | 19.98 Hz |
  | lp_sgf_c4p0_o1 | 8/8 | 0.182 | 0.005628 | 0.009046 | 0.005238 | 0.013614 | 19.99 Hz |
  | lp_sgf_c0p8_o1 | 7/8 | 0.237 | 0.003227 | 0.007946 | 0.005052 | 0.014922 | 19.99 Hz |

  Interpretation:

  - lp_sgf_c4p0_o1 was the best balanced LP-MPPI candidate.
  - It matched vanilla reliability: 8/8.
  - It slightly improved mean final distance in this matrix: 0.182 m vs 0.189 m.
  - It reduced optimal trajectory vx variation: 0.005628 vs 0.009025.
  - It did not introduce observed runtime loss: 19.99 Hz vs 19.98 Hz.
  - It did not improve all smoothness axes: optimal dwz and inter-iteration metrics were similar or slightly worse than vanilla.
  - lp_sgf_c0p8_o1 was smoother on some optimal trajectory metrics, but less reliable: 7/8.

  ### Parameter tuning performed

  LP cutoff/order sweep:

  - cutoff: 0.8, 1.2, 2.0, 3.0, 4.0
  - order: 1, 2, 3, 4
  - scenario: tb3_tight_s_turn
  - repeats: 3 per profile

  Findings:

  - Lower cutoff and higher order produced smoother perturbations.
  - Very aggressive filtering commonly reduced responsiveness near the goal.
  - Conservative settings were more reliable.
  - Good candidates from tuning:
      - cutoff=3.0, order=4
      - cutoff=4.0, order=1
  - After the warm-up-and-crop correction and final selected matrix, cutoff=4.0, order=1 was the best balanced candidate.

  ### Failure / weakness analysis

  A key failure mode was observed with overly aggressive LP settings:

  - Scenario: tb3_tight_s_turn
  - Profile example: low cutoff / aggressive smoothing
  - Failure type: Nav2 progress failure near goal / status 6
  - Cause interpretation:
      - LP filtering reduces high-frequency exploration and command variation.
      - In tight terminal turns, too much filtering can reduce responsiveness near the goal.
      - The robot may get close to the goal but not satisfy progress checking fast enough.

  This is why the feature is disabled by default and why conservative tuning is recommended.

  ### Why warm-up-and-crop was added

  The initial causal IIR filtering approach started with zero filter state.

  Problem:

  - The first samples in the MPPI horizon were strongly suppressed.
  - Nav2 needs near-term control authority because the first part of the sampled horizon affects the immediate command.
  - Suppressing the first samples made tight turns weaker.

  Fix:

  - Generate extra noise samples before the real horizon.
  - Filter the longer sequence.
  - Crop the final time_steps samples back to the Nav2 horizon.

  This preserves the LP-MPPI idea while avoiding an implementation artifact from zero initial filter state.

  ### Visual validation

  Visual proof was done with trace replay:

  - First run headless Nav2 to generate exact trace.
  - Then replay the recorded trace in RViz.
  - This avoids changing benchmark behavior with RViz load.

  Visual cases prepared:

  - turning route, vanilla SGF
  - turning route, LP balanced setting
  - turning route, aggressive LP setting
  - tight S-turn, vanilla SGF
  - tight S-turn, LP balanced setting
  - tight S-turn, aggressive LP setting
  - near-obstacle crossing, vanilla SGF
  - near-obstacle crossing, LP balanced setting

  The visual evidence is intended to show both:

  - where LP-MPPI improves smoothness,
  - where over-filtering can reduce responsiveness.

  ### What this PR does not claim

  This PR does not claim LP-MPPI is a universal replacement for vanilla MPPI sampling.

  The observed claim is narrower:

  - Conservative LP-MPPI tuning can reduce sampled optimal trajectory jitter while preserving reliability and runtime in the tested loopback scenarios.
  - Aggressive LP filtering has a clear smoothness/responsiveness tradeoff.
  - The feature should remain opt-in.

  ### Related work not included in this PR

  I also evaluated low-frequency / colored-noise perturbation sampling separately.

  That work is intentionally not included here because:

  - it changes the sampling method differently from LP-MPPI,
  - it has different tuning parameters,
  - it showed different runtime and reliability tradeoffs,
  - it should be reviewed as a separate PR if pursued.

  Low-frequency findings will be discussed separately.

  ———

 I also prepared a small evidence folder with the selected benchmark table, replay instructions, visual recordings, and the matching JSON/log/trace artifacts for the LP-MPPI cases discussed above: https://drive.google.com/drive/folders/1Uc-durJ76RmLbV0ER7LsJWuZ752Mm3bj?usp=drive_link

  It includes only the referenced LP-MPPI / baseline visual cases and matrix summaries, not the full raw benchmark workspace. If maintainers want to reproduce or inspect the benchmark harness itself, I can also upload the benchmark scripts separately.

  ## Future work that may be required in bullet points

  - Add the new LP-MPPI parameters to docs.nav2.org.
  - Add MPPI tuning guide notes for cutoff/order tradeoffs.
  - Test on real robot hardware.
  - Test additional robot models beyond TB3-style loopback simulation.
  - Test more tight terminal maneuvers and near-obstacle paths.
  - Consider whether recommended LP settings should be documented as examples, not defaults.
  - Continue separate evaluation of low-frequency / colored-noise MPPI in a different PR.
