### PR TITLE
[nav2_behavior_tree] Fix incorrect wakeUpSignal() call in ROS 2 Rolling on Ubuntu 26.04

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp
@@ -61,7 +61,7 @@ public:
       return false;
     }
     // Sleep until the target time, preemptible by emitWakeUpSignal().
-    auto wake_up = tree_->wakeUpSignal();
+    auto wake_up = tree_->emitWakeUpSignal();
     const bool is_sim_time =
       clock_->get_clock_type() == RCL_ROS_TIME &&
       clock_->ros_time_is_active();


### PR DESCRIPTION
In file included from /home/hau/ros2_rolling/src/navigation2/nav2_behavior_tree/src/behavior_tree_engine.cpp:27:
/home/hau/ros2_rolling/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp: In member function ‘bool nav2_behavior_tree::LoopRate::sleep()’:
/home/hau/ros2_rolling/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp:64:27: error: ‘class BT::Tree’ has no member named ‘wakeUpSignal’; did you mean ‘emitWakeUpSignal’?
   64 |     auto wake_up = tree_->wakeUpSignal();
      |                           ^~~~~~~~~~~~
      |                           emitWakeUpSignal


Replaced usage of non-existent BT::Tree::wakeUpSignal() with the correct BT::Tree::emitWakeUpSignal() in loop_rate.hpp. This resolves compilation errors in ROS 2 Rolling on Ubuntu 26.04 and ensures proper preemption behavior during timed sleeps.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
