### PR TITLE
Add low-frequency MPPI sampling

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -144,6 +144,14 @@ controller_server:
       vx_std: 0.2
       vy_std: 0.2
       wz_std: 0.4
+      sampling_std:
+        reduction_factor: 1.0
+      colored_noise:
+        enabled: false
+        exponent: 2.0
+        offset_t: 1
+        offset_decay_rate: 0.97
+        fmin: 0.0
       vx_max: 0.5
       vx_min: -0.35
       vy_max: 0.5

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -49,6 +49,12 @@ This process is then repeated a number of times and returns a converged solution
  | vx_std                     | double | Default 0.2. Sampling standard deviation for VX                                                          |
  | vy_std                     | double | Default 0.2. Sampling standard deviation for VY                                                          |
  | wz_std                     | double | Default 0.4. Sampling standard deviation for Wz                                                          |
+ | sampling_std.reduction_factor | double | Default 1.0. Multiplier applied to sampling standard deviations on each additional MPPI iteration. Values in `(0.0, 1.0]` are accepted; `1.0` disables per-iteration reduction. |
+ | colored_noise.enabled      | bool   | Default false. When true, samples MPPI perturbations from a low-frequency colored-noise distribution instead of independent white Gaussian noise. |
+ | colored_noise.exponent     | double | Default 2.0. Power-law exponent for colored-noise sampling. `0.0` is white noise; larger values put more energy in lower frequencies for smoother candidate controls. Only read when `colored_noise.enabled` is true. |
+ | colored_noise.offset_t     | int    | Default 1. Offset used when cropping the doubled-horizon colored-noise sequence. Only read when `colored_noise.enabled` is true. |
+ | colored_noise.offset_decay_rate | double | Default 0.97. Decay factor applied to the cropped offset correction. Only read when `colored_noise.enabled` is true. |
+ | colored_noise.fmin         | double | Default 0.0. Relative low-frequency cutoff in `[0.0, 0.5]`; values below `1 / (2 * time_steps)` are mapped to the lowest finite frequency. Only read when `colored_noise.enabled` is true. |
  | vx_max                     | double | Default 0.5. Max VX (m/s)                                                                                |
  | vy_max                     | double | Default 0.5. Max VY in either direction, if holonomic. (m/s)                                             |
  | vx_min                     | double | Default -0.35. Min VX (m/s)                                                                              |
@@ -204,6 +210,14 @@ controller_server:
       vx_std: 0.2
       vy_std: 0.2
       wz_std: 0.4
+      sampling_std:
+        reduction_factor: 1.0
+      colored_noise:
+        enabled: false
+        exponent: 2.0
+        offset_t: 1
+        offset_decay_rate: 0.97
+        fmin: 0.0
       vx_max: 0.5
       vx_min: -0.35
       vy_max: 0.5

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
@@ -41,6 +41,7 @@ struct OptimizerSettings
   size_t retry_attempt_limit{0};
   bool open_loop{false};
   unsigned int sgf_order{2u};
+  float sampling_std_reduction_factor{1.0f};
 };
 
 }  // namespace mppi::models

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/noise_generator.hpp
@@ -34,6 +34,49 @@ namespace mppi
 {
 
 /**
+ * @class mppi::ColoredNoiseGenerator
+ * @brief Generates low-frequency MPPI perturbations with power-law spectral density.
+ */
+class ColoredNoiseGenerator
+{
+public:
+  /**
+   * @brief Configure colored-noise sampling.
+   * @param enabled Whether colored noise is enabled.
+   * @param exponent Power spectral density exponent. 0.0 matches white noise.
+   * @param offset_t Horizon offset used by the doubled-horizon crop.
+   * @param offset_decay_rate Decay applied to the offset correction over the returned horizon.
+   * @param fmin Relative low-frequency cutoff in [0.0, 0.5].
+   * @param logger Logger for configuration warnings.
+   */
+  void configure(
+    bool enabled, float exponent, int offset_t, float offset_decay_rate,
+    float fmin, const rclcpp::Logger & logger);
+
+  /**
+   * @brief Whether colored-noise sampling is enabled.
+   * @return True when enabled.
+   */
+  bool isEnabled() const;
+
+  /**
+   * @brief Generate colored noise for one control axis.
+   * @param noise Output matrix [batch_size, time_steps].
+   * @param sigma Desired standard deviation of the output signal.
+   * @param generator Random engine.
+   */
+  void generate(
+    Eigen::ArrayXXf & noise, float sigma, std::default_random_engine & generator) const;
+
+protected:
+  bool enabled_{false};
+  float exponent_{2.0f};
+  int offset_t_{1};
+  float offset_decay_rate_{0.97f};
+  float fmin_{0.0f};
+};
+
+/**
  * @class mppi::NoiseGenerator
  * @brief Generates noise trajectories from optimal trajectory
  */
@@ -95,6 +138,8 @@ protected:
    */
   void generateNoisedControls();
 
+  ColoredNoiseGenerator colored_noise_generator_;
+
   Eigen::ArrayXXf noises_vx_;
   Eigen::ArrayXXf noises_vy_;
   Eigen::ArrayXXf noises_wz_;
@@ -111,6 +156,7 @@ protected:
   std::condition_variable noise_cond_;
   std::mutex noise_lock_;
   bool active_{false}, ready_{false}, regenerate_noises_{false};
+  rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/src/noise_generator.cpp
+++ b/nav2_mppi_controller/src/noise_generator.cpp
@@ -14,11 +14,158 @@
 
 #include "nav2_mppi_controller/tools/noise_generator.hpp"
 
+#include <unsupported/Eigen/FFT>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 namespace mppi
 {
+
+void ColoredNoiseGenerator::configure(
+  bool enabled, float exponent, int offset_t, float offset_decay_rate,
+  float fmin, const rclcpp::Logger & logger)
+{
+  enabled_ = enabled;
+  if (!enabled_) {
+    return;
+  }
+
+  if (exponent < 0.0f) {
+    RCLCPP_WARN(
+      logger,
+      "colored_noise.exponent must be >= 0.0. Clamping %.3f to 0.0.",
+      exponent);
+    exponent = 0.0f;
+  }
+
+  if (offset_t < 0) {
+    RCLCPP_WARN(
+      logger,
+      "colored_noise.offset_t must be >= 0. Clamping %d to 0.",
+      offset_t);
+    offset_t = 0;
+  }
+
+  if (offset_decay_rate < 0.0f || offset_decay_rate > 1.0f) {
+    const float clamped = std::clamp(offset_decay_rate, 0.0f, 1.0f);
+    RCLCPP_WARN(
+      logger,
+      "colored_noise.offset_decay_rate must be in [0.0, 1.0]. Clamping %.3f to %.3f.",
+      offset_decay_rate, clamped);
+    offset_decay_rate = clamped;
+  }
+
+  if (fmin < 0.0f || fmin > 0.5f) {
+    const float clamped = std::clamp(fmin, 0.0f, 0.5f);
+    RCLCPP_WARN(
+      logger,
+      "colored_noise.fmin must be in [0.0, 0.5]. Clamping %.3f to %.3f.",
+      fmin, clamped);
+    fmin = clamped;
+  }
+
+  exponent_ = exponent;
+  offset_t_ = offset_t;
+  offset_decay_rate_ = offset_decay_rate;
+  fmin_ = fmin;
+}
+
+bool ColoredNoiseGenerator::isEnabled() const
+{
+  return enabled_;
+}
+
+void ColoredNoiseGenerator::generate(
+  Eigen::ArrayXXf & noise, float sigma, std::default_random_engine & generator) const
+{
+  const int batch_size = noise.rows();
+  const int time_steps = noise.cols();
+  if (time_steps <= 0 || batch_size <= 0 || sigma <= 0.0f) {
+    noise.setZero(batch_size, time_steps);
+    return;
+  }
+
+  const int sample_time_steps = 2 * time_steps;
+  const int frequency_count = sample_time_steps / 2 + 1;
+  const float cutoff_frequency =
+    std::max(fmin_, 1.0f / static_cast<float>(sample_time_steps));
+
+  Eigen::ArrayXf frequency_scale(frequency_count);
+  int smaller_frequency_count = 0;
+  bool lower_frequency_bins_filled = false;
+  for (int i = 0; i < frequency_count; ++i) {
+    const float frequency = static_cast<float>(i) / static_cast<float>(sample_time_steps);
+    if (frequency < cutoff_frequency) {
+      ++smaller_frequency_count;
+      continue;
+    }
+
+    if (!lower_frequency_bins_filled) {
+      for (int j = 0; j < smaller_frequency_count; ++j) {
+        frequency_scale(j) = std::pow(frequency, -exponent_ / 2.0f);
+      }
+      lower_frequency_bins_filled = true;
+    }
+    frequency_scale(i) = std::pow(frequency, -exponent_ / 2.0f);
+  }
+  double scale_square_sum = 0.0;
+  for (int i = 1; i < frequency_count - 1; ++i) {
+    scale_square_sum += static_cast<double>(frequency_scale(i)) *
+      static_cast<double>(frequency_scale(i));
+  }
+
+  const float final_frequency_factor =
+    (1.0f + static_cast<float>(sample_time_steps % 2)) / 2.0f;
+  const double final_frequency_scale =
+    static_cast<double>(frequency_scale(frequency_count - 1) * final_frequency_factor);
+  scale_square_sum += final_frequency_scale * final_frequency_scale;
+
+  const double unit_std =
+    2.0 * std::sqrt(scale_square_sum) / static_cast<double>(sample_time_steps);
+
+  const float unit_scale = 1.0f / static_cast<float>(unit_std);
+  const int cropped_offset_t = std::min(offset_t_, sample_time_steps - 1);
+  Eigen::FFT<float> fft;
+  std::vector<std::complex<float>> frequency_domain(sample_time_steps);
+  std::vector<std::complex<float>> time_domain;
+  std::normal_distribution<float> normal_distribution(0.0f, 1.0f);
+
+  for (int row = 0; row < batch_size; ++row) {
+    std::fill(
+      frequency_domain.begin(), frequency_domain.end(),
+      std::complex<float>(0.0f, 0.0f));
+
+    frequency_domain[0] = std::complex<float>(
+      normal_distribution(generator) * frequency_scale(0) * std::sqrt(2.0f),
+      0.0f);
+
+    for (int frequency_index = 1; frequency_index < frequency_count - 1; ++frequency_index) {
+      const std::complex<float> sample(
+        normal_distribution(generator) * frequency_scale(frequency_index),
+        normal_distribution(generator) * frequency_scale(frequency_index));
+      frequency_domain[frequency_index] = sample;
+      frequency_domain[sample_time_steps - frequency_index] = std::conj(sample);
+    }
+
+    frequency_domain[frequency_count - 1] = std::complex<float>(
+      normal_distribution(generator) * frequency_scale(frequency_count - 1) * std::sqrt(2.0f),
+      0.0f);
+    fft.inv(time_domain, frequency_domain);
+
+    const float offset_value = time_domain[cropped_offset_t].real() * unit_scale;
+    float offset_decay = 1.0f;
+    for (int time_index = 0; time_index < time_steps; ++time_index) {
+      noise(row, time_index) =
+        sigma * (time_domain[time_index].real() * unit_scale - offset_value * offset_decay);
+      offset_decay *= offset_decay_rate_;
+    }
+  }
+}
 
 void NoiseGenerator::initialize(
   mppi::models::OptimizerSettings & settings, bool is_holonomic,
@@ -27,6 +174,7 @@ void NoiseGenerator::initialize(
   settings_ = settings;
   is_holonomic_ = is_holonomic;
   active_ = true;
+  generator_ = std::default_random_engine();
 
   ndistribution_vx_ = std::normal_distribution(0.0f, settings_.sampling_std.vx);
   ndistribution_vy_ = std::normal_distribution(0.0f, settings_.sampling_std.vy);
@@ -34,6 +182,27 @@ void NoiseGenerator::initialize(
 
   auto getParam = param_handler->getParamGetter(name);
   getParam(regenerate_noises_, "regenerate_noises", false);
+  bool colored_noise_enabled = false;
+  getParam(
+    colored_noise_enabled, "colored_noise.enabled", false,
+    ParameterType::Static);
+  if (colored_noise_enabled) {
+    double exponent = 2.0;
+    int offset_t = 1;
+    double offset_decay_rate = 0.97;
+    double fmin = 0.0;
+    getParam(exponent, "colored_noise.exponent", 2.0, ParameterType::Static);
+    getParam(offset_t, "colored_noise.offset_t", 1, ParameterType::Static);
+    getParam(
+      offset_decay_rate, "colored_noise.offset_decay_rate", 0.97,
+      ParameterType::Static);
+    getParam(fmin, "colored_noise.fmin", 0.0, ParameterType::Static);
+    colored_noise_generator_.configure(
+      true, static_cast<float>(exponent), offset_t,
+      static_cast<float>(offset_decay_rate), static_cast<float>(fmin), logger_);
+  } else {
+    colored_noise_generator_.configure(false, 2.0f, 1, 0.97f, 0.0f, logger_);
+  }
 
   if (regenerate_noises_) {
     noise_thread_ = std::thread(std::bind(&NoiseGenerator::noiseThread, this));
@@ -44,8 +213,11 @@ void NoiseGenerator::initialize(
 
 void NoiseGenerator::shutdown()
 {
-  active_ = false;
-  ready_ = true;
+  {
+    std::unique_lock<std::mutex> guard(noise_lock_);
+    active_ = false;
+    ready_ = true;
+  }
   noise_cond_.notify_all();
   if (noise_thread_.joinable()) {
     noise_thread_.join();
@@ -68,6 +240,9 @@ void NoiseGenerator::setNoisedControls(
   const models::ControlSequence & control_sequence)
 {
   std::unique_lock<std::mutex> guard(noise_lock_);
+  if (regenerate_noises_) {
+    noise_cond_.wait(guard, [this]() {return !ready_ || !active_;});
+  }
 
   state.cvx = noises_vx_.rowwise() + control_sequence.vx.transpose();
   state.cvy = noises_vy_.rowwise() + control_sequence.vy.transpose();
@@ -76,38 +251,55 @@ void NoiseGenerator::setNoisedControls(
 
 void NoiseGenerator::reset(mppi::models::OptimizerSettings & settings, bool is_holonomic)
 {
-  settings_ = settings;
-  is_holonomic_ = is_holonomic;
-
-  // Recompute the noises on reset, initialization, and fallback
   {
     std::unique_lock<std::mutex> guard(noise_lock_);
+    settings_ = settings;
+    is_holonomic_ = is_holonomic;
+    ndistribution_vx_ = std::normal_distribution(0.0f, settings_.sampling_std.vx);
+    ndistribution_vy_ = std::normal_distribution(0.0f, settings_.sampling_std.vy);
+    ndistribution_wz_ = std::normal_distribution(0.0f, settings_.sampling_std.wz);
+
+    // Recompute the noises on reset, initialization, and fallback.
     noises_vx_.setZero(settings_.batch_size, settings_.time_steps);
     noises_vy_.setZero(settings_.batch_size, settings_.time_steps);
     noises_wz_.setZero(settings_.batch_size, settings_.time_steps);
-    ready_ = true;
-  }
-
-  if (regenerate_noises_) {
-    noise_cond_.notify_all();
-  } else {
+    ready_ = false;
     generateNoisedControls();
   }
+
+  noise_cond_.notify_all();
 }
 
 void NoiseGenerator::noiseThread()
 {
-  do {
+  while (true) {
     std::unique_lock<std::mutex> guard(noise_lock_);
-    noise_cond_.wait(guard, [this]() {return ready_;});
+    noise_cond_.wait(guard, [this]() {return ready_ || !active_;});
+    if (!active_) {
+      break;
+    }
     ready_ = false;
     generateNoisedControls();
-  } while (active_);
+    guard.unlock();
+    noise_cond_.notify_all();
+  }
 }
 
 void NoiseGenerator::generateNoisedControls()
 {
   auto & s = settings_;
+  if (colored_noise_generator_.isEnabled()) {
+    noises_vx_.resize(s.batch_size, s.time_steps);
+    noises_wz_.resize(s.batch_size, s.time_steps);
+    colored_noise_generator_.generate(noises_vx_, s.sampling_std.vx, generator_);
+    colored_noise_generator_.generate(noises_wz_, s.sampling_std.wz, generator_);
+    if (is_holonomic_) {
+      noises_vy_.resize(s.batch_size, s.time_steps);
+      colored_noise_generator_.generate(noises_vy_, s.sampling_std.vy, generator_);
+    }
+    return;
+  }
+
   noises_vx_ = Eigen::ArrayXXf::NullaryExpr(
     s.batch_size, s.time_steps, [&]() {return ndistribution_vx_(generator_);});
   noises_wz_ = Eigen::ArrayXXf::NullaryExpr(

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -126,6 +126,15 @@ void Optimizer::getParams()
     RCLCPP_WARN(logger_, "sgf_order must be 1 or 2, defaulting to 2");
     s.sgf_order = 2;
   }
+  getParam(
+    s.sampling_std_reduction_factor, "sampling_std.reduction_factor", 1.0f,
+    ParameterType::Static);
+  if (s.sampling_std_reduction_factor <= 0.0f || s.sampling_std_reduction_factor > 1.0f) {
+    RCLCPP_WARN(
+      logger_,
+      "sampling_std.reduction_factor must be in (0.0, 1.0]. Defaulting to 1.0.");
+    s.sampling_std_reduction_factor = 1.0f;
+  }
 
   s.base_constraints.ax_max = fabs(s.base_constraints.ax_max);
   if (s.base_constraints.ax_min > 0.0) {
@@ -263,10 +272,26 @@ std::tuple<geometry_msgs::msg::TwistStamped, Eigen::ArrayXXf> Optimizer::evalCon
 
 void Optimizer::optimize()
 {
+  const auto original_sampling_std = settings_.sampling_std;
   for (size_t i = 0; i < settings_.iteration_count; ++i) {
+    costs_.setZero(settings_.batch_size);
+    critics_data_.fail_flag = false;
+    if (i > 0 && settings_.sampling_std_reduction_factor < 1.0f) {
+      const float factor = std::pow(
+        settings_.sampling_std_reduction_factor, static_cast<float>(i));
+      settings_.sampling_std.vx = original_sampling_std.vx * factor;
+      settings_.sampling_std.vy = original_sampling_std.vy * factor;
+      settings_.sampling_std.wz = original_sampling_std.wz * factor;
+      noise_generator_.reset(settings_, isHolonomic());
+    }
+
     generateNoisedTrajectories();
     critic_manager_.evalTrajectoriesScores(critics_data_);
     updateControlSequence();
+  }
+  if (settings_.sampling_std_reduction_factor < 1.0f) {
+    settings_.sampling_std = original_sampling_std;
+    noise_generator_.reset(settings_, isHolonomic());
   }
 }
 

--- a/nav2_mppi_controller/test/noise_generator_test.cpp
+++ b/nav2_mppi_controller/test/noise_generator_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cmath>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -27,6 +28,39 @@
 // Tests noise generator object
 
 using namespace mppi;  // NOLINT
+
+static double highFrequencyEnergyRatio(const Eigen::ArrayXXf & values)
+{
+  double high_frequency_energy = 0.0;
+  double total_energy = 0.0;
+  const int time_steps = values.cols();
+  const double two_pi = 2.0 * std::acos(-1.0);
+
+  for (int row = 0; row < values.rows(); ++row) {
+    const double mean = values.row(row).mean();
+    for (int frequency_index = 1; frequency_index <= time_steps / 2; ++frequency_index) {
+      double real = 0.0;
+      double imaginary = 0.0;
+      for (int time_index = 0; time_index < time_steps; ++time_index) {
+        const double angle = two_pi *
+          static_cast<double>(frequency_index) *
+          static_cast<double>(time_index) /
+          static_cast<double>(time_steps);
+        const double value = static_cast<double>(values(row, time_index)) - mean;
+        real += value * std::cos(angle);
+        imaginary -= value * std::sin(angle);
+      }
+
+      const double energy = real * real + imaginary * imaginary;
+      total_energy += energy;
+      if (frequency_index >= time_steps / 4) {
+        high_frequency_energy += energy;
+      }
+    }
+  }
+
+  return high_frequency_energy / total_energy;
+}
 
 TEST(NoiseGeneratorTest, NoiseGeneratorLifecycle)
 {
@@ -201,6 +235,166 @@ TEST(NoiseGeneratorTest, NoiseGeneratorMainNoRegenerate)
   EXPECT_EQ(state.cvy(0, 9), initial_cvy_9);  // Not populated in non-holonomic
   EXPECT_EQ(state.cwz(0, 9), initial_cwz_9);
 
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, ColoredNoiseDisabledDoesNotRequireOptionalParams)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("colored_noise_disabled_node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.colored_noise.enabled", rclcpp::ParameterValue(false));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  NoiseGenerator generator;
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 20;
+  settings.time_steps = 10;
+  settings.sampling_std.vx = 0.1;
+  settings.sampling_std.vy = 0.1;
+  settings.sampling_std.wz = 0.1;
+
+  EXPECT_NO_THROW(generator.initialize(settings, false, "test_name", &handler));
+  EXPECT_NO_THROW(generator.reset(settings, false));
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, ColoredNoiseHasLowerHighFrequencyEnergyThanWhiteNoise)
+{
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 400;
+  settings.time_steps = 56;
+  settings.sampling_std.vx = 0.4;
+  settings.sampling_std.vy = 0.4;
+  settings.sampling_std.wz = 0.4;
+
+  auto sample_noise = [&](bool use_colored_noise) {
+      auto node = std::make_shared<nav2::LifecycleNode>(
+        use_colored_noise ? "colored_noise_node" : "white_noise_node");
+      node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+      node->declare_parameter(
+        "test_name.colored_noise.enabled",
+        rclcpp::ParameterValue(use_colored_noise));
+      if (use_colored_noise) {
+        node->declare_parameter("test_name.colored_noise.exponent", rclcpp::ParameterValue(2.0));
+        node->declare_parameter("test_name.colored_noise.offset_t", rclcpp::ParameterValue(1));
+        node->declare_parameter(
+          "test_name.colored_noise.offset_decay_rate",
+          rclcpp::ParameterValue(0.97));
+        node->declare_parameter("test_name.colored_noise.fmin", rclcpp::ParameterValue(0.0));
+      }
+
+      std::string name = "test";
+      ParametersHandler handler(node, name);
+      NoiseGenerator generator;
+      generator.initialize(settings, false, "test_name", &handler);
+      generator.reset(settings, false);
+
+      mppi::models::ControlSequence control_sequence;
+      control_sequence.reset(settings.time_steps);
+      mppi::models::State state;
+      state.reset(settings.batch_size, settings.time_steps);
+      generator.setNoisedControls(state, control_sequence);
+      generator.shutdown();
+      return state.cvx;
+    };
+
+  const auto white_noise = sample_noise(false);
+  const auto colored_noise = sample_noise(true);
+
+  EXPECT_LT(highFrequencyEnergyRatio(colored_noise), highFrequencyEnergyRatio(white_noise) * 0.25);
+}
+
+TEST(NoiseGeneratorTest, ColoredNoiseInvalidParametersAreClamped)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("colored_noise_clamp_node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.colored_noise.enabled", rclcpp::ParameterValue(true));
+  node->declare_parameter("test_name.colored_noise.exponent", rclcpp::ParameterValue(-1.0));
+  node->declare_parameter("test_name.colored_noise.offset_t", rclcpp::ParameterValue(-4));
+  node->declare_parameter("test_name.colored_noise.offset_decay_rate", rclcpp::ParameterValue(1.4));
+  node->declare_parameter("test_name.colored_noise.fmin", rclcpp::ParameterValue(0.8));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  NoiseGenerator generator;
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 20;
+  settings.time_steps = 10;
+  settings.sampling_std.vx = 0.1;
+  settings.sampling_std.vy = 0.1;
+  settings.sampling_std.wz = 0.1;
+
+  generator.initialize(settings, false, "test_name", &handler);
+  generator.reset(settings, false);
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State state;
+  state.reset(settings.batch_size, settings.time_steps);
+  EXPECT_NO_THROW(generator.setNoisedControls(state, control_sequence));
+  EXPECT_TRUE(state.cvx.isFinite().all());
+  EXPECT_TRUE(state.cwz.isFinite().all());
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, ColoredNoiseZeroStdProducesZeroNoise)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("colored_noise_zero_std_node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.colored_noise.enabled", rclcpp::ParameterValue(true));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  NoiseGenerator generator;
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 20;
+  settings.time_steps = 10;
+  settings.sampling_std.vx = 0.0;
+  settings.sampling_std.vy = 0.0;
+  settings.sampling_std.wz = 0.0;
+
+  generator.initialize(settings, false, "test_name", &handler);
+  generator.reset(settings, false);
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State state;
+  state.reset(settings.batch_size, settings.time_steps);
+  generator.setNoisedControls(state, control_sequence);
+
+  EXPECT_TRUE(state.cvx.isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.cwz.isApproxToConstant(0.0f));
+  generator.shutdown();
+}
+
+TEST(NoiseGeneratorTest, ColoredNoiseGeneratesHolonomicYAxis)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("colored_noise_holonomic_node");
+  node->declare_parameter("test_name.regenerate_noises", rclcpp::ParameterValue(false));
+  node->declare_parameter("test_name.colored_noise.enabled", rclcpp::ParameterValue(true));
+  std::string name = "test";
+  ParametersHandler handler(node, name);
+
+  NoiseGenerator generator;
+  mppi::models::OptimizerSettings settings;
+  settings.batch_size = 20;
+  settings.time_steps = 10;
+  settings.sampling_std.vx = 0.1;
+  settings.sampling_std.vy = 0.1;
+  settings.sampling_std.wz = 0.1;
+
+  generator.initialize(settings, true, "test_name", &handler);
+  generator.reset(settings, true);
+
+  mppi::models::ControlSequence control_sequence;
+  control_sequence.reset(settings.time_steps);
+  mppi::models::State state;
+  state.reset(settings.batch_size, settings.time_steps);
+  generator.setNoisedControls(state, control_sequence);
+
+  EXPECT_TRUE(state.cvy.isFinite().all());
+  EXPECT_GT(state.cvy.abs().maxCoeff(), 0.0f);
   generator.shutdown();
 }
 

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -1054,6 +1054,104 @@ TEST(OptimizerTests, InterIterationConstraintsTests)
   EXPECT_NEAR(seq.vx(0), 0.55f, 1e-6);
 }
 
+TEST(OptimizerTests, SamplingStdReductionFactorParamLoading)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("sampling_std_reduction_node");
+  OptimizerTester optimizer_tester;
+
+  node->declare_parameter(
+    "mppic.sampling_std.reduction_factor",
+    rclcpp::ParameterValue(0.7f));
+  node->declare_parameter("mppic.batch_size", rclcpp::ParameterValue(20));
+  node->declare_parameter("mppic.time_steps", rclcpp::ParameterValue(10));
+  node->declare_parameter(
+    "mppic.diff_drive.plugin",
+    rclcpp::ParameterValue("mppi::DiffDriveMotionModel"));
+  node->declare_parameter("controller_frequency", rclcpp::ParameterValue(30.0));
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  std::string name = "test";
+  ParametersHandler param_handler(node, name);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
+
+  EXPECT_FLOAT_EQ(optimizer_tester.getSettings().sampling_std_reduction_factor, 0.7f);
+}
+
+TEST(OptimizerTests, InvalidSamplingStdReductionFactorDefaultsToOne)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("invalid_sampling_std_reduction_node");
+  OptimizerTester optimizer_tester;
+
+  node->declare_parameter(
+    "mppic.sampling_std.reduction_factor",
+    rclcpp::ParameterValue(1.5f));
+  node->declare_parameter("mppic.batch_size", rclcpp::ParameterValue(20));
+  node->declare_parameter("mppic.time_steps", rclcpp::ParameterValue(10));
+  node->declare_parameter(
+    "mppic.diff_drive.plugin",
+    rclcpp::ParameterValue("mppi::DiffDriveMotionModel"));
+  node->declare_parameter("controller_frequency", rclcpp::ParameterValue(30.0));
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap_invalid", "", true);
+  std::string name = "test";
+  ParametersHandler param_handler(node, name);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
+
+  EXPECT_FLOAT_EQ(optimizer_tester.getSettings().sampling_std_reduction_factor, 1.0f);
+}
+
+TEST(OptimizerTests, MultiIterationStdReductionRestoresOriginalSamplingStd)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("multi_iteration_std_reduction_node");
+  OptimizerTester optimizer_tester;
+
+  node->declare_parameter("mppic.iteration_count", rclcpp::ParameterValue(3));
+  node->declare_parameter(
+    "mppic.sampling_std.reduction_factor",
+    rclcpp::ParameterValue(0.5f));
+  node->declare_parameter("mppic.batch_size", rclcpp::ParameterValue(50));
+  node->declare_parameter("mppic.time_steps", rclcpp::ParameterValue(20));
+  node->declare_parameter("mppic.model_dt", rclcpp::ParameterValue(0.05));
+  node->declare_parameter("mppic.vx_std", rclcpp::ParameterValue(0.25));
+  node->declare_parameter("mppic.vy_std", rclcpp::ParameterValue(0.15));
+  node->declare_parameter("mppic.wz_std", rclcpp::ParameterValue(0.35));
+  node->declare_parameter(
+    "mppic.diff_drive.plugin",
+    rclcpp::ParameterValue("mppi::DiffDriveMotionModel"));
+  node->declare_parameter("controller_frequency", rclcpp::ParameterValue(20.0));
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap_multi_iteration", "", true);
+  std::string name = "test";
+  ParametersHandler param_handler(node, name);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
+
+  geometry_msgs::msg::PoseStamped pose;
+  geometry_msgs::msg::Twist robot_speed;
+  nav_msgs::msg::Path path;
+  path.poses.resize(17);
+  geometry_msgs::msg::Pose goal;
+
+  EXPECT_NO_THROW(optimizer_tester.evalControl(pose, robot_speed, path, goal, nullptr));
+  EXPECT_FLOAT_EQ(optimizer_tester.getSettings().sampling_std.vx, 0.25f);
+  EXPECT_FLOAT_EQ(optimizer_tester.getSettings().sampling_std.vy, 0.15f);
+  EXPECT_FLOAT_EQ(optimizer_tester.getSettings().sampling_std.wz, 0.35f);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_mppi_controller/test/utils/factory.hpp
+++ b/nav2_mppi_controller/test/utils/factory.hpp
@@ -65,6 +65,24 @@ void setUpOptimizerParams(
   params_.emplace_back(rclcpp::Parameter(node_name + ".lookahead_dist", s.lookahead_distance));
   params_.emplace_back(rclcpp::Parameter(node_name + ".motion_model", s.motion_model));
   params_.emplace_back(rclcpp::Parameter(node_name + ".critics", critics));
+  params_.emplace_back(
+    rclcpp::Parameter(node_name + ".colored_noise.enabled", s.colored_noise_enabled));
+  if (s.colored_noise_enabled) {
+    params_.emplace_back(
+      rclcpp::Parameter(node_name + ".colored_noise.exponent", s.colored_noise_exponent));
+    params_.emplace_back(
+      rclcpp::Parameter(node_name + ".colored_noise.offset_t", s.colored_noise_offset_t));
+    params_.emplace_back(
+      rclcpp::Parameter(
+        node_name + ".colored_noise.offset_decay_rate",
+        s.colored_noise_offset_decay_rate));
+    params_.emplace_back(
+      rclcpp::Parameter(node_name + ".colored_noise.fmin", s.colored_noise_fmin));
+  }
+  params_.emplace_back(
+    rclcpp::Parameter(
+      node_name + ".sampling_std.reduction_factor",
+      s.sampling_std_reduction_factor));
   params_.emplace_back(rclcpp::Parameter("controller_frequency", dummy_freq));
   // Inject plugin type for the chosen motion model so tests don't need an installed plugin
   params_.emplace_back(

--- a/nav2_mppi_controller/test/utils/models.hpp
+++ b/nav2_mppi_controller/test/utils/models.hpp
@@ -26,6 +26,12 @@ struct TestOptimizerSettings
   double lookahead_distance;
   std::string motion_model;
   bool consider_footprint;
+  bool colored_noise_enabled{false};
+  double colored_noise_exponent{2.0};
+  int colored_noise_offset_t{1};
+  double colored_noise_offset_decay_rate{0.97};
+  double colored_noise_fmin{0.0};
+  double sampling_std_reduction_factor{1.0};
 };
 
 struct TestPose

--- a/nav2_ros_common/test/test_actions.cpp
+++ b/nav2_ros_common/test/test_actions.cpp
@@ -567,6 +567,14 @@ TEST_F(ActionTest, test_handle_cancel)
   // Check cancelled
   EXPECT_EQ(future_goal_handle.get()->get_status(), rclcpp_action::GoalStatus::STATUS_CANCELING);
 
+  // Wait for the server to finish processing cancellation before teardown.
+  auto future_result = node_->action_client_->async_get_result(future_goal_handle.get());
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(
+      node_,
+      future_result), rclcpp::FutureReturnCode::SUCCESS);
+  EXPECT_EQ(future_result.get().code, rclcpp_action::ResultCode::CANCELED);
+
   SUCCEED();
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Addresses #5973 |
| Primary OS tested on | Ubuntu 24.04 with ROS Rolling in Docker / overlay workspace |
| Robotic platform tested on | TurtleBot3-style differential-drive loopback simulation using Nav2 `tb3_loopback_simulation_launch.py`; headless benchmark traces with RViz/plot replay inspection |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Adds an optional low-frequency / colored-noise sampling mode to the MPPI controller.
* This addresses #5973 by adding a sampling distribution that generates temporally correlated perturbations instead of independent white Gaussian noise at every time step.
* The feature is disabled by default, so existing MPPI behavior remains unchanged unless the new parameters are enabled.
* The new colored-noise parameters are:
  * `colored_noise.enabled`
  * `colored_noise.exponent`
  * `colored_noise.offset_t`
  * `colored_noise.offset_decay_rate`
  * `colored_noise.fmin`
* The implementation is based on the low-frequency sampling approach described in:
  * Vlahov et al., “Low Frequency Sampling in Model Predictive Path Integral Control”
  * https://arxiv.org/pdf/2404.03094
* I also referenced the implementation examples mentioned in #5973:
  * https://github.com/ACDSLab/MPPI-Generic/tree/main/include/mppi/sampling_distributions
  * https://github.com/felixpatzelt/colorednoise/blob/master/colorednoise.py
* Colored-noise perturbations are generated in the frequency domain and transformed back to the time domain with an inverse FFT.
* The generator uses:
  * doubled-horizon sampling, `2 * time_steps`
  * power-law frequency scaling using `frequency^(-exponent / 2)`
  * Hermitian symmetry so the inverse FFT produces real-valued control perturbations
  * normalization so the time-domain perturbation variance matches the requested sampling standard deviation
  * crop/offset handling using `colored_noise.offset_t`
  * optional decayed offset correction using `colored_noise.offset_decay_rate`
  * a minimum frequency clamp using `colored_noise.fmin`
* The colored-noise generator supports differential and holonomic control dimensions:
  * `vx`
  * `wz`
  * `vy` when holonomic
* Adds `sampling_std.reduction_factor` so multi-iteration MPPI runs can optionally reduce the sampling standard deviation on later iterations.
* The refinement path keeps the default behavior unchanged:
  * default `iteration_count` remains `1`
  * default `sampling_std.reduction_factor` is `1.0`
* Adds unit coverage for:
  * colored-noise disabled mode
  * colored-noise parameter clamping
  * colored-noise high-frequency energy reduction compared to white Gaussian samples
  * `sampling_std.reduction_factor` parameter loading
  * invalid `sampling_std.reduction_factor` fallback

## Implementation notes and scope

This PR adds the colored-noise sampling distribution to Nav2’s existing MPPI implementation. It is not intended to replace the whole MPPI controller derivation with a full paper-replica implementation.

The sampler itself follows the paper/reference structure closely:

* sample Gaussian values in the frequency domain
* apply power-law frequency scaling
* enforce Hermitian symmetry
* use inverse FFT to generate real-valued time-domain samples
* normalize the samples
* use doubled-horizon crop/offset handling

One important theoretical difference is that Nav2 still uses its existing MPPI update and control-cost correction structure. The existing correction uses the configured per-axis sampling standard deviations. Colored noise introduces temporal correlation across the horizon, so this PR should be understood as adding a low-frequency sampling distribution to Nav2 MPPI rather than adding a full covariance-aware paper clone.

The multi-iteration refinement path works best with `regenerate_noises: true`, which is already the default in Nav2 bringup params. If users disable noise regeneration, repeated iterations can reuse the same noise batch depending on configuration, which limits the usefulness of refinement.

## Description of documentation updates.

* Updated `nav2_mppi_controller/README.md` with the new colored-noise parameters.
* Updated default bringup params with disabled-by-default values:
  * `colored_noise.enabled: false`
  * `colored_noise.exponent: 2.0`
  * `colored_noise.offset_t: 1`
  * `colored_noise.offset_decay_rate: 0.97`
  * `colored_noise.fmin: 0.0`
  * `sampling_std.reduction_factor: 1.0`
* docs.nav2.org should add the new MPPI parameters.
* The MPPI tuning guide should document the main tuning behavior:
  * larger `colored_noise.exponent` shifts more sample energy into lower frequencies
  * lower-frequency samples can help produce longer, smoother control perturbations
  * tuning is scenario-dependent
  * this should be treated as an optional sampling mode, not a new default behavior
  * in my benchmark, exponent `2.0` was the best tested value
  * lower tested exponents with SGF, `0.5` and `1.0`, were not favorable in this matrix
* The tuning guide should also mention that this is different from SGF:
  * SGF smooths the selected control sequence after optimization
  * colored-noise sampling changes the perturbation distribution before rollout/evaluation
  * these can be used independently or together

## Description of how this change was tested

### Build and unit tests

I built the MPPI package sequentially:

```bash
colcon build --packages-select nav2_mppi_controller --executor sequential --parallel-workers 1
```
The build completed successfully.

I then ran the targeted unit tests:

```bash
ctest --test-dir /opt/overlay_ws/build/nav2_mppi_controller -R "noise_generator_test|optimizer_unit_tests" --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 2
```

The passing tests were:

- `noise_generator_test`
- `optimizer_unit_tests`

### Benchmark setup

I ran a repeated headless loopback simulation matrix using Nav2’s TurtleBot3 loopback simulation.

The benchmark runner launched a fresh Nav2 stack per trial, waited for lifecycle activation, sent a `NavigateToPose` goal, collected `/cmd_vel_nav`, `odom`, and `controller_server/optimal_trajectory`, then shut the stack down before the next trial. This was done to keep each trial isolated and avoid reusing stale state or artifacts.

The benchmark also saved:

- result JSONs
- launch logs
- evaluation logs
- trace JSONs
- replay metadata
- summary CSV/JSON/Markdown
- plots for visual inspection

The matrix had:

- 4 scenarios
- 9 profiles
- 2 repeats per scenario/profile
- 72 final result runs

Artifact integrity from the final matrix:

- 72 final result JSONs
- 72 localization prime JSONs
- 72 trace files
- 72 replay metadata files
- 0 infrastructure failures
- 0 data-quality warning runs
- 48 successful navigation runs
- 24 behavioral failures

### Scenarios tested

The scenarios were selected to include easy, moderate, and hard cases:

- `tb3_open_straight`: basic straight navigation sanity check
- `tb3_turning_route`: moderate route with turning behavior
- `tb3_tight_s_turn`: hard route requiring tight maneuvering
- `tb3_near_obstacle_crossing`: hard obstacle interaction case

### Profiles compared

The benchmark compared current baselines and low-frequency variants:

| Profile | Meaning |
| --- | --- |
| `vanilla_raw` | White Gaussian sampling, no SGF |
| `vanilla_sgf` | Current default SGF order 2 behavior |
| `vanilla_sgf_o1` | SGF order 1 baseline |
| `lowfreq_raw` | Colored noise, exponent `2.0`, no SGF |
| `lowfreq_sgf_g0p5` | Colored noise, exponent `0.5`, SGF enabled |
| `lowfreq_sgf_g1p0` | Colored noise, exponent `1.0`, SGF enabled |
| `lowfreq_sgf_g2p0` | Colored noise, exponent `2.0`, SGF enabled |
| `lowfreq_refined_i2_s1p0` | Colored noise, exponent `2.0`, no SGF, `iteration_count=2`, `sampling_std.reduction_factor=1.0` |
| `lowfreq_refined_i3_s1p0` | Colored noise, exponent `2.0`, no SGF, `iteration_count=3`, `sampling_std.reduction_factor=1.0` |

### Aggregate benchmark results

Overall success counts:

| Profile | Successes |
| --- | ---: |
| Colored noise exponent `2.0` + SGF | 7/8 |
| SGF order 1 | 6/8 |
| Colored noise raw, exponent `2.0` | 6/8 |
| Colored noise refined, `iteration_count=2` | 6/8 |
| Colored noise refined, `iteration_count=3` | 6/8 |
| SGF order 2 default | 5/8 |
| White Gaussian raw | 4/8 |
| Colored noise exponent `0.5` + SGF | 4/8 |
| Colored noise exponent `1.0` + SGF | 4/8 |

The strongest positive case was `tb3_near_obstacle_crossing`:

| Profile | Result |
| --- | ---: |
| Colored noise exponent `2.0` + SGF | 2/2 |
| Colored noise raw, exponent `2.0` | 1/2 |
| Colored noise refined, `iteration_count=2` | 1/2 |
| Colored noise refined, `iteration_count=3` | 1/2 |
| White Gaussian raw | 0/2 |
| SGF order 2 default | 0/2 |
| SGF order 1 | 0/2 |
| Colored noise exponent `0.5` + SGF | 0/2 |
| Colored noise exponent `1.0` + SGF | 0/2 |

The easier scenarios were passed by all tested profiles:

- `tb3_open_straight`: all profiles 2/2
- `tb3_turning_route`: all profiles 2/2

The hard tight S-turn remained mixed:

| Profile | Result |
| --- | ---: |
| SGF order 1 | 2/2 |
| SGF order 2 default | 1/2 |
| Colored noise raw, exponent `2.0` | 1/2 |
| Colored noise exponent `2.0` + SGF | 1/2 |
| Colored noise refined, `iteration_count=2` | 1/2 |
| Colored noise refined, `iteration_count=3` | 1/2 |
| White Gaussian raw | 0/2 |
| Colored noise exponent `0.5` + SGF | 0/2 |
| Colored noise exponent `1.0` + SGF | 0/2 |

### Smoothness, jitter, and frequency metrics

The benchmark also computed the smoothness and jitter metrics requested in #5973. Lower values are smoother for the delta/jitter/high-frequency metrics below.

Metric definitions:

- `Opt mean abs dvx/dwz`: mean absolute step-to-step velocity change inside each published optimal trajectory.
- `Inter first mean abs dvx/dwz`: mean absolute change of the first optimal-trajectory command between controller iterations. This is the closest “inter-iteration jitter” metric.
- `Inter overlap mean abs dvx/dwz`: mean absolute change between overlapping shifted horizon commands from consecutive optimal trajectories.
- `Cmd mean abs dvx/dwz`: mean absolute command-to-command change in executed `/cmd_vel_nav`.
- `Cmd HF vx/wz`: high-frequency energy ratio in executed commands above the benchmark cutoff.

Aggregate values from the final working matrix:

| Profile | Success | Opt mean abs dvx | Opt mean abs dwz | Inter first mean abs dvx | Inter first mean abs dwz | Inter overlap mean abs dvx | Inter overlap mean abs dwz | Cmd mean abs dvx | Cmd mean abs dwz | Cmd HF vx | Cmd HF wz |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| White Gaussian raw | 4/8 | 0.00689 | 0.00843 | 0.00590 | 0.01576 | 0.00764 | 0.00951 | 0.00615 | 0.01609 | 0.00190 | 0.00133 |
| SGF order 2 default | 5/8 | 0.00668 | 0.00826 | 0.00568 | 0.01479 | 0.00733 | 0.00924 | 0.00594 | 0.01531 | 0.00195 | 0.00204 |
| SGF order 1 | 6/8 | 0.00631 | 0.00660 | 0.00495 | 0.01423 | 0.00731 | 0.00869 | 0.00517 | 0.01469 | 0.00111 | 0.00087 |
| Colored noise raw, exponent `2.0` | 6/8 | 0.00503 | 0.01391 | 0.00675 | 0.02592 | 0.02441 | 0.02968 | 0.00702 | 0.02652 | 0.00171 | 0.00119 |
| Colored noise exponent `2.0` + SGF | 7/8 | 0.00498 | 0.01359 | 0.00665 | 0.02394 | 0.02426 | 0.02674 | 0.00694 | 0.02453 | 0.00196 | 0.00097 |
| Colored noise refined, `iteration_count=2` | 6/8 | 0.00487 | 0.01321 | 0.00650 | 0.02370 | 0.02245 | 0.02689 | 0.00680 | 0.02431 | 0.00176 | 0.00106 |
| Colored noise refined, `iteration_count=3` | 6/8 | 0.00490 | 0.01328 | 0.00662 | 0.02389 | 0.02386 | 0.02760 | 0.00691 | 0.02452 | 0.00235 | 0.00105 |

The metric takeaway is mixed and should be stated that way:

- Colored-noise sampling reduced optimal-trajectory `vx` step changes compared with the white Gaussian and SGF baselines.
- SGF order 1 remained best on executed command smoothness and inter-iteration jitter in this matrix.
- The best colored-noise reliability profile, exponent `2.0` + SGF, had higher `wz` and inter-overlap deltas than SGF order 1, so it is not a blanket smoothness win.
- The strongest positive signal for this PR is reliability and trajectory feasibility in the hard near-obstacle case, not universal improvement of every smoothness metric.

### Runtime / controller-rate observations

All tested low-frequency profiles maintained approximately the expected `20 Hz` optimal trajectory publication rate in this matrix.

Mean values from the final matrix:

| Profile | Successes | Mean duration | Mean optimal trajectory rate |
| --- | ---: | ---: | ---: |
| Colored noise exponent `2.0` + SGF | 7/8 | 19.41 s | 19.99 Hz |
| Colored noise refined, `iteration_count=3` | 6/8 | 19.89 s | 19.98 Hz |
| Colored noise refined, `iteration_count=2` | 6/8 | 20.91 s | 20.01 Hz |
| Colored noise raw, exponent `2.0` | 6/8 | 21.04 s | 19.98 Hz |
| Colored noise exponent `1.0` + SGF | 4/8 | 22.93 s | 19.99 Hz |
| Colored noise exponent `0.5` + SGF | 4/8 | 24.20 s | 19.99 Hz |

I interpret this as “no observed controller-rate degradation in this benchmark.” This is not a CPU profiler result; it only shows that the controller maintained the expected rate under these test conditions.

### Smoothness / velocity inspection

I generated before/after-style plots for visual inspection of the velocity signals and trajectories. The plots include:

- profile summary
- scenario success heatmap
- velocity inspection for `tb3_turning_route`
- velocity inspection for `tb3_tight_s_turn`
- velocity inspection for `tb3_near_obstacle_crossing`

The plots are intended to make the velocity/noise behavior inspectable rather than relying only on scalar metrics.

The main visual/metric finding is that colored-noise sampling changes the perturbation distribution before rollout/evaluation, while SGF smooths after the optimizer selects the trajectory. The best tested result came from combining colored noise exponent `2.0` with SGF.

Recommended plot attachments:

<img width="3240" height="1620" alt="lowfreq_profile_summary" src="https://github.com/user-attachments/assets/ca6d9f03-a746-4d38-93e6-9ebe8e00e813" />

<img width="2520" height="1080" alt="lowfreq_scenario_success" src="https://github.com/user-attachments/assets/ea8b5537-b7d7-4920-9082-58323aa7789d" />

<img width="2880" height="1800" alt="lowfreq_velocity_inspection_near_obstacle_crossing" src="https://github.com/user-attachments/assets/3ae3e4ba-9ec8-42e5-ba10-c99d93b6178e" />

<img width="2880" height="1800" alt="lowfreq_velocity_inspection_tight_s_turn" src="https://github.com/user-attachments/assets/00a771a7-d38e-4989-ab68-be1ac40ae96d" />

<img width="2880" height="1800" alt="lowfreq_velocity_inspection_turning_route" src="https://github.com/user-attachments/assets/c414f574-c35c-4a50-8d90-6c7342c129ba" />

### Benchmark interpretation

My conclusion from this matrix is:

- Low-frequency colored-noise sampling is a promising optional MPPI sampling mode.
- The best tested configuration was colored noise exponent `2.0` with SGF enabled.
- The main benefit showed up in the hard near-obstacle crossing scenario, where the best colored-noise profile succeeded 2/2 while the tested white Gaussian / SGF baselines failed 0/2.
- The result is not a universal win across every metric.
- SGF order 1 remains very competitive, especially on executed-command smoothness metrics.
- Lower tested colored-noise exponents with SGF, `0.5` and `1.0`, were not favorable in this matrix.
- Multi-iteration refinement worked and maintained controller rate, but did not clearly outperform colored noise exponent `2.0` + SGF in this test set.
- I do not think this should become a default behavior from this PR. It is better introduced as an optional sampling mode with documentation and tuning guidance.

## Future work that may be required.

* Add docs.nav2.org documentation for:
  * `colored_noise.enabled`
  * `colored_noise.exponent`
  * `colored_noise.offset_t`
  * `colored_noise.offset_decay_rate`
  * `colored_noise.fmin`
  * `sampling_std.reduction_factor`
* Add MPPI tuning-guide notes for:
  * exponent selection
  * interaction with SGF
  * when to use colored-noise sampling
  * when not to use it
* Add broader validation on:
  * physical robots
  * omnidirectional platforms
  * robots with slower actuator dynamics
  * longer and more cluttered routes
* Add CPU profiling focused on:
  * Eigen FFT overhead
  * colored-noise generation cost
  * multi-iteration refinement cost
* Consider future investigation into a covariance-aware update/control-cost correction for a closer theoretical match to the paper.
* Add more distribution-level tests:
  * output variance close to requested `vx_std`, `vy_std`, and `wz_std`
  * `exponent=0.0` approximating white-noise spectral behavior
  * `offset_t` and `offset_decay_rate` behavior
  * multi-iteration regeneration behavior
* Continue tuning before considering any default-enabled configuration.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
