### PR TITLE
Lookahead for Speed Limit Filter

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -147,6 +147,7 @@ private:
   // Lookahead distance held when entering a speed zone to avoid oscillations
   double held_lookahead_dist_;
   size_t cached_lookahead_start_idx_;  // Cached start index for closest pose search
+  double limit_at_robot_pose_;  // Speed limit at robot pose, used to release the lookahead hold
   bool enable_path_lookahead_;  // Whether to enable path lookahead
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead
   double min_lookahead_;   // Lower limit on lookahead distance (m)

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -144,7 +144,7 @@ private:
 
   // Lookahead distance held when entering a speed zone to avoid oscillations
   double held_lookahead_dist_;
-  size_t cached_lookahead_start_idx_;  // Cached start index for closest pose search
+  size_t lookahead_start_idx_;  // Start index for closest pose search, cached for efficiency
   double limit_at_robot_pose_;  // Speed limit at robot pose, used to release the lookahead hold
   bool enable_path_lookahead_;  // Whether to enable path lookahead
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -117,7 +117,7 @@ private:
    * @brief Get the speed limit from the path lookahead
    * @param robot_pose robot pose
    * @param lookahead_dist lookahead distance
-   * @return speed limit from the path lookahead
+   * @return strictest speed limit found along the lookahead
    */
   double getSpeedLimitFromLookahead(
     const geometry_msgs::msg::Pose & robot_pose,
@@ -145,7 +145,6 @@ private:
   // Lookahead distance held when entering a speed zone to avoid oscillations
   double held_lookahead_dist_;
   size_t lookahead_start_idx_;  // Start index for closest pose search, cached for efficiency
-  double limit_at_robot_pose_;  // Speed limit at robot pose, used to release the lookahead hold
   bool enable_path_lookahead_;  // Whether to enable path lookahead
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead
   double min_lookahead_;   // Lower limit on lookahead distance (m)

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -49,6 +49,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_util/odometry_utils.hpp"
 #include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/path_utils.hpp"
 
 namespace nav2_costmap_2d
 {

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -105,18 +105,17 @@ private:
   /**
    * @brief Look up the speed limit at a single pose in the costmap's global frame
    * @param pose Pose in global_frame_
-   * @param speed_limit Output: computed speed limit if pose maps to a valid mask cell
-   * @return true if pose mapped to a valid mask cell, false if outside mask or
-   *         transform failed. When false, speed_limit is unchanged.
+   * @param speed_limit output: computed speed limit
+   * @return true if pose mapped to a valid mask cell, false otherwise
    */
   bool getSpeedLimitAtPose(
     const geometry_msgs::msg::Pose & pose,
     double & speed_limit);
   /**
    * @brief Get the speed limit from the path lookahead
-   * @param robot_pose Robot pose
-   * @param lookahead_dist Lookahead distance
-   * @return Speed limit from the path lookahead
+   * @param robot_pose robot pose
+   * @param lookahead_dist lookahead distance
+   * @return speed limit from the path lookahead
    */
   double getSpeedLimitFromLookahead(
     const geometry_msgs::msg::Pose & robot_pose,
@@ -132,7 +131,7 @@ private:
   nav_msgs::msg::OccupancyGrid::ConstSharedPtr filter_mask_;
   nav_msgs::msg::Path::ConstSharedPtr current_path_;
 
-  // Odometry for lookahead calculation
+  // Odometry for variable lookahead distance calculation
   std::shared_ptr<nav2_util::OdomSmoother> odom_smoother_;
 
   std::string global_frame_;  // Frame of current layer (master_grid)
@@ -143,11 +142,11 @@ private:
 
   // Path lookahead
   static constexpr double POSE_SEARCH_EXIT_THRESHOLD_ = 1.0;
-  size_t cached_start_idx_;
-  bool enable_path_lookahead_;
+  size_t cached_lookahead_start_idx_;  // Cached start index for closest pose search
+  bool enable_path_lookahead_;  // Whether to enable path lookahead
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead
-  double min_lookahead_;   // Lower clamp on lookahead distance (m)
-  double max_lookahead_;   // Upper clamp on lookahead distance (m)
+  double min_lookahead_;   // Lower limit on lookahead distance (m)
+  double max_lookahead_;   // Upper limit on lookahead distance (m)
   double path_sample_resolution_;     // Resolution for sampling the path (m)
   bool publish_lookahead_;    // Whether to publish the last lookahead point for debugging
 };

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -151,7 +151,6 @@ private:
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead
   double min_lookahead_;   // Lower limit on lookahead distance (m)
   double max_lookahead_;   // Upper limit on lookahead distance (m)
-  double path_sample_resolution_;     // Resolution for sampling the path (m)
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -117,11 +117,13 @@ private:
    * @brief Get the speed limit from the path lookahead
    * @param robot_pose robot pose
    * @param lookahead_dist lookahead distance
-   * @return strictest speed limit found along the lookahead
+   * @param speed_limit output: strictest speed limit found along the lookahead
+   * @return true if the lookahead could be evaluated, false otherwise
    */
-  double getSpeedLimitFromLookahead(
+  bool getSpeedLimitFromLookahead(
     const geometry_msgs::msg::Pose & robot_pose,
-    double lookahead_dist);
+    double lookahead_dist,
+    double & speed_limit);
 
   nav2::Subscription<nav2_msgs::msg::CostmapFilterInfo>::SharedPtr filter_info_sub_;
   nav2::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr mask_sub_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -43,8 +43,11 @@
 
 #include "nav2_costmap_2d/costmap_filters/costmap_filter.hpp"
 
+#include "geometry_msgs/msg/point_stamped.hpp"
 #include "nav2_msgs/msg/costmap_filter_info.hpp"
 #include "nav2_msgs/msg/speed_limit.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_util/odometry_utils.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -95,19 +98,57 @@ private:
    * @brief Callback for the filter mask
    */
   void maskCallback(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & msg);
+  /**
+   * @brief Callback for the planned path used by path lookahead
+   */
+  void pathCallback(const nav_msgs::msg::Path::ConstSharedPtr & msg);
+  /**
+   * @brief Look up the speed limit at a single pose in the costmap's global frame
+   * @param pose Pose in global_frame_
+   * @param speed_limit Output: computed speed limit if pose maps to a valid mask cell
+   * @return true if pose mapped to a valid mask cell, false if outside mask or
+   *         transform failed. When false, speed_limit is unchanged.
+   */
+  bool getSpeedLimitAtPose(
+    const geometry_msgs::msg::Pose & pose,
+    double & speed_limit);
+  /**
+   * @brief Get the speed limit from the path lookahead
+   * @param robot_pose Robot pose
+   * @param lookahead_dist Lookahead distance
+   * @return Speed limit from the path lookahead
+   */
+  double getSpeedLimitFromLookahead(
+    const geometry_msgs::msg::Pose & robot_pose,
+    double lookahead_dist);
 
   nav2::Subscription<nav2_msgs::msg::CostmapFilterInfo>::SharedPtr filter_info_sub_;
   nav2::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr mask_sub_;
+  nav2::Subscription<nav_msgs::msg::Path>::SharedPtr path_sub_;
 
   nav2::Publisher<nav2_msgs::msg::SpeedLimit>::SharedPtr speed_limit_pub_;
+  nav2::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr lookahead_pub_;
 
   nav_msgs::msg::OccupancyGrid::ConstSharedPtr filter_mask_;
+  nav_msgs::msg::Path::ConstSharedPtr current_path_;
+
+  // Odometry for lookahead calculation
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother_;
 
   std::string global_frame_;  // Frame of current layer (master_grid)
 
   double base_, multiplier_;
   bool percentage_;
   double speed_limit_, speed_limit_prev_;
+
+  // Path lookahead
+  size_t cached_start_idx_;
+  bool enable_path_lookahead_;
+  double max_decel_;       // Deceleration (m/s^2) used to size lookahead
+  double min_lookahead_;   // Lower clamp on lookahead distance (m)
+  double max_lookahead_;   // Upper clamp on lookahead distance (m)
+  double path_sample_resolution_;     // Resolution for sampling the path (m)
+  bool publish_lookahead_;    // Whether to publish the last lookahead point for debugging
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -144,6 +144,8 @@ private:
 
   // Path lookahead
   static constexpr double POSE_SEARCH_EXIT_THRESHOLD_ = 1.0;
+  // Lookahead distance held when entering a speed zone to avoid oscillations
+  double held_lookahead_dist_;
   size_t cached_lookahead_start_idx_;  // Cached start index for closest pose search
   bool enable_path_lookahead_;  // Whether to enable path lookahead
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -48,6 +48,7 @@
 #include "nav2_msgs/msg/speed_limit.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_util/odometry_utils.hpp"
+#include "nav2_util/geometry_utils.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -148,7 +149,6 @@ private:
   double min_lookahead_;   // Lower limit on lookahead distance (m)
   double max_lookahead_;   // Upper limit on lookahead distance (m)
   double path_sample_resolution_;     // Resolution for sampling the path (m)
-  bool publish_lookahead_;    // Whether to publish the last lookahead point for debugging
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -142,8 +142,6 @@ private:
   bool percentage_;
   double speed_limit_, speed_limit_prev_;
 
-  // Path lookahead
-  static constexpr double POSE_SEARCH_EXIT_THRESHOLD_ = 1.0;
   // Lookahead distance held when entering a speed zone to avoid oscillations
   double held_lookahead_dist_;
   size_t cached_lookahead_start_idx_;  // Cached start index for closest pose search

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -142,6 +142,7 @@ private:
   double speed_limit_, speed_limit_prev_;
 
   // Path lookahead
+  static constexpr double POSE_SEARCH_EXIT_THRESHOLD_ = 1.0;
   size_t cached_start_idx_;
   bool enable_path_lookahead_;
   double max_decel_;       // Deceleration (m/s^2) used to size lookahead

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -51,8 +51,7 @@ namespace nav2_costmap_2d
 SpeedFilter::SpeedFilter()
 : filter_info_sub_(nullptr), mask_sub_(nullptr),
   speed_limit_pub_(nullptr), filter_mask_(nullptr), global_frame_(""),
-  speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT),
-  held_lookahead_dist_(0.0), cached_lookahead_start_idx_(0)
+  speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT)
 {
 }
 
@@ -152,6 +151,11 @@ void SpeedFilter::initializeFilter(
   base_ = BASE_DEFAULT;
   multiplier_ = MULTIPLIER_DEFAULT;
   percentage_ = false;
+
+  // Reset path lookahead states
+  held_lookahead_dist_ = 0.0;
+  cached_lookahead_start_idx_ = 0;
+  limit_at_robot_pose_ = NO_SPEED_LIMIT;
 }
 
 void SpeedFilter::filterInfoCallback(
@@ -363,6 +367,8 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     // Pose mapped outside mask or transform failed
     return NO_SPEED_LIMIT;
   }
+  limit_at_robot_pose_ = speed_limit_at_robot_pose;
+
   if (speed_limit_at_robot_pose != NO_SPEED_LIMIT) {
     min_speed_limit = speed_limit_at_robot_pose;
     found_any_limit = true;
@@ -440,23 +446,20 @@ void SpeedFilter::process(
       d_lookahead = (linear_vel * linear_vel) / (2.0 * std::abs(max_decel_));
       d_lookahead = std::clamp(d_lookahead, min_lookahead_, max_lookahead_);
 
-      // If a limit is currently active, don't let the lookahead shrink below
-      // the one that captured the speed zone
-      if(speed_limit_ != NO_SPEED_LIMIT) {
-        d_lookahead = std::max(d_lookahead, held_lookahead_dist_);
-      }
+      // If lookahead distance is being held, don't let it shrink below the held value
+      d_lookahead = std::max(d_lookahead, held_lookahead_dist_);
     } else {
       d_lookahead = max_lookahead_;
     }
 
     speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
 
-    // If a limit is currently active, hold the lookahead distance
-    if (speed_limit_ != NO_SPEED_LIMIT) {
-      held_lookahead_dist_ = d_lookahead;
-    } else {
-      // If no limit is currently active, reset the held distance
+    // If the speed limit at robot pose is same as the strictest speed limit along path,
+    // release the lookahead hold
+    if (limit_at_robot_pose_ == speed_limit_) {
       held_lookahead_dist_ = 0.0;
+    } else {
+      held_lookahead_dist_ = d_lookahead;
     }
   } else {
     if (!getSpeedLimitAtPose(pose, speed_limit_)) {
@@ -499,8 +502,6 @@ void SpeedFilter::resetFilter()
     lookahead_pub_->on_deactivate();
     lookahead_pub_.reset();
   }
-  held_lookahead_dist_ = 0.0;
-  cached_lookahead_start_idx_ = 0;
 }
 
 bool SpeedFilter::isActive()

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -342,11 +342,10 @@ double SpeedFilter::getSpeedLimitFromLookahead(
 
   size_t start_idx = search_start;
   double min_dist = std::numeric_limits<double>::max();
-  constexpr double kClosestExitMargin = 1.0;
 
   // Find the closest pose to the robot
-  // To save computation time, stop searching path poses start getting further than
-  // the closest pose + a margin
+  // To save computation time, stop searching path when poses get further than
+  // the closest pose + a threshold
   for (size_t i = search_start; i < poses.size(); i++) {
     const auto & p = poses[i].pose.position;
     const double dx = p.x - robot_pose.position.x;
@@ -355,7 +354,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     if (d < min_dist) {
       min_dist = d;
       start_idx = i;
-    } else if (d > min_dist + kClosestExitMargin) {
+    } else if (d > min_dist + POSE_SEARCH_EXIT_THRESHOLD_) {
       break;
     }
   }
@@ -370,12 +369,11 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double dist_along_path = 0.0;
   double last_sample_dist = -path_sample_resolution_;
 
+  // Lookahead endpoint for visualization
   geometry_msgs::msg::PointStamped lookahead_endpoint;
   lookahead_endpoint.header.frame_id = global_frame_;
   lookahead_endpoint.header.stamp = clock_->now();
-  lookahead_endpoint.point.x = robot_pose.position.x;
-  lookahead_endpoint.point.y = robot_pose.position.y;
-  lookahead_endpoint.point.z = robot_pose.position.z;
+  lookahead_endpoint.point = robot_pose.position;
 
   // Check robot's current pose to list of poses to be checked
   double speed_limit_at_robot_pose = NO_SPEED_LIMIT;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -323,6 +323,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   auto lookahead_point_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
   lookahead_point_msg->header.frame_id = global_frame_;
   lookahead_point_msg->header.stamp = clock_->now();
+  lookahead_point_msg->point = robot_pose.position;
 
   // Transform path if not in the global frame
   nav_msgs::msg::Path transformed_path;
@@ -346,8 +347,6 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   // Update cached start index
   lookahead_start_idx_ = nav2_util::distance_from_path(
     transformed_path, robot_pose, pose_search_start).closest_segment_index;
-
-  lookahead_point_msg->point = robot_pose.position;
 
   // Check robot's current pose
   double limit_at_robot_pose = NO_SPEED_LIMIT;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -75,7 +75,7 @@ void SpeedFilter::initializeFilter(
   enable_path_lookahead_ = node->declare_or_get_parameter(
     name_ + "." + "enable_path_lookahead", false);
   max_decel_ = node->declare_or_get_parameter(
-    name_ + "." + "max_decel", 0.5);
+    name_ + "." + "max_decel", -0.5);
   min_lookahead_ = node->declare_or_get_parameter(
     name_ + "." + "min_lookahead", 0.3);
   max_lookahead_ = node->declare_or_get_parameter(
@@ -89,12 +89,11 @@ void SpeedFilter::initializeFilter(
 
   // Check params
   if (enable_path_lookahead_) {
-    if (max_decel_ <= 0.0) {
+    if (max_decel_ >= 0.0) {
       RCLCPP_WARN(
         logger_,
-        "SpeedFilter: max_decel = %f is non-positive,"
-        "lookahead distance will be set to max_lookahead",
-          max_decel_);
+        "SpeedFilter: max_decel should be negative,"
+        "lookahead distance will be set to max_lookahead instead");
     }
     if (min_lookahead_ < 0.0) {
       RCLCPP_WARN(
@@ -454,8 +453,8 @@ void SpeedFilter::process(
 
     // Calculate lookahead distance at current velocity
     double d_lookahead;
-    if (max_decel_ > 0.0) {
-      d_lookahead = (linear_vel * linear_vel) / (2.0 * max_decel_);
+    if (max_decel_ < 0.0) {
+      d_lookahead = (linear_vel * linear_vel) / (2.0 * std::abs(max_decel_));
       d_lookahead = std::clamp(d_lookahead, min_lookahead_, max_lookahead_);
     } else {
       d_lookahead = max_lookahead_;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -362,11 +362,6 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   // Walk poses from the lookahead start index forward, sampling the speed limit at each pose.
   double dist_along_path = 0.0;
   for (size_t i = lookahead_start_idx_; i < poses.size(); ++i) {
-    if (i > lookahead_start_idx_) {
-      dist_along_path += nav2_util::geometry_utils::euclidean_distance(
-        poses[i - 1].pose.position, poses[i].pose.position);
-    }
-
     if (dist_along_path > lookahead_dist) {
       break;
     }
@@ -375,12 +370,16 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     lookahead_point_msg->point = poses[i].pose.position;
 
     double sampled_speed_limit = NO_SPEED_LIMIT;
-    if (!getSpeedLimitAtPose(poses[i].pose, sampled_speed_limit)) {
-      // Pose mapped outside mask or transform failed
-      continue;
-    }
-    if (sampled_speed_limit != NO_SPEED_LIMIT) {
+    if (getSpeedLimitAtPose(poses[i].pose, sampled_speed_limit) &&
+      sampled_speed_limit != NO_SPEED_LIMIT)
+    {
       min_speed_limit = std::min(min_speed_limit, sampled_speed_limit);
+    }
+
+    // Accumulate distance to the next pose for the following iteration's check
+    if (i + 1 < poses.size()) {
+      dist_along_path += nav2_util::geometry_utils::euclidean_distance(
+        poses[i].pose.position, poses[i + 1].pose.position);
     }
   }
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -38,6 +38,7 @@
 #include "nav2_costmap_2d/costmap_filters/speed_filter.hpp"
 
 #include <cmath>
+#include <limits>
 #include <utility>
 #include <memory>
 #include <string>
@@ -155,7 +156,6 @@ void SpeedFilter::initializeFilter(
   // Reset path lookahead states
   held_lookahead_dist_ = 0.0;
   lookahead_start_idx_ = 0;
-  limit_at_robot_pose_ = NO_SPEED_LIMIT;
 }
 
 void SpeedFilter::filterInfoCallback(
@@ -314,6 +314,16 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   const geometry_msgs::msg::Pose & robot_pose,
   double lookahead_dist)
 {
+  double min_speed_limit = std::numeric_limits<double>::infinity();
+
+  // Release the hold by default, a stricter limit ahead re-arms it
+  held_lookahead_dist_ = 0.0;
+
+  // Lookahead endpoint for visualization
+  auto lookahead_point_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  lookahead_point_msg->header.frame_id = global_frame_;
+  lookahead_point_msg->header.stamp = clock_->now();
+
   // Transform path if not in the global frame
   nav_msgs::msg::Path transformed_path = *current_path_;
   if(current_path_->header.frame_id != global_frame_) {
@@ -332,33 +342,21 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   const size_t pose_search_start =
     (lookahead_start_idx_ < poses.size()) ? lookahead_start_idx_ : 0;
 
-  // Find the closest segment to the robot
-  auto path_search_result = nav2_util::distance_from_path(
-    transformed_path, robot_pose, pose_search_start);
-
   // Update cached start index
-  lookahead_start_idx_ = path_search_result.closest_segment_index;
+  lookahead_start_idx_ = nav2_util::distance_from_path(
+    transformed_path, robot_pose, pose_search_start).closest_segment_index;
 
-  double min_speed_limit = NO_SPEED_LIMIT;
-  bool found_any_limit = false;
-
-  // Lookahead endpoint for visualization
-  auto lookahead_point_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
-  lookahead_point_msg->header.frame_id = global_frame_;
-  lookahead_point_msg->header.stamp = clock_->now();
   lookahead_point_msg->point = robot_pose.position;
 
   // Check robot's current pose
-  double speed_limit_at_robot_pose = NO_SPEED_LIMIT;
-  if (!getSpeedLimitAtPose(robot_pose, speed_limit_at_robot_pose)) {
+  double limit_at_robot_pose = NO_SPEED_LIMIT;
+  if (!getSpeedLimitAtPose(robot_pose, limit_at_robot_pose)) {
     // Pose mapped outside mask or transform failed
     return NO_SPEED_LIMIT;
   }
-  limit_at_robot_pose_ = speed_limit_at_robot_pose;
 
-  if (speed_limit_at_robot_pose != NO_SPEED_LIMIT) {
-    min_speed_limit = speed_limit_at_robot_pose;
-    found_any_limit = true;
+  if (limit_at_robot_pose != NO_SPEED_LIMIT) {
+    min_speed_limit = std::min(min_speed_limit, limit_at_robot_pose);
   }
 
   // Walk poses from the lookahead start index forward, sampling the speed limit at each pose.
@@ -381,16 +379,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
       // Pose mapped outside mask or transform failed
       continue;
     }
-    if (sampled_speed_limit == NO_SPEED_LIMIT) {
-      continue;
-    }
-
-    // Update strictest speed limit
-    if (!found_any_limit) {
-      // First limit found on the lookahead path, set it as the strictest
-      min_speed_limit = sampled_speed_limit;
-      found_any_limit = true;
-    } else {
+    if (sampled_speed_limit != NO_SPEED_LIMIT) {
       min_speed_limit = std::min(min_speed_limit, sampled_speed_limit);
     }
   }
@@ -399,6 +388,15 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     lookahead_pub_->publish(std::move(lookahead_point_msg));
   }
 
+  // No limit found anywhere along the lookahead, fall back to no-limit
+  if (std::isinf(min_speed_limit)) {
+    min_speed_limit = NO_SPEED_LIMIT;
+  }
+
+  // Hold the lookahead distance if upcoming speed limit is different from the current one
+  if (limit_at_robot_pose != min_speed_limit) {
+    held_lookahead_dist_ = lookahead_dist;
+  }
   return min_speed_limit;
 }
 
@@ -428,26 +426,16 @@ void SpeedFilter::process(
     const double linear_vel = std::abs(twist.linear.x);
 
     // Calculate lookahead distance at current velocity
-    double d_lookahead;
+    double d_lookahead = max_lookahead_;
     if (max_decel_ < 0.0) {
       d_lookahead = (linear_vel * linear_vel) / (2.0 * std::abs(max_decel_));
       d_lookahead = std::clamp(d_lookahead, min_lookahead_, max_lookahead_);
 
       // If lookahead distance is being held, don't let it shrink below the held value
       d_lookahead = std::max(d_lookahead, held_lookahead_dist_);
-    } else {
-      d_lookahead = max_lookahead_;
     }
 
     speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
-
-    // If the speed limit at robot pose is same as the strictest speed limit along path,
-    // release the lookahead hold
-    if (limit_at_robot_pose_ == speed_limit_) {
-      held_lookahead_dist_ = 0.0;
-    } else {
-      held_lookahead_dist_ = d_lookahead;
-    }
   } else {
     if (!getSpeedLimitAtPose(pose, speed_limit_)) {
       RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit at pose");

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -86,8 +86,6 @@ void SpeedFilter::initializeFilter(
     name_ + "." + "path_topic", std::string("plan"));
   std::string odom_topic = node->declare_or_get_parameter(
     name_ + "." + "odom_topic", std::string("odom"));
-  publish_lookahead_ = node->declare_or_get_parameter(
-    name_ + "." + "publish_lookahead", false);
 
   // Check params
   if (enable_path_lookahead_) {
@@ -155,11 +153,9 @@ void SpeedFilter::initializeFilter(
     odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(
       node, 0.3, odom_topic);
 
-    if (publish_lookahead_) {
-      lookahead_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>(
-        name_ + "/lookahead_endpoint");
-      lookahead_pub_->on_activate();
-    }
+    lookahead_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>(
+      name_ + "/lookahead_point");
+    lookahead_pub_->on_activate();
   }
 
   // Reset speed conversion states
@@ -258,8 +254,7 @@ void SpeedFilter::pathCallback(
 
 bool SpeedFilter::getSpeedLimitAtPose(
   const geometry_msgs::msg::Pose & pose,
-  double & speed_limit
-)
+  double & speed_limit)
 {
   geometry_msgs::msg::Pose mask_pose;  // robot coordinates in mask frame
 
@@ -345,10 +340,8 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   // To save computation time, stop searching path when poses get further than
   // the closest pose + a threshold
   for (size_t i = pose_search_start; i < poses.size(); i++) {
-    const auto & p = poses[i].pose.position;
-    const double dx = p.x - robot_pose.position.x;
-    const double dy = p.y - robot_pose.position.y;
-    const double d = std::sqrt(dx * dx + dy * dy);
+    const double d = nav2_util::geometry_utils::euclidean_distance(
+      poses[i].pose.position, robot_pose.position);
     if (d < min_dist) {
       min_dist = d;
       lookahead_start_idx = i;
@@ -368,10 +361,10 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double last_sample_dist = -path_sample_resolution_;
 
   // Lookahead endpoint for visualization
-  geometry_msgs::msg::PointStamped lookahead_endpoint;
-  lookahead_endpoint.header.frame_id = global_frame_;
-  lookahead_endpoint.header.stamp = clock_->now();
-  lookahead_endpoint.point = robot_pose.position;
+  auto lookahead_point_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  lookahead_point_msg->header.frame_id = global_frame_;
+  lookahead_point_msg->header.stamp = clock_->now();
+  lookahead_point_msg->point = robot_pose.position;
 
   // Check robot's current pose to list of poses to be checked
   double speed_limit_at_robot_pose = NO_SPEED_LIMIT;
@@ -387,11 +380,8 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   // Walk poses from lookahead_start_idx forward. Sample the speed limit at each pose.
   for (size_t i = lookahead_start_idx; i < poses.size(); ++i) {
     if(i > lookahead_start_idx) {
-      const auto & prev = poses[i - 1].pose.position;
-      const auto & curr = poses[i].pose.position;
-      const double dx = curr.x - prev.x;
-      const double dy = curr.y - prev.y;
-      dist_along_path += std::sqrt(dx * dx + dy * dy);
+      dist_along_path += nav2_util::geometry_utils::euclidean_distance(
+        poses[i - 1].pose.position, poses[i].pose.position);
     }
 
     if (dist_along_path > lookahead_dist) {
@@ -404,7 +394,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     last_sample_dist = dist_along_path;
 
     // Update lookahead endpoint for visualization
-    lookahead_endpoint.point = poses[i].pose.position;
+    lookahead_point_msg->point = poses[i].pose.position;
 
     double sampled_speed_limit = NO_SPEED_LIMIT;
     if (!getSpeedLimitAtPose(poses[i].pose, sampled_speed_limit)) {
@@ -425,8 +415,8 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     }
   }
 
-  if (publish_lookahead_ && lookahead_pub_) {
-    lookahead_pub_->publish(lookahead_endpoint);
+  if (lookahead_pub_ && lookahead_pub_->get_subscription_count() > 0) {
+    lookahead_pub_->publish(std::move(lookahead_point_msg));
   }
 
   return min_speed_limit;
@@ -447,13 +437,11 @@ void SpeedFilter::process(
     return;
   }
 
-  // Decide path lookahead vs just checking at robot pose. Path lookahead requires
-  // the feature enabled, a non-empty path received, and the OdomSmoother
-  // available to query current speed
+  // Decide path lookahead vs just checking at robot pose.
+  // Path lookahead requires a non-empty path received
   const bool use_path_lookahead =
     enable_path_lookahead_ &&
-    current_path_ && !current_path_->poses.empty() &&
-    odom_smoother_;
+    current_path_ && !current_path_->poses.empty();
 
   if (use_path_lookahead) {
     const auto twist = odom_smoother_->getTwist();
@@ -470,7 +458,7 @@ void SpeedFilter::process(
 
     speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
   } else {
-    if(!getSpeedLimitAtPose(pose, speed_limit_)) {
+    if (!getSpeedLimitAtPose(pose, speed_limit_)) {
       RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit at pose");
       return;
     }

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -80,8 +80,6 @@ void SpeedFilter::initializeFilter(
     name_ + "." + "min_lookahead", 0.3);
   max_lookahead_ = node->declare_or_get_parameter(
     name_ + "." + "max_lookahead", 5.0);
-  path_sample_resolution_ = node->declare_or_get_parameter(
-    name_ + "." + "path_sample_resolution", 0.1);
   std::string path_topic = node->declare_or_get_parameter(
     name_ + "." + "path_topic", std::string("plan"));
   std::string odom_topic = node->declare_or_get_parameter(
@@ -109,13 +107,6 @@ void SpeedFilter::initializeFilter(
         "clamping to min_lookahead.",
         max_lookahead_, min_lookahead_);
       max_lookahead_ = min_lookahead_;
-    }
-    if (path_sample_resolution_ <= 0.0) {
-      RCLCPP_WARN(
-        logger_,
-        "SpeedFilter: path_sample_resolution = %f is non-positive; falling back to 0.1m.",
-        path_sample_resolution_);
-      path_sample_resolution_ = 0.1;
     }
   }
 
@@ -360,17 +351,13 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double min_speed_limit = NO_SPEED_LIMIT;
   bool found_any_limit = false;
 
-  // Initialize last_sample_dist such that the first pose is always sampled.
-  double dist_along_path = 0.0;
-  double last_sample_dist = -path_sample_resolution_;
-
   // Lookahead endpoint for visualization
   auto lookahead_point_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
   lookahead_point_msg->header.frame_id = global_frame_;
   lookahead_point_msg->header.stamp = clock_->now();
   lookahead_point_msg->point = robot_pose.position;
 
-  // Check robot's current pose to list of poses to be checked
+  // Check robot's current pose
   double speed_limit_at_robot_pose = NO_SPEED_LIMIT;
   if (!getSpeedLimitAtPose(robot_pose, speed_limit_at_robot_pose)) {
     // Pose mapped outside mask or transform failed
@@ -381,9 +368,10 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     found_any_limit = true;
   }
 
-  // Walk poses from lookahead_start_idx forward. Sample the speed limit at each pose.
+  // Walk poses from lookahead_start_idx forward, sampling the speed limit at each pose.
+  double dist_along_path = 0.0;
   for (size_t i = lookahead_start_idx; i < poses.size(); ++i) {
-    if(i > lookahead_start_idx) {
+    if (i > lookahead_start_idx) {
       dist_along_path += nav2_util::geometry_utils::euclidean_distance(
         poses[i - 1].pose.position, poses[i].pose.position);
     }
@@ -391,11 +379,6 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     if (dist_along_path > lookahead_dist) {
       break;
     }
-
-    if (dist_along_path - last_sample_dist < path_sample_resolution_) {
-      continue;
-    }
-    last_sample_dist = dist_along_path;
 
     // Update lookahead endpoint for visualization
     lookahead_point_msg->point = poses[i].pose.position;
@@ -469,7 +452,7 @@ void SpeedFilter::process(
     speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
 
     // If a limit is currently active, hold the lookahead distance
-    if(speed_limit_ != NO_SPEED_LIMIT) {
+    if (speed_limit_ != NO_SPEED_LIMIT) {
       held_lookahead_dist_ = d_lookahead;
     } else {
       // If no limit is currently active, reset the held distance

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -51,7 +51,8 @@ namespace nav2_costmap_2d
 SpeedFilter::SpeedFilter()
 : filter_info_sub_(nullptr), mask_sub_(nullptr),
   speed_limit_pub_(nullptr), filter_mask_(nullptr), global_frame_(""),
-  speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT)
+  speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT),
+  cached_start_idx_(0)
 {
 }
 
@@ -69,6 +70,57 @@ void SpeedFilter::initializeFilter(
   std::string speed_limit_topic = node->declare_or_get_parameter(name_ + "." + "speed_limit_topic",
     std::string("speed_limit"));
   speed_limit_topic = joinWithParentNamespace(speed_limit_topic);
+
+  // Path lookahead parameters
+  enable_path_lookahead_ = node->declare_or_get_parameter(
+    name_ + "." + "enable_path_lookahead", false);
+  max_decel_ = node->declare_or_get_parameter(
+    name_ + "." + "max_decel", 0.5);
+  min_lookahead_ = node->declare_or_get_parameter(
+    name_ + "." + "min_lookahead", 0.3);
+  max_lookahead_ = node->declare_or_get_parameter(
+    name_ + "." + "max_lookahead", 5.0);
+  path_sample_resolution_ = node->declare_or_get_parameter(
+    name_ + "." + "path_sample_resolution", 0.1);
+  std::string path_topic = node->declare_or_get_parameter(
+    name_ + "." + "path_topic", std::string("plan"));
+  std::string odom_topic = node->declare_or_get_parameter(
+    name_ + "." + "odom_topic", std::string("odom"));
+  publish_lookahead_ = node->declare_or_get_parameter(
+    name_ + "." + "publish_lookahead", false);
+
+  // Check params
+  if (enable_path_lookahead_) {
+    if (max_decel_ <= 0.0) {
+      RCLCPP_WARN(
+        logger_,
+        "SpeedFilter: max_decel = %f is non-positive,"
+        "lookahead distance will be clamped to max_lookahead",
+          max_decel_);
+    }
+    if (min_lookahead_ < 0.0) {
+      RCLCPP_WARN(
+        logger_,
+        "SpeedFilter: min_lookahead = %f is negative,"
+        "clamping to 0.0m", min_lookahead_);
+      min_lookahead_ = 0.0;
+    }
+    if (max_lookahead_ < min_lookahead_) {
+      RCLCPP_WARN(
+        logger_,
+        "SpeedFilter: max_lookahead = %f is less than min_lookahead = %f,"
+        "clamping to min_lookahead.",
+        max_lookahead_, min_lookahead_);
+      max_lookahead_ = min_lookahead_;
+    }
+    if (path_sample_resolution_ <= 0.0) {
+      RCLCPP_WARN(
+        logger_,
+        "SpeedFilter: path_sample_resolution = %f is non-positive; falling back to 0.1m.",
+        path_sample_resolution_);
+      path_sample_resolution_ = 0.1;
+    }
+  }
 
   filter_info_topic_ = joinWithParentNamespace(filter_info_topic);
   // Setting new costmap filter info subscriber
@@ -88,6 +140,27 @@ void SpeedFilter::initializeFilter(
   speed_limit_pub_ = node->create_publisher<nav2_msgs::msg::SpeedLimit>(
     speed_limit_topic);
   speed_limit_pub_->on_activate();
+
+  // Path subscriptions and odom smoother if lookahead enabled
+  if (enable_path_lookahead_) {
+    std::string resolved_path_topic = joinWithParentNamespace(path_topic);
+    RCLCPP_INFO(
+      logger_,
+      "SpeedFilter: Path lookahead enabled. Subscribing to \"%s\" topic for path...",
+      resolved_path_topic.c_str());
+    path_sub_ = node->create_subscription<nav_msgs::msg::Path>(
+      resolved_path_topic,
+      std::bind(&SpeedFilter::pathCallback, this, std::placeholders::_1));
+
+    odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(
+      node, 0.3, odom_topic);
+
+    if (publish_lookahead_) {
+      lookahead_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>(
+        name_ + "/lookahead_endpoint");
+      lookahead_pub_->on_activate();
+    }
+  }
 
   // Reset speed conversion states
   base_ = BASE_DEFAULT;
@@ -174,6 +247,194 @@ void SpeedFilter::maskCallback(
   filter_mask_ = msg;
 }
 
+void SpeedFilter::pathCallback(
+  const nav_msgs::msg::Path::ConstSharedPtr & msg)
+{
+  std::lock_guard<CostmapFilter::mutex_t> guard(*getMutex());
+  current_path_ = msg;
+  // Reset cached start index when new path is received
+  cached_start_idx_ = 0;
+}
+
+bool SpeedFilter::getSpeedLimitAtPose(
+  const geometry_msgs::msg::Pose & pose,
+  double & speed_limit
+)
+{
+  geometry_msgs::msg::Pose mask_pose;  // robot coordinates in mask frame
+
+  // Transforming robot pose from current layer frame to mask frame
+  if (!transformPose(global_frame_, pose, filter_mask_->header.frame_id, mask_pose)) {
+    return false;
+  }
+
+  // Converting mask_pose robot position to filter_mask_ indexes (mask_robot_i, mask_robot_j)
+  unsigned int mask_robot_i, mask_robot_j;
+  if (!nav2_util::worldToMap(
+      filter_mask_, mask_pose.position.x, mask_pose.position.y,
+      mask_robot_i, mask_robot_j))
+  {
+    return false;
+  }
+
+  // Getting filter_mask data from cell where the robot placed and
+  // calculating speed limit value
+  int8_t speed_mask_data = getMaskData(filter_mask_, mask_robot_i, mask_robot_j);
+  if (speed_mask_data == SPEED_MASK_NO_LIMIT) {
+    // Corresponding filter mask cell is free.
+    // Setting no speed limit there.
+    speed_limit = NO_SPEED_LIMIT;
+  } else if (speed_mask_data == SPEED_MASK_UNKNOWN) {
+    // Corresponding filter mask cell is unknown.
+    // Do nothing.
+    RCLCPP_ERROR(
+      logger_,
+      "SpeedFilter: Found unknown cell in filter_mask[%i, %i], "
+      "which is invalid for this kind of filter",
+      mask_robot_i, mask_robot_j);
+    return false;
+  } else {
+    // Normal case: speed_mask_data in range of [1..100]
+    speed_limit = speed_mask_data * multiplier_ + base_;
+    if (percentage_) {
+      if (speed_limit < 0.0 || speed_limit > 100.0) {
+        RCLCPP_WARN(
+          logger_,
+          "SpeedFilter: Speed limit in filter_mask[%i, %i] is %f%%, "
+          "out of bounds of [0, 100]. Setting it to no-limit value.",
+          mask_robot_i, mask_robot_j, speed_limit);
+        speed_limit = NO_SPEED_LIMIT;
+      }
+    } else {
+      if (speed_limit < 0.0) {
+        RCLCPP_WARN(
+          logger_,
+          "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0 m/s, "
+          "which can not be true. Setting it to no-limit value.",
+          mask_robot_i, mask_robot_j);
+        speed_limit = NO_SPEED_LIMIT;
+      }
+    }
+  }
+  return true;
+}
+
+double SpeedFilter::getSpeedLimitFromLookahead(
+  const geometry_msgs::msg::Pose & robot_pose,
+  double lookahead_dist)
+{
+  const auto & poses = current_path_->poses;
+
+  // Validate frame id
+  if (!current_path_->header.frame_id.empty() &&
+    current_path_->header.frame_id != global_frame_)
+  {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *(clock_), 5000,
+      "SpeedFilter: Path frame [%s] differs from costmap global frame [%s],"
+      "skipping path lookahead",
+      current_path_->header.frame_id.c_str(), global_frame_.c_str());
+    return NO_SPEED_LIMIT;
+  }
+
+  const size_t search_start =
+    (cached_start_idx_ < poses.size()) ? cached_start_idx_ : 0;
+
+  size_t start_idx = search_start;
+  double min_dist = std::numeric_limits<double>::max();
+  constexpr double kClosestExitMargin = 1.0;
+
+  // Find the closest pose to the robot
+  // To save computation time, stop searching path poses start getting further than
+  // the closest pose + a margin
+  for (size_t i = search_start; i < poses.size(); i++) {
+    const auto & p = poses[i].pose.position;
+    const double dx = p.x - robot_pose.position.x;
+    const double dy = p.y - robot_pose.position.y;
+    const double d = std::sqrt(dx * dx + dy * dy);
+    if (d < min_dist) {
+      min_dist = d;
+      start_idx = i;
+    } else if (d > min_dist + kClosestExitMargin) {
+      break;
+    }
+  }
+
+  // Update cached start index
+  cached_start_idx_ = start_idx;
+
+  double min_speed_limit = NO_SPEED_LIMIT;
+  bool found_any_limit = false;
+
+  // Initialize last_sample_dist such that the first pose is always sampled.
+  double dist_along_path = 0.0;
+  double last_sample_dist = -path_sample_resolution_;
+
+  geometry_msgs::msg::PointStamped lookahead_endpoint;
+  lookahead_endpoint.header.frame_id = global_frame_;
+  lookahead_endpoint.header.stamp = clock_->now();
+  lookahead_endpoint.point.x = robot_pose.position.x;
+  lookahead_endpoint.point.y = robot_pose.position.y;
+  lookahead_endpoint.point.z = robot_pose.position.z;
+
+  // Check robot's current pose to list of poses to be checked
+  double speed_limit_at_robot_pose = NO_SPEED_LIMIT;
+  if (!getSpeedLimitAtPose(robot_pose, speed_limit_at_robot_pose)) {
+    // Pose mapped outside mask or transform failed
+    return NO_SPEED_LIMIT;
+  }
+  if (speed_limit_at_robot_pose != NO_SPEED_LIMIT) {
+    min_speed_limit = speed_limit_at_robot_pose;
+    found_any_limit = true;
+  }
+
+  // Walk poses from start_idx forward. Sample the speed limit at each pose.
+  for (size_t i = start_idx; i < poses.size(); ++i) {
+    if(i > start_idx) {
+      const auto & prev = poses[i - 1].pose.position;
+      const auto & curr = poses[i].pose.position;
+      const double dx = curr.x - prev.x;
+      const double dy = curr.y - prev.y;
+      dist_along_path += std::sqrt(dx * dx + dy * dy);
+    }
+
+    if (dist_along_path > lookahead_dist) {
+      break;
+    }
+
+    if (dist_along_path - last_sample_dist < path_sample_resolution_) {
+      continue;
+    }
+    last_sample_dist = dist_along_path;
+
+    lookahead_endpoint.point = poses[i].pose.position;
+
+    double sampled_speed_limit = NO_SPEED_LIMIT;
+    if (!getSpeedLimitAtPose(poses[i].pose, sampled_speed_limit)) {
+      // Pose mapped outside mask or transform failed
+      continue;
+    }
+    if (sampled_speed_limit == NO_SPEED_LIMIT) {
+      continue;
+    }
+
+    // Update strictest speed limit
+    if (!found_any_limit) {
+      // First limit found on the lookahead path, set it as the strictest
+      min_speed_limit = sampled_speed_limit;
+      found_any_limit = true;
+    } else {
+      min_speed_limit = std::min(min_speed_limit, sampled_speed_limit);
+    }
+  }
+
+  if (publish_lookahead_ && lookahead_pub_) {
+    lookahead_pub_->publish(lookahead_endpoint);
+  }
+
+  return min_speed_limit;
+}
+
 void SpeedFilter::process(
   nav2_costmap_2d::Costmap2D & /*master_grid*/,
   int /*min_i*/, int /*min_j*/, int /*max_i*/, int /*max_j*/,
@@ -189,59 +450,32 @@ void SpeedFilter::process(
     return;
   }
 
-  geometry_msgs::msg::Pose mask_pose;  // robot coordinates in mask frame
+  // Decide path lookahead vs just checking at robot pose. Path lookahead requires
+  // the feature enabled, a non-empty path received, and the OdomSmoother
+  // available to query current speed
+  const bool use_path_lookahead =
+    enable_path_lookahead_ &&
+    current_path_ && !current_path_->poses.empty() &&
+    odom_smoother_;
 
-  // Transforming robot pose from current layer frame to mask frame
-  if (!transformPose(global_frame_, pose, filter_mask_->header.frame_id, mask_pose)) {
-    return;
-  }
+  if (use_path_lookahead) {
+    const auto twist = odom_smoother_->getTwist();
+    const double linear_vel = std::abs(twist.linear.x);
 
-  // Converting mask_pose robot position to filter_mask_ indexes (mask_robot_i, mask_robot_j)
-  unsigned int mask_robot_i, mask_robot_j;
-  if (!nav2_util::worldToMap(
-      filter_mask_, mask_pose.position.x, mask_pose.position.y,
-      mask_robot_i, mask_robot_j))
-  {
-    return;
-  }
-
-  // Getting filter_mask data from cell where the robot placed and
-  // calculating speed limit value
-  int8_t speed_mask_data = getMaskData(filter_mask_, mask_robot_i, mask_robot_j);
-  if (speed_mask_data == SPEED_MASK_NO_LIMIT) {
-    // Corresponding filter mask cell is free.
-    // Setting no speed limit there.
-    speed_limit_ = NO_SPEED_LIMIT;
-  } else if (speed_mask_data == SPEED_MASK_UNKNOWN) {
-    // Corresponding filter mask cell is unknown.
-    // Do nothing.
-    RCLCPP_ERROR(
-      logger_,
-      "SpeedFilter: Found unknown cell in filter_mask[%i, %i], "
-      "which is invalid for this kind of filter",
-      mask_robot_i, mask_robot_j);
-    return;
-  } else {
-    // Normal case: speed_mask_data in range of [1..100]
-    speed_limit_ = speed_mask_data * multiplier_ + base_;
-    if (percentage_) {
-      if (speed_limit_ < 0.0 || speed_limit_ > 100.0) {
-        RCLCPP_WARN(
-          logger_,
-          "SpeedFilter: Speed limit in filter_mask[%i, %i] is %f%%, "
-          "out of bounds of [0, 100]. Setting it to no-limit value.",
-          mask_robot_i, mask_robot_j, speed_limit_);
-        speed_limit_ = NO_SPEED_LIMIT;
-      }
+    // Calculate lookahead distance at current velocity
+    double d_lookahead;
+    if (max_decel_ > 0.0) {
+      d_lookahead = (linear_vel * linear_vel) / (2.0 * max_decel_);
+      d_lookahead = std::clamp(d_lookahead, min_lookahead_, max_lookahead_);
     } else {
-      if (speed_limit_ < 0.0) {
-        RCLCPP_WARN(
-          logger_,
-          "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0 m/s, "
-          "which can not be true. Setting it to no-limit value.",
-          mask_robot_i, mask_robot_j);
-        speed_limit_ = NO_SPEED_LIMIT;
-      }
+      d_lookahead = max_lookahead_;
+    }
+
+    speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
+  } else {
+    if(!getSpeedLimitAtPose(pose, speed_limit_)) {
+      RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit at pose");
+      return;
     }
   }
 
@@ -274,6 +508,10 @@ void SpeedFilter::resetFilter()
   if (speed_limit_pub_) {
     speed_limit_pub_->on_deactivate();
     speed_limit_pub_.reset();
+  }
+  if (lookahead_pub_) {
+    lookahead_pub_->on_deactivate();
+    lookahead_pub_.reset();
   }
 }
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -52,7 +52,7 @@ SpeedFilter::SpeedFilter()
 : filter_info_sub_(nullptr), mask_sub_(nullptr),
   speed_limit_pub_(nullptr), filter_mask_(nullptr), global_frame_(""),
   speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT),
-  cached_start_idx_(0)
+  cached_lookahead_start_idx_(0)
 {
 }
 
@@ -95,7 +95,7 @@ void SpeedFilter::initializeFilter(
       RCLCPP_WARN(
         logger_,
         "SpeedFilter: max_decel = %f is non-positive,"
-        "lookahead distance will be clamped to max_lookahead",
+        "lookahead distance will be set to max_lookahead",
           max_decel_);
     }
     if (min_lookahead_ < 0.0) {
@@ -253,7 +253,7 @@ void SpeedFilter::pathCallback(
   std::lock_guard<CostmapFilter::mutex_t> guard(*getMutex());
   current_path_ = msg;
   // Reset cached start index when new path is received
-  cached_start_idx_ = 0;
+  cached_lookahead_start_idx_ = 0;
 }
 
 bool SpeedFilter::getSpeedLimitAtPose(
@@ -326,9 +326,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   const auto & poses = current_path_->poses;
 
   // Validate frame id
-  if (!current_path_->header.frame_id.empty() &&
-    current_path_->header.frame_id != global_frame_)
-  {
+  if (current_path_->header.frame_id != global_frame_) {
     RCLCPP_WARN_THROTTLE(
       logger_, *(clock_), 5000,
       "SpeedFilter: Path frame [%s] differs from costmap global frame [%s],"
@@ -337,30 +335,30 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     return NO_SPEED_LIMIT;
   }
 
-  const size_t search_start =
-    (cached_start_idx_ < poses.size()) ? cached_start_idx_ : 0;
+  const size_t pose_search_start =
+    (cached_lookahead_start_idx_ < poses.size()) ? cached_lookahead_start_idx_ : 0;
 
-  size_t start_idx = search_start;
+  size_t lookahead_start_idx = pose_search_start;
   double min_dist = std::numeric_limits<double>::max();
 
   // Find the closest pose to the robot
   // To save computation time, stop searching path when poses get further than
   // the closest pose + a threshold
-  for (size_t i = search_start; i < poses.size(); i++) {
+  for (size_t i = pose_search_start; i < poses.size(); i++) {
     const auto & p = poses[i].pose.position;
     const double dx = p.x - robot_pose.position.x;
     const double dy = p.y - robot_pose.position.y;
     const double d = std::sqrt(dx * dx + dy * dy);
     if (d < min_dist) {
       min_dist = d;
-      start_idx = i;
+      lookahead_start_idx = i;
     } else if (d > min_dist + POSE_SEARCH_EXIT_THRESHOLD_) {
       break;
     }
   }
 
   // Update cached start index
-  cached_start_idx_ = start_idx;
+  cached_lookahead_start_idx_ = lookahead_start_idx;
 
   double min_speed_limit = NO_SPEED_LIMIT;
   bool found_any_limit = false;
@@ -386,9 +384,9 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     found_any_limit = true;
   }
 
-  // Walk poses from start_idx forward. Sample the speed limit at each pose.
-  for (size_t i = start_idx; i < poses.size(); ++i) {
-    if(i > start_idx) {
+  // Walk poses from lookahead_start_idx forward. Sample the speed limit at each pose.
+  for (size_t i = lookahead_start_idx; i < poses.size(); ++i) {
+    if(i > lookahead_start_idx) {
       const auto & prev = poses[i - 1].pose.position;
       const auto & curr = poses[i].pose.position;
       const double dx = curr.x - prev.x;
@@ -405,6 +403,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     }
     last_sample_dist = dist_along_path;
 
+    // Update lookahead endpoint for visualization
     lookahead_endpoint.point = poses[i].pose.position;
 
     double sampled_speed_limit = NO_SPEED_LIMIT;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -338,7 +338,6 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   }
 
   const auto & poses = transformed_path.poses;
-
   const size_t pose_search_start =
     (lookahead_start_idx_ < poses.size()) ? lookahead_start_idx_ : 0;
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -154,7 +154,7 @@ void SpeedFilter::initializeFilter(
 
   // Reset path lookahead states
   held_lookahead_dist_ = 0.0;
-  cached_lookahead_start_idx_ = 0;
+  lookahead_start_idx_ = 0;
   limit_at_robot_pose_ = NO_SPEED_LIMIT;
 }
 
@@ -245,7 +245,7 @@ void SpeedFilter::pathCallback(
   current_path_ = msg;
 
   // Reset cached start index when new path is received
-  cached_lookahead_start_idx_ = 0;
+  lookahead_start_idx_ = 0;
 }
 
 bool SpeedFilter::getSpeedLimitAtPose(
@@ -315,7 +315,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double lookahead_dist)
 {
   // Transform path if not in the global frame
-  nav_msgs::msg::Path transformed_path;
+  nav_msgs::msg::Path transformed_path = *current_path_;
   if(current_path_->header.frame_id != global_frame_) {
     if(!nav2_util::transformPathInTargetFrame(*current_path_, transformed_path, *tf_,
         global_frame_))
@@ -325,23 +325,19 @@ double SpeedFilter::getSpeedLimitFromLookahead(
           "no speed limit will be published");
       return NO_SPEED_LIMIT;
     }
-  } else {
-    transformed_path = *current_path_;
   }
 
   const auto & poses = transformed_path.poses;
 
   const size_t pose_search_start =
-    (cached_lookahead_start_idx_ < poses.size()) ? cached_lookahead_start_idx_ : 0;
+    (lookahead_start_idx_ < poses.size()) ? lookahead_start_idx_ : 0;
 
   // Find the closest segment to the robot
   auto path_search_result = nav2_util::distance_from_path(
     transformed_path, robot_pose, pose_search_start);
 
-  size_t lookahead_start_idx = path_search_result.closest_segment_index;
-
   // Update cached start index
-  cached_lookahead_start_idx_ = lookahead_start_idx;
+  lookahead_start_idx_ = path_search_result.closest_segment_index;
 
   double min_speed_limit = NO_SPEED_LIMIT;
   bool found_any_limit = false;
@@ -365,10 +361,10 @@ double SpeedFilter::getSpeedLimitFromLookahead(
     found_any_limit = true;
   }
 
-  // Walk poses from lookahead_start_idx forward, sampling the speed limit at each pose.
+  // Walk poses from the lookahead start index forward, sampling the speed limit at each pose.
   double dist_along_path = 0.0;
-  for (size_t i = lookahead_start_idx; i < poses.size(); ++i) {
-    if (i > lookahead_start_idx) {
+  for (size_t i = lookahead_start_idx_; i < poses.size(); ++i) {
+    if (i > lookahead_start_idx_) {
       dist_along_path += nav2_util::geometry_utils::euclidean_distance(
         poses[i - 1].pose.position, poses[i].pose.position);
     }

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -247,7 +247,22 @@ void SpeedFilter::pathCallback(
   const nav_msgs::msg::Path::ConstSharedPtr & msg)
 {
   std::lock_guard<CostmapFilter::mutex_t> guard(*getMutex());
-  current_path_ = msg;
+
+  current_path_ = std::make_shared<nav_msgs::msg::Path>();
+
+  // Transform path if not in the global frame
+  if(msg->header.frame_id != global_frame_) {
+    auto transformed_path = std::make_shared<nav_msgs::msg::Path>();
+    if(nav2_util::transformPathInTargetFrame(*msg, *transformed_path, *tf_, global_frame_)) {
+      current_path_ = transformed_path;
+    } else {
+      RCLCPP_ERROR(logger_,
+          "SpeedFilter: Failed to transform path to global frame, skipping path lookahead");
+    }
+  } else {
+    current_path_ = msg;
+  }
+
   // Reset cached start index when new path is received
   cached_lookahead_start_idx_ = 0;
 }
@@ -319,16 +334,6 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double lookahead_dist)
 {
   const auto & poses = current_path_->poses;
-
-  // Validate frame id
-  if (current_path_->header.frame_id != global_frame_) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *(clock_), 5000,
-      "SpeedFilter: Path frame [%s] differs from costmap global frame [%s],"
-      "skipping path lookahead",
-      current_path_->header.frame_id.c_str(), global_frame_.c_str());
-    return NO_SPEED_LIMIT;
-  }
 
   const size_t pose_search_start =
     (cached_lookahead_start_idx_ < poses.size()) ? cached_lookahead_start_idx_ : 0;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -334,22 +334,11 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   const size_t pose_search_start =
     (cached_lookahead_start_idx_ < poses.size()) ? cached_lookahead_start_idx_ : 0;
 
-  size_t lookahead_start_idx = pose_search_start;
-  double min_dist = std::numeric_limits<double>::max();
+  // Find the closest segment to the robot
+  auto path_search_result = nav2_util::distance_from_path(
+    transformed_path, robot_pose, pose_search_start);
 
-  // Find the closest pose to the robot
-  // To save computation time, stop searching path when poses get further than
-  // the closest pose + a threshold
-  for (size_t i = pose_search_start; i < poses.size(); i++) {
-    const double d = nav2_util::geometry_utils::euclidean_distance(
-      poses[i].pose.position, robot_pose.position);
-    if (d < min_dist) {
-      min_dist = d;
-      lookahead_start_idx = i;
-    } else if (d > min_dist + POSE_SEARCH_EXIT_THRESHOLD_) {
-      break;
-    }
-  }
+  size_t lookahead_start_idx = path_search_result.closest_segment_index;
 
   // Update cached start index
   cached_lookahead_start_idx_ = lookahead_start_idx;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -310,11 +310,12 @@ bool SpeedFilter::getSpeedLimitAtPose(
   return true;
 }
 
-double SpeedFilter::getSpeedLimitFromLookahead(
+bool SpeedFilter::getSpeedLimitFromLookahead(
   const geometry_msgs::msg::Pose & robot_pose,
-  double lookahead_dist)
+  double lookahead_dist,
+  double & speed_limit)
 {
-  double min_speed_limit = std::numeric_limits<double>::infinity();
+  double min_speed_limit = std::numeric_limits<double>::max();
 
   // Release the hold by default, a stricter limit ahead re-arms it
   held_lookahead_dist_ = 0.0;
@@ -334,7 +335,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
       RCLCPP_ERROR_THROTTLE(logger_, *(clock_), 5000,
           "SpeedFilter: Failed to transform path to global frame, "
           "no speed limit will be published");
-      return NO_SPEED_LIMIT;
+      return false;
     }
   } else {
     transformed_path = *current_path_;
@@ -352,11 +353,13 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   double limit_at_robot_pose = NO_SPEED_LIMIT;
   if (!getSpeedLimitAtPose(robot_pose, limit_at_robot_pose)) {
     // Pose mapped outside mask or transform failed
-    return NO_SPEED_LIMIT;
+    RCLCPP_ERROR_THROTTLE(logger_, *(clock_), 5000,
+        "SpeedFilter: Failed to get speed limit at robot pose");
+    return false;
   }
 
   if (limit_at_robot_pose != NO_SPEED_LIMIT) {
-    min_speed_limit = std::min(min_speed_limit, limit_at_robot_pose);
+    min_speed_limit = limit_at_robot_pose;
   }
 
   // Walk poses from the lookahead start index forward, sampling the speed limit at each pose.
@@ -388,7 +391,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   }
 
   // No limit found anywhere along the lookahead, fall back to no-limit
-  if (std::isinf(min_speed_limit)) {
+  if (min_speed_limit == std::numeric_limits<double>::max()) {
     min_speed_limit = NO_SPEED_LIMIT;
   }
 
@@ -396,7 +399,9 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   if (limit_at_robot_pose != min_speed_limit) {
     held_lookahead_dist_ = lookahead_dist;
   }
-  return min_speed_limit;
+
+  speed_limit = min_speed_limit;
+  return true;
 }
 
 void SpeedFilter::process(
@@ -434,7 +439,10 @@ void SpeedFilter::process(
       d_lookahead = std::max(d_lookahead, held_lookahead_dist_);
     }
 
-    speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
+    if (!getSpeedLimitFromLookahead(pose, d_lookahead, speed_limit_)) {
+      RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit from lookahead");
+      return;
+    }
   } else {
     if (!getSpeedLimitAtPose(pose, speed_limit_)) {
       RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit at pose");

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -52,7 +52,7 @@ SpeedFilter::SpeedFilter()
 : filter_info_sub_(nullptr), mask_sub_(nullptr),
   speed_limit_pub_(nullptr), filter_mask_(nullptr), global_frame_(""),
   speed_limit_(NO_SPEED_LIMIT), speed_limit_prev_(NO_SPEED_LIMIT),
-  cached_lookahead_start_idx_(0)
+  held_lookahead_dist_(0.0), cached_lookahead_start_idx_(0)
 {
 }
 
@@ -456,11 +456,25 @@ void SpeedFilter::process(
     if (max_decel_ < 0.0) {
       d_lookahead = (linear_vel * linear_vel) / (2.0 * std::abs(max_decel_));
       d_lookahead = std::clamp(d_lookahead, min_lookahead_, max_lookahead_);
+
+      // If a limit is currently active, don't let the lookahead shrink below
+      // the one that captured the speed zone
+      if(speed_limit_ != NO_SPEED_LIMIT) {
+        d_lookahead = std::max(d_lookahead, held_lookahead_dist_);
+      }
     } else {
       d_lookahead = max_lookahead_;
     }
 
     speed_limit_ = getSpeedLimitFromLookahead(pose, d_lookahead);
+
+    // If a limit is currently active, hold the lookahead distance
+    if(speed_limit_ != NO_SPEED_LIMIT) {
+      held_lookahead_dist_ = d_lookahead;
+    } else {
+      // If no limit is currently active, reset the held distance
+      held_lookahead_dist_ = 0.0;
+    }
   } else {
     if (!getSpeedLimitAtPose(pose, speed_limit_)) {
       RCLCPP_ERROR(logger_, "SpeedFilter: Failed to get speed limit at pose");
@@ -502,6 +516,8 @@ void SpeedFilter::resetFilter()
     lookahead_pub_->on_deactivate();
     lookahead_pub_.reset();
   }
+  held_lookahead_dist_ = 0.0;
+  cached_lookahead_start_idx_ = 0;
 }
 
 bool SpeedFilter::isActive()

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -325,7 +325,7 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   lookahead_point_msg->header.stamp = clock_->now();
 
   // Transform path if not in the global frame
-  nav_msgs::msg::Path transformed_path = *current_path_;
+  nav_msgs::msg::Path transformed_path;
   if(current_path_->header.frame_id != global_frame_) {
     if(!nav2_util::transformPathInTargetFrame(*current_path_, transformed_path, *tf_,
         global_frame_))
@@ -335,6 +335,8 @@ double SpeedFilter::getSpeedLimitFromLookahead(
           "no speed limit will be published");
       return NO_SPEED_LIMIT;
     }
+  } else {
+    transformed_path = *current_path_;
   }
 
   const auto & poses = transformed_path.poses;

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -242,20 +242,7 @@ void SpeedFilter::pathCallback(
 {
   std::lock_guard<CostmapFilter::mutex_t> guard(*getMutex());
 
-  current_path_ = std::make_shared<nav_msgs::msg::Path>();
-
-  // Transform path if not in the global frame
-  if(msg->header.frame_id != global_frame_) {
-    auto transformed_path = std::make_shared<nav_msgs::msg::Path>();
-    if(nav2_util::transformPathInTargetFrame(*msg, *transformed_path, *tf_, global_frame_)) {
-      current_path_ = transformed_path;
-    } else {
-      RCLCPP_ERROR(logger_,
-          "SpeedFilter: Failed to transform path to global frame, skipping path lookahead");
-    }
-  } else {
-    current_path_ = msg;
-  }
+  current_path_ = msg;
 
   // Reset cached start index when new path is received
   cached_lookahead_start_idx_ = 0;
@@ -327,7 +314,22 @@ double SpeedFilter::getSpeedLimitFromLookahead(
   const geometry_msgs::msg::Pose & robot_pose,
   double lookahead_dist)
 {
-  const auto & poses = current_path_->poses;
+  // Transform path if not in the global frame
+  nav_msgs::msg::Path transformed_path;
+  if(current_path_->header.frame_id != global_frame_) {
+    if(!nav2_util::transformPathInTargetFrame(*current_path_, transformed_path, *tf_,
+        global_frame_))
+    {
+      RCLCPP_ERROR_THROTTLE(logger_, *(clock_), 5000,
+          "SpeedFilter: Failed to transform path to global frame, "
+          "no speed limit will be published");
+      return NO_SPEED_LIMIT;
+    }
+  } else {
+    transformed_path = *current_path_;
+  }
+
+  const auto & poses = transformed_path.poses;
 
   const size_t pose_search_start =
     (cached_lookahead_start_idx_ < poses.size()) ? cached_lookahead_start_idx_ : 0;

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -51,6 +51,18 @@ static const uint8_t INCORRECT_TYPE = 200;
 
 static constexpr double EPSILON = 1e-5;
 
+struct PathLookaheadParams
+{
+  bool enable_path_lookahead = false;
+  double max_decel = 0.5;
+  double min_lookahead = 0.0;
+  double max_lookahead = 5.0;
+  double path_sample_resolution = 0.1;
+  std::string path_topic = "plan";
+  std::string odom_topic = "odom";
+  bool publish_lookahead = false;
+};
+
 class InfoPublisher : public rclcpp::Node
 {
 public:
@@ -100,6 +112,54 @@ public:
 private:
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr publisher_;
 };  // MaskPublisher
+
+class PathPublisher : public rclcpp::Node
+{
+public:
+  explicit PathPublisher(const nav_msgs::msg::Path & path)
+  : Node("path_pub")
+  {
+    publisher_ = this->create_publisher<nav_msgs::msg::Path>(
+      "plan", rclcpp::QoS(10));
+    publisher_->publish(path);
+  }
+
+  ~PathPublisher()
+  {
+    publisher_.reset();
+  }
+
+private:
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr publisher_;
+};  // PathPublisher
+
+class OdomPublisher : public rclcpp::Node
+{
+public:
+  OdomPublisher()
+  : Node("odom_pub")
+  {
+    publisher_ = this->create_publisher<nav_msgs::msg::Odometry>("odom", rclcpp::QoS(1));
+  }
+
+  ~OdomPublisher()
+  {
+    publisher_.reset();
+  }
+
+  void publishVelocity(double vx)
+  {
+    nav_msgs::msg::Odometry msg;
+    msg.header.frame_id = "odom";
+    msg.child_frame_id = "base_link";
+    msg.header.stamp = this->now();
+    msg.twist.twist.linear.x = vx;
+    publisher_->publish(msg);
+  }
+
+private:
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr publisher_;
+};  // OdomPublisher
 
 class SpeedLimitSubscriber : public rclcpp::Node
 {
@@ -211,9 +271,14 @@ protected:
   void publishMaps(uint8_t type, double base, double multiplier);
   void rePublishInfo(uint8_t type, double base, double multiplier);
   void rePublishMask();
-  bool createSpeedFilter(const std::string & global_frame);
+  bool createSpeedFilter(const std::string & global_frame, const PathLookaheadParams & params = {});
   void createTFBroadcaster(const std::string & mask_frame, const std::string & global_frame);
   void publishTransform();
+  void publishPath(const nav_msgs::msg::Path & path);
+  void publishOdom(double vx);
+  nav_msgs::msg::Path createPath(
+    double x0, double y0, double x1, double y1, double spacing,
+    const std::string & frame_id);
 
   // Test methods
   void testFullMask(
@@ -224,6 +289,7 @@ protected:
     double tr_x, double tr_y);
   void testOutOfMask(uint8_t type, double base, double multiplier);
   void testIncorrectLimits(uint8_t type, double base, double multiplier);
+  void testPathLookaheadDetection(uint8_t type, double base, double multiplier, double linear_vel);
 
   void reset();
 
@@ -255,6 +321,8 @@ private:
 
   std::shared_ptr<InfoPublisher> info_publisher_;
   std::shared_ptr<MaskPublisher> mask_publisher_;
+  std::shared_ptr<PathPublisher> path_publisher_;
+  std::shared_ptr<OdomPublisher> odom_publisher_;
   std::shared_ptr<SpeedLimitSubscriber> speed_limit_subscriber_;
   rclcpp::executors::SingleThreadedExecutor speed_limit_subscriber_executor_;
 };
@@ -307,6 +375,21 @@ void TestNode::rePublishMask()
   waitSome(100ms);
 }
 
+void TestNode::publishPath(const nav_msgs::msg::Path & path)
+{
+  path_publisher_ = std::make_shared<PathPublisher>(path);
+  // Allow path subscriber to receive a new message
+  waitSome(100ms);
+}
+
+void TestNode::publishOdom(double vx)
+{
+  odom_publisher_ = std::make_shared<OdomPublisher>();
+  odom_publisher_->publishVelocity(vx);
+  // Allow odom subscriber to receive a new message
+  waitSome(100ms);
+}
+
 nav2_msgs::msg::SpeedLimit::ConstSharedPtr TestNode::getSpeedLimit()
 {
   std::this_thread::sleep_for(100ms);
@@ -341,7 +424,9 @@ void TestNode::waitSome(const std::chrono::nanoseconds & duration)
   }
 }
 
-bool TestNode::createSpeedFilter(const std::string & global_frame)
+bool TestNode::createSpeedFilter(
+  const std::string & global_frame,
+  const PathLookaheadParams & params)
 {
   node_ = std::make_shared<nav2::LifecycleNode>("test_node");
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
@@ -362,6 +447,46 @@ bool TestNode::createSpeedFilter(const std::string & global_frame)
     std::string(FILTER_NAME) + ".speed_limit_topic", rclcpp::ParameterValue(SPEED_LIMIT_TOPIC));
   node_->set_parameter(
     rclcpp::Parameter(std::string(FILTER_NAME) + ".speed_limit_topic", SPEED_LIMIT_TOPIC));
+
+  if (params.enable_path_lookahead) {
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".enable_path_lookahead",
+      rclcpp::ParameterValue(params.enable_path_lookahead));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".enable_path_lookahead",
+      params.enable_path_lookahead));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".max_decel", rclcpp::ParameterValue(params.max_decel));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".max_decel", params.max_decel));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".min_lookahead", rclcpp::ParameterValue(params.min_lookahead));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".min_lookahead", params.min_lookahead));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".max_lookahead", rclcpp::ParameterValue(params.max_lookahead));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".max_lookahead", params.max_lookahead));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".path_sample_resolution",
+      rclcpp::ParameterValue(params.path_sample_resolution));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".path_sample_resolution",
+      params.path_sample_resolution));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".path_topic", rclcpp::ParameterValue(params.path_topic));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".path_topic", params.path_topic));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".odom_topic", rclcpp::ParameterValue(params.odom_topic));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".odom_topic", params.odom_topic));
+    node_->declare_parameter(
+      std::string(FILTER_NAME) + ".publish_lookahead",
+      rclcpp::ParameterValue(params.publish_lookahead));
+    node_->set_parameter(
+      rclcpp::Parameter(std::string(FILTER_NAME) + ".publish_lookahead", params.publish_lookahead));
+  }
 
   speed_filter_ = std::make_shared<nav2_costmap_2d::SpeedFilter>();
   speed_filter_->initialize(&layers, FILTER_NAME, tf_buffer_.get(), node_, nullptr);
@@ -441,6 +566,28 @@ void TestNode::verifySpeedLimit(
   } else {
     FAIL() << "The type of costmap filter is unknown";
   }
+}
+
+nav_msgs::msg::Path TestNode::createPath(
+  double x0, double y0, double x1, double y1, double spacing = 0.1,
+  const std::string & frame_id = "map")
+{
+  nav_msgs::msg::Path path;
+  path.header.frame_id = frame_id;
+  path.header.stamp = node_->now();
+  const double dx = x1 - x0;
+  const double dy = y1 - y0;
+  const double len = std::hypot(dx, dy);
+  const size_t n = static_cast<size_t>(len / spacing) + 1;
+  for (size_t i = 0; i <= n; ++i) {
+    geometry_msgs::msg::PoseStamped p;
+    p.header.frame_id = frame_id;
+    const double t = (n == 0) ? 0.0 : static_cast<double>(i) / n;
+    p.pose.position.x = x0 + t * dx;
+    p.pose.position.y = y0 + t * dy;
+    path.poses.push_back(p);
+  }
+  return path;
 }
 
 void TestNode::testFullMask(
@@ -622,6 +769,34 @@ void TestNode::testIncorrectLimits(uint8_t type, double base, double multiplier)
   }
 }
 
+void TestNode::testPathLookaheadDetection(
+  uint8_t type, double base, double multiplier,
+  double linear_vel)
+{
+  const int min_i = 0;
+  const int min_j = 0;
+  const int max_i = width_ + 4;
+  const int max_j = height_ + 4;
+
+  // Robot at (2, 0): a free cell (mask data = 0 in the bottom row).
+  // Path runs (2, 0) -> (2, 5), entering the speed-restricted region (y >= 1).
+  // First in-zone cell along the path is (2, 1) with data = 3
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 2.0;
+  pose.position.y = 0.0;
+
+  publishPath(createPath(2.0, 0.0, 2.0, 5.0, 0.5));
+  publishOdom(linear_vel);
+  publishTransform();
+  waitSome(100ms);
+
+  speed_filter_->process(*master_grid_, min_i, min_j, max_i, max_j, pose);
+  auto speed_limit = waitSpeedLimit();
+  ASSERT_TRUE(speed_limit != nullptr);
+
+  verifySpeedLimit(type, base, multiplier, 2, 1, speed_limit);
+}
+
 void TestNode::reset()
 {
   mask_.reset();
@@ -774,6 +949,44 @@ TEST_F(TestNode, testDifferentFrame)
   testFullMask(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, TRANSLATION_X, TRANSLATION_Y);
 
   // Clean-up
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadDetectsZoneAhead)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = 0.2;
+  params.min_lookahead = 0.0;
+  params.max_lookahead = 5.0;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  testPathLookaheadDetection(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadFallBackToRobotPose)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = 0.2;
+  params.min_lookahead = 0.0;
+  params.max_lookahead = 5.0;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  // No path or odom published, filter should fall back to just checking at robot pose
+  testSimpleMask(
+    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, NO_TRANSLATION, NO_TRANSLATION);
+
   speed_filter_->resetFilter();
   reset();
 }

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -57,7 +57,6 @@ struct PathLookaheadParams
   double max_decel = -0.5;
   double min_lookahead = 0.0;
   double max_lookahead = 5.0;
-  double path_sample_resolution = 0.1;
   std::string path_topic = "plan";
   std::string odom_topic = "odom";
   bool publish_lookahead = false;
@@ -469,12 +468,6 @@ bool TestNode::createSpeedFilter(
       std::string(FILTER_NAME) + ".max_lookahead", rclcpp::ParameterValue(params.max_lookahead));
     node_->set_parameter(
       rclcpp::Parameter(std::string(FILTER_NAME) + ".max_lookahead", params.max_lookahead));
-    node_->declare_parameter(
-      std::string(FILTER_NAME) + ".path_sample_resolution",
-      rclcpp::ParameterValue(params.path_sample_resolution));
-    node_->set_parameter(
-      rclcpp::Parameter(std::string(FILTER_NAME) + ".path_sample_resolution",
-      params.path_sample_resolution));
     node_->declare_parameter(
       std::string(FILTER_NAME) + ".path_topic", rclcpp::ParameterValue(params.path_topic));
     node_->set_parameter(
@@ -1028,7 +1021,6 @@ TEST_F(TestNode, testPathLookaheadInvalidDecel)
   params.max_decel = 0.0;  // invalid
   params.min_lookahead = 0.3;
   params.max_lookahead = 5.0;
-  params.path_sample_resolution = 0.1;
   EXPECT_TRUE(createSpeedFilter("map", params));
 
   testPathLookaheadDetection(
@@ -1049,7 +1041,6 @@ TEST_F(TestNode, testPathLookaheadInvalidMinLookahead)
   params.max_decel = -0.25;
   params.min_lookahead = -1.0;  // invalid: gets clamped to 0
   params.max_lookahead = 5.0;
-  params.path_sample_resolution = 0.5;
   EXPECT_TRUE(createSpeedFilter("map", params));
 
   // Filter still works, min_lookahead was reset to 0.0
@@ -1071,28 +1062,6 @@ TEST_F(TestNode, testPathLookaheadInvalidMaxLookahead)
   params.max_decel = -0.5;
   params.min_lookahead = 2.0;
   params.max_lookahead = 0.5;  // invalid: less than min, gets clamped up to min
-  params.path_sample_resolution = 0.5;
-  EXPECT_TRUE(createSpeedFilter("map", params));
-
-  testPathLookaheadDetection(
-    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0,
-    NO_TRANSLATION, NO_TRANSLATION);
-
-  speed_filter_->resetFilter();
-  reset();
-}
-
-TEST_F(TestNode, testPathLookaheadInvalidPathSampleResolution)
-{
-  createMaps("map");
-  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
-
-  PathLookaheadParams params;
-  params.enable_path_lookahead = true;
-  params.max_decel = -0.5;
-  params.min_lookahead = 5.0;
-  params.max_lookahead = 10.0;
-  params.path_sample_resolution = -0.5;  // invalid: gets reset to 0.1
   EXPECT_TRUE(createSpeedFilter("map", params));
 
   testPathLookaheadDetection(

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -54,7 +54,7 @@ static constexpr double EPSILON = 1e-5;
 struct PathLookaheadParams
 {
   bool enable_path_lookahead = false;
-  double max_decel = 0.5;
+  double max_decel = -0.5;
   double min_lookahead = 0.0;
   double max_lookahead = 5.0;
   double path_sample_resolution = 0.1;
@@ -964,7 +964,7 @@ TEST_F(TestNode, testPathLookaheadDetectsZoneAhead)
 
   PathLookaheadParams params;
   params.enable_path_lookahead = true;
-  params.max_decel = 0.2;
+  params.max_decel = -0.2;
   params.min_lookahead = 0.0;
   params.max_lookahead = 5.0;
   EXPECT_TRUE(createSpeedFilter("map", params));
@@ -983,7 +983,7 @@ TEST_F(TestNode, testPathLookaheadFallBackToRobotPose)
 
   PathLookaheadParams params;
   params.enable_path_lookahead = true;
-  params.max_decel = 0.2;
+  params.max_decel = -0.2;
   params.min_lookahead = 0.0;
   params.max_lookahead = 5.0;
   EXPECT_TRUE(createSpeedFilter("map", params));
@@ -1003,7 +1003,7 @@ TEST_F(TestNode, testPathLookaheadWithDifferentFrame)
 
   PathLookaheadParams params;
   params.enable_path_lookahead = true;
-  params.max_decel = 0.2;
+  params.max_decel = -0.2;
   params.min_lookahead = 0.0;
   params.max_lookahead = 5.0;
   EXPECT_TRUE(createSpeedFilter("map", params));

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -289,7 +289,9 @@ protected:
     double tr_x, double tr_y);
   void testOutOfMask(uint8_t type, double base, double multiplier);
   void testIncorrectLimits(uint8_t type, double base, double multiplier);
-  void testPathLookaheadDetection(uint8_t type, double base, double multiplier, double linear_vel);
+  void testPathLookaheadDetection(
+    uint8_t type, double base, double multiplier, double linear_vel,
+    double tr_x, double tr_y);
 
   void reset();
 
@@ -771,7 +773,7 @@ void TestNode::testIncorrectLimits(uint8_t type, double base, double multiplier)
 
 void TestNode::testPathLookaheadDetection(
   uint8_t type, double base, double multiplier,
-  double linear_vel)
+  double linear_vel, double tr_x, double tr_y)
 {
   const int min_i = 0;
   const int min_j = 0;
@@ -785,9 +787,11 @@ void TestNode::testPathLookaheadDetection(
   pose.position.x = 2.0;
   pose.position.y = 0.0;
 
-  publishPath(createPath(2.0, 0.0, 2.0, 5.0, 0.5));
   publishOdom(linear_vel);
   publishTransform();
+
+  const std::string path_frame = (tr_x == 0.0 || tr_y == 0.0) ? "map" : "odom";
+  publishPath(createPath(2.0 - tr_x, 0.0 - tr_y, 2.0 - tr_x, 5.0 - tr_y, 0.5, path_frame));
   waitSome(100ms);
 
   speed_filter_->process(*master_grid_, min_i, min_j, max_i, max_j, pose);
@@ -965,7 +969,8 @@ TEST_F(TestNode, testPathLookaheadDetectsZoneAhead)
   params.max_lookahead = 5.0;
   EXPECT_TRUE(createSpeedFilter("map", params));
 
-  testPathLookaheadDetection(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0);
+  testPathLookaheadDetection(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0, NO_TRANSLATION,
+    NO_TRANSLATION);
 
   speed_filter_->resetFilter();
   reset();
@@ -986,6 +991,27 @@ TEST_F(TestNode, testPathLookaheadFallBackToRobotPose)
   // No path or odom published, filter should fall back to just checking at robot pose
   testSimpleMask(
     nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, NO_TRANSLATION, NO_TRANSLATION);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadWithDifferentFrame)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = 0.2;
+  params.min_lookahead = 0.0;
+  params.max_lookahead = 5.0;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+  createTFBroadcaster("map", "odom");
+
+  // Path is published in odom frame, but filter is in map frame
+  testPathLookaheadDetection(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0, TRANSLATION_X,
+    TRANSLATION_Y);
 
   speed_filter_->resetFilter();
   reset();

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -1017,6 +1017,92 @@ TEST_F(TestNode, testPathLookaheadWithDifferentFrame)
   reset();
 }
 
+TEST_F(TestNode, testPathLookaheadInvalidDecel)
+{
+  // Covers the max_decel >= 0 fallback and warning.
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = 0.0;  // invalid
+  params.min_lookahead = 0.3;
+  params.max_lookahead = 5.0;
+  params.path_sample_resolution = 0.1;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  testPathLookaheadDetection(
+    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0,
+    1.0, NO_TRANSLATION, NO_TRANSLATION);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadInvalidMinLookahead)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = -0.25;
+  params.min_lookahead = -1.0;  // invalid: gets clamped to 0
+  params.max_lookahead = 5.0;
+  params.path_sample_resolution = 0.5;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  // Filter still works, min_lookahead was reset to 0.0
+  testPathLookaheadDetection(
+    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0,
+    NO_TRANSLATION, NO_TRANSLATION);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadInvalidMaxLookahead)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = -0.5;
+  params.min_lookahead = 2.0;
+  params.max_lookahead = 0.5;  // invalid: less than min, gets clamped up to min
+  params.path_sample_resolution = 0.5;
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  testPathLookaheadDetection(
+    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0,
+    NO_TRANSLATION, NO_TRANSLATION);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
+TEST_F(TestNode, testPathLookaheadInvalidPathSampleResolution)
+{
+  createMaps("map");
+  publishMaps(nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0);
+
+  PathLookaheadParams params;
+  params.enable_path_lookahead = true;
+  params.max_decel = -0.5;
+  params.min_lookahead = 5.0;
+  params.max_lookahead = 10.0;
+  params.path_sample_resolution = -0.5;  // invalid: gets reset to 0.1
+  EXPECT_TRUE(createSpeedFilter("map", params));
+
+  testPathLookaheadDetection(
+    nav2_costmap_2d::SPEED_FILTER_PERCENT, 0.0, 1.0, 1.0,
+    NO_TRANSLATION, NO_TRANSLATION);
+
+  speed_filter_->resetFilter();
+  reset();
+}
+
 int main(int argc, char ** argv)
 {
   // Initialize the system


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu (osrf/ros:jazzy-desktop-full)  |
| Robotic platform tested on | TB4 Gazebo simulation |
| Does this PR contain AI generated software? | Some lines were generated but all were checked manually |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Adds an optional path lookahead mode to the `SpeedFilter` costmap filter. When enabled, the filter looks ahead along the planned path and applies the strictest speed limit found within a window, instead of only checking the cell under the robot. This allows the robot to start decelerating before it enters a speed zone, instead of decelerating after entering the zone.
* Lookahead distance is computed from current odometry speed and a configured `max_decel`: `d = v² / (2·max_decel)`, clamped between `min_lookahead` and `max_lookahead`. Uses `nav2_util::OdomSmoother` to get robot's current velocity input.
* Closest-pose-on-path search is bounded by a cached `start_idx` (advanced on calls, reset on new path received) plus an early-exit on the search once distance starts increasing after having found a minimum. Keeps the search constant time per iteration instead of O(path length).
* All new behavior gated behind `enable_path_lookahead`, defaults to `false`. Existing single-cell behavior is unchanged when disabled.
* Lookahead distance is held when entering a new speed zone to avoid velocity oscillations caused by the velocity <-> loookahead feedback loop
* New params: `enable_path_lookahead`, `max_decel`, `min_lookahead`, `max_lookahead`, `path_sample_resolution`, `path_topic`, `odom_topic`.

## Description of documentation updates required from your changes

* New parameters need to be added to the `SpeedFilter` configuration page on docs.nav2.org
* Tuning guide can mention the new mode and when to enable it. E.g. when zone boundaries are hard limits or sudden deceleration is to be avoided
* Draft Docs PR here: https://github.com/ros-navigation/docs.nav2.org/pull/919

## Description of how this change was tested

* Wrote unit tests for the new path-lookahead code paths in `speed_filter_test.cpp` (detection of upcoming zones, fallback when no path/odom is published). Tested with colcon test.
* Tested end-to-end in TB4 Gazebo simulation with the depot world and the existing `depot_speed.pgm` mask. Verified the speed limit kicks in before entering the speed zone.

---

## Future work that may be required in bullet points

* Only tested on a diff-drive platform with `twist.linear.x`. Omni-directional platforms might need linear.x & linear.y both scaled.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
