### PR TITLE
Add ESDF exposure in InflationLayer, EsdfCritic, and CorridorCritic (…

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -152,6 +152,36 @@ public:
     return inflation_radius_;
   }
 
+  /**
+   * @brief Query the ESDF distance to the nearest obstacle at a costmap cell.
+   *
+   * Returns the Euclidean distance in meters. Returns DT_INF for cells that
+   * have not yet been covered by an update window (e.g. before the first
+   * reinflation). Caller should hold getMutex() while reading.
+   *
+   * @param mx Costmap cell x index (column)
+   * @param my Costmap cell y index (row)
+   * @return Distance to nearest obstacle in meters, or DT_INF if unknown
+   */
+  float getDistanceToObstacle(unsigned int mx, unsigned int my) const
+  {
+    if (static_cast<int>(my) >= esdf_.rows() || static_cast<int>(mx) >= esdf_.cols()) {
+      return DistanceTransform::DT_INF;
+    }
+    return esdf_(static_cast<int>(my), static_cast<int>(mx));
+  }
+
+  /**
+   * @brief Get the full ESDF matrix (row = y cell, col = x cell, values in meters).
+   *
+   * Cells not yet covered by an update window have value DT_INF.
+   * Caller should hold getMutex() while reading.
+   */
+  const MatrixXfRM & getEsdf() const
+  {
+    return esdf_;
+  }
+
 protected:
   /**
    * @brief Apply inflation costs from distance map to costmap
@@ -220,6 +250,9 @@ protected:
   unsigned int cell_inflation_radius_;
   int num_threads_;  // Number of OpenMP threads (-1 = auto)
   double resolution_;
+
+  // Full-costmap ESDF; distances in meters, DT_INF for uninitialized cells
+  MatrixXfRM esdf_;
 
   // Cost LUT precision: 100 samples per cell provides smooth gradients
   static constexpr int COST_LUT_PRECISION = 100;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/safe_corridor.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/safe_corridor.hpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_COSTMAP_2D__SAFE_CORRIDOR_HPP_
+#define NAV2_COSTMAP_2D__SAFE_CORRIDOR_HPP_
+
+#include <algorithm>
+#include <limits>
+
+#include <Eigen/Core>
+
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/inflation_layer.hpp"
+
+namespace nav2_costmap_2d
+{
+
+/**
+ * @class SafeCorridorComputer
+ * @brief Utility that computes, for each point on a path, the usable corridor
+ * half-width — defined as the ESDF clearance at that path point minus the
+ * robot's inscribed radius, clamped to [0, max_width].
+ *
+ * A trajectory point is considered inside the corridor at path point k if its
+ * Euclidean distance to path point k does not exceed corridor_width[k].
+ *
+ * This is a lightweight upper bound on the actual free-space region: the true
+ * corridor may be asymmetric (narrow on one side), but using the ESDF value
+ * at the path point as an isotropic bound is conservative — any trajectory
+ * point that stays within this radius of the path is guaranteed to have
+ * at least robot_radius clearance from every obstacle.
+ *
+ * Usage:
+ *   auto widths = SafeCorridorComputer::computeWidths(
+ *       path_x, path_y, *inflation_layer, *costmap, robot_radius, max_width);
+ *   // widths[k] is the usable half-width (m) at path point k
+ */
+class SafeCorridorComputer
+{
+public:
+  /**
+   * @brief Compute corridor half-widths along a path.
+   *
+   * @param path_x  World x-coordinates of path points (Eigen array)
+   * @param path_y  World y-coordinates of path points (Eigen array)
+   * @param layer   InflationLayer exposing the ESDF via getDistanceToObstacle()
+   * @param costmap Costmap2D for world→cell conversion
+   * @param robot_radius Inscribed radius of the robot (m)
+   * @param max_width    Maximum corridor half-width (m); avoids unbounded widths
+   *                     in wide-open spaces
+   * @return Eigen::ArrayXf of length path_x.size(), corridor widths in meters
+   */
+  static Eigen::ArrayXf computeWidths(
+    const Eigen::ArrayXf & path_x,
+    const Eigen::ArrayXf & path_y,
+    const InflationLayer & layer,
+    const Costmap2D & costmap,
+    float robot_radius,
+    float max_width = 3.0f)
+  {
+    const Eigen::Index n = path_x.size();
+    Eigen::ArrayXf widths(n);
+
+    const float origin_x = static_cast<float>(costmap.getOriginX());
+    const float origin_y = static_cast<float>(costmap.getOriginY());
+    const float resolution = static_cast<float>(costmap.getResolution());
+    const unsigned int size_x = costmap.getSizeInCellsX();
+    const unsigned int size_y = costmap.getSizeInCellsY();
+
+    for (Eigen::Index k = 0; k < n; k++) {
+      const float wx = path_x(k);
+      const float wy = path_y(k);
+
+      if (wx < origin_x || wy < origin_y) {
+        widths(k) = 0.0f;
+        continue;
+      }
+
+      const unsigned int mx = static_cast<unsigned int>((wx - origin_x) / resolution);
+      const unsigned int my = static_cast<unsigned int>((wy - origin_y) / resolution);
+
+      if (mx >= size_x || my >= size_y) {
+        widths(k) = 0.0f;
+        continue;
+      }
+
+      const float esdf_dist = layer.getDistanceToObstacle(mx, my);
+      widths(k) = std::min(std::max(0.0f, esdf_dist - robot_radius), max_width);
+    }
+
+    return widths;
+  }
+};
+
+}  // namespace nav2_costmap_2d
+
+#endif  // NAV2_COSTMAP_2D__SAFE_CORRIDOR_HPP_

--- a/nav2_costmap_2d/include/nav2_costmap_2d/safe_corridor.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/safe_corridor.hpp
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/inflation_layer.hpp"
@@ -62,8 +63,8 @@ public:
    * @return Eigen::ArrayXf of length path_x.size(), corridor widths in meters
    */
   static Eigen::ArrayXf computeWidths(
-    const Eigen::ArrayXf & path_x,
-    const Eigen::ArrayXf & path_y,
+    const Eigen::Ref<const Eigen::ArrayXf> & path_x,
+    const Eigen::Ref<const Eigen::ArrayXf> & path_y,
     const InflationLayer & layer,
     const Costmap2D & costmap,
     float robot_radius,

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -121,6 +121,10 @@ InflationLayer::matchSize()
   resolution_ = costmap->getResolution();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
+  esdf_.setConstant(
+    static_cast<int>(costmap->getSizeInCellsY()),
+    static_cast<int>(costmap->getSizeInCellsX()),
+    DistanceTransform::DT_INF);
 }
 
 void
@@ -315,6 +319,13 @@ InflationLayer::updateCosts(
 
   // Perform Felzenszwalb-Huttenlocher distance transform
   DistanceTransform::distanceTransform2D(distance_map, roi_height, roi_width);
+
+  // Persist ESDF for the update window (convert cell distances to meters)
+  esdf_.block(min_j, min_i, max_j - min_j, max_i - min_i) =
+    distance_map.block(
+      min_j - roi_min_j, min_i - roi_min_i,
+      max_j - min_j, max_i - min_i) *
+    static_cast<float>(resolution_);
 
   // Apply inflation costs
   applyInflation(

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -800,6 +800,83 @@ TEST_F(TestNode, testDynParamsSet)
   costmap->on_shutdown(rclcpp_lifecycle::State());
 }
 
+// ESDF: obstacle cell has distance 0, nearby free cells have correct Euclidean distance
+TEST_F(TestNode, testEsdfDistances)
+{
+  initNode(1.0);
+  tf2_ros::Buffer tf(node_->get_clock());
+  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  // 10x10 map, 0.1 m/cell → 1.0 m wide
+  layers.resizeMap(10, 10, 0.1, 0, 0);
+
+  setRadii(layers, 0.1, 0.1);
+
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
+  addObstacleLayer(layers, tf, node_, olayer);
+
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> ilayer = nullptr;
+  addInflationLayer(layers, tf, node_, ilayer);
+
+  // Place obstacle at cell (5, 5)
+  addObservation(olayer, 0.55, 0.55, MAX_Z);
+
+  layers.updateMap(0, 0, 0);
+
+  std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> guard(*ilayer->getMutex());
+
+  // Obstacle cell itself: distance == 0
+  EXPECT_FLOAT_EQ(ilayer->getDistanceToObstacle(5, 5), 0.0f);
+
+  // Neighbor at (6, 5): one cell away = 0.1 m
+  const float d1 = ilayer->getDistanceToObstacle(6, 5);
+  EXPECT_NEAR(d1, 0.1f, 0.01f);
+
+  // Diagonal neighbor at (6, 6): sqrt(2) cells away ≈ 0.141 m
+  const float d2 = ilayer->getDistanceToObstacle(6, 6);
+  EXPECT_NEAR(d2, static_cast<float>(std::sqrt(2.0) * 0.1), 0.01f);
+
+  // ESDF matrix dimensions match the costmap
+  const auto & esdf = ilayer->getEsdf();
+  EXPECT_EQ(esdf.rows(), 10);
+  EXPECT_EQ(esdf.cols(), 10);
+}
+
+// ESDF resets correctly when matchSize is called (map resize)
+TEST_F(TestNode, testEsdfMatchSizeReset)
+{
+  initNode(0.5);
+  tf2_ros::Buffer tf(node_->get_clock());
+  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  layers.resizeMap(5, 5, 0.1, 0, 0);
+
+  setRadii(layers, 0.1, 0.1);
+
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
+  addObstacleLayer(layers, tf, node_, olayer);
+
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> ilayer = nullptr;
+  addInflationLayer(layers, tf, node_, ilayer);
+
+  {
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> guard(*ilayer->getMutex());
+    const auto & esdf = ilayer->getEsdf();
+    EXPECT_EQ(esdf.rows(), 5);
+    EXPECT_EQ(esdf.cols(), 5);
+    // All cells uninitialised before any update
+    EXPECT_EQ(esdf(0, 0), nav2_costmap_2d::DistanceTransform::DT_INF);
+  }
+
+  // Resize map and verify ESDF tracks the new dimensions
+  layers.resizeMap(8, 8, 0.1, 0, 0);
+
+  {
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> guard(*ilayer->getMutex());
+    const auto & esdf = ilayer->getEsdf();
+    EXPECT_EQ(esdf.rows(), 8);
+    EXPECT_EQ(esdf.cols(), 8);
+  }
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -92,6 +92,8 @@ target_link_libraries(mppi_motion_models PUBLIC
 add_library(mppi_critics SHARED
   src/critics/constraint_critic.cpp
   src/critics/cost_critic.cpp
+  src/critics/corridor_critic.cpp
+  src/critics/esdf_critic.cpp
   src/critics/goal_critic.cpp
   src/critics/goal_angle_critic.cpp
   src/critics/obstacles_critic.cpp

--- a/nav2_mppi_controller/critics.xml
+++ b/nav2_mppi_controller/critics.xml
@@ -5,6 +5,14 @@
       <description>mppi critic for obstacle avoidance</description>
     </class>
 
+    <class type="mppi::critics::EsdfCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic for obstacle avoidance using exact ESDF distances from InflationLayer</description>
+    </class>
+
+    <class type="mppi::critics::CorridorCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic that penalizes trajectories leaving the ESDF-derived safe corridor around the reference path</description>
+    </class>
+
     <class type="mppi::critics::CostCritic" base_class_type="mppi::critics::CriticFunction">
       <description>mppi critic for obstacle avoidance using costmap score</description>
     </class>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/corridor_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/corridor_critic.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__CORRIDOR_CRITIC_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__CORRIDOR_CRITIC_HPP_
+
+#include <memory>
+#include <string>
+
+#include "nav2_costmap_2d/inflation_layer.hpp"
+#include "nav2_costmap_2d/safe_corridor.hpp"
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/models/state.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::CorridorCritic
+ * @brief Penalizes MPPI trajectory samples that deviate beyond the safe corridor
+ * around the reference path.
+ *
+ * The safe corridor at each path point is defined as a circle of radius
+ *   corridor_width[k] = clamp(esdf(path[k]) - robot_radius, 0, max_corridor_width)
+ * centered on path point k. Any trajectory point whose distance to the nearest
+ * path point exceeds that path point's corridor width incurs a penalty
+ * proportional to the excess deviation.
+ *
+ * This complements EsdfCritic (which punishes proximity to obstacles) by also
+ * penalizing trajectories that wander into narrow regions or dead-ends that the
+ * path does not cross, even if those regions are currently obstacle-free.
+ *
+ * Algorithm per scoring cycle:
+ *   1. Compute corridor_width[k] for every path point k (O(path_len) ESDF lookups).
+ *   2. For each trajectory time step j, find the representative path point by
+ *      matching the mean trajectory position at step j (O(path_len) per step).
+ *   3. For every trajectory sample i at step j, add a cost proportional to
+ *      max(0, dist(traj[i,j], path[nk]) - corridor_width[nk]).
+ *      This is vectorized over i using Eigen.
+ *
+ * Parameters (ROS2 params, namespace = critic name):
+ *   enabled              (bool,  default true)
+ *   cost_power           (uint,  default 1)
+ *   cost_weight          (float, default 5.0)
+ *   robot_radius         (float, default 0.0 — auto from inscribed radius)
+ *   max_corridor_width   (float, default 3.0 m)
+ *   threshold_to_consider (float, default 0.5 m — skip critic near goal)
+ *   inflation_layer_name (string, default "" — auto-detect)
+ */
+class CorridorCritic : public CriticFunction
+{
+public:
+  void initialize() override;
+
+  void score(CriticData & data) override;
+
+protected:
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> inflation_layer_{nullptr};
+
+  float robot_radius_{0.0f};
+  float max_corridor_width_{3.0f};
+  float weight_{5.0f};
+  float threshold_to_consider_{0.5f};
+  std::string inflation_layer_name_;
+  unsigned int power_{1};
+};
+
+}  // namespace mppi::critics
+
+#endif  // NAV2_MPPI_CONTROLLER__CRITICS__CORRIDOR_CRITIC_HPP_

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/esdf_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/esdf_critic.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <cmath>
 
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
 #include "nav2_costmap_2d/inflation_layer.hpp"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/esdf_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/esdf_critic.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__ESDF_CRITIC_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__ESDF_CRITIC_HPP_
+
+#include <memory>
+#include <string>
+
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
+#include "nav2_costmap_2d/inflation_layer.hpp"
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/models/state.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::EsdfCritic
+ * @brief Critic that scores trajectories using exact Euclidean distances from
+ * the ESDF exposed by InflationLayer. This avoids the lossy log-inversion
+ * approximation used by ObstaclesCritic when back-computing distance from
+ * costmap costs, yielding more accurate repulsion and margin scoring.
+ *
+ * Requires the costmap to have an InflationLayer (not LegacyInflationLayer).
+ */
+class EsdfCritic : public CriticFunction
+{
+public:
+  void initialize() override;
+
+  void score(CriticData & data) override;
+
+protected:
+  /**
+   * @brief Check if a pose is in collision using exact ESDF distance.
+   * @param esdf_dist  Euclidean distance (m) to nearest obstacle from the cell
+   * @param x          World x of the pose (for footprint check)
+   * @param y          World y of the pose
+   * @param theta      Heading of the pose
+   * @return true if the pose is in collision
+   */
+  inline bool inCollision(float esdf_dist, float x, float y, float theta);
+
+  /**
+   * @brief Fast float world-to-map conversion (avoids double round-trip).
+   */
+  inline bool worldToMapFloat(float wx, float wy, unsigned int & mx, unsigned int & my) const
+  {
+    if (wx < origin_x_ || wy < origin_y_) {
+      return false;
+    }
+    mx = static_cast<unsigned int>((wx - origin_x_) / resolution_);
+    my = static_cast<unsigned int>((wy - origin_y_) / resolution_);
+    return mx < size_x_ && my < size_y_;
+  }
+
+  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+  collision_checker_{nullptr};
+
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> inflation_layer_{nullptr};
+
+  bool consider_footprint_{false};
+  bool is_tracking_unknown_{true};
+
+  float collision_cost_{100000.0f};
+  float collision_margin_distance_{0.10f};
+  float near_goal_distance_{0.5f};
+
+  float inscribed_radius_{0.0f};
+  float circumscribed_radius_{0.0f};
+  float inflation_radius_{0.0f};
+
+  float repulsion_weight_{1.5f};
+  float critical_weight_{20.0f};
+
+  float origin_x_{0.0f}, origin_y_{0.0f}, resolution_{0.0f};
+  unsigned int size_x_{0}, size_y_{0};
+
+  std::string inflation_layer_name_;
+  unsigned int power_{1};
+};
+
+}  // namespace mppi::critics
+
+#endif  // NAV2_MPPI_CONTROLLER__CRITICS__ESDF_CRITIC_HPP_

--- a/nav2_mppi_controller/src/critics/corridor_critic.cpp
+++ b/nav2_mppi_controller/src/critics/corridor_critic.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2026, Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits>
+
+#include "nav2_mppi_controller/critics/corridor_critic.hpp"
+#include "nav2_costmap_2d/inflation_layer_interface.hpp"
+
+namespace mppi::critics
+{
+
+void CorridorCritic::initialize()
+{
+  auto getParam = parameters_handler_->getParamGetter(name_);
+  getParam(power_, "cost_power", 1u);
+  getParam(weight_, "cost_weight", 5.0f);
+  getParam(robot_radius_, "robot_radius", 0.0f);
+  getParam(max_corridor_width_, "max_corridor_width", 3.0f);
+  getParam(threshold_to_consider_, "threshold_to_consider", 0.5f);
+  getParam(inflation_layer_name_, "inflation_layer_name", std::string(""));
+
+  // If robot_radius was not explicitly set, pull the inscribed radius from the costmap
+  if (robot_radius_ <= 0.0f) {
+    robot_radius_ = static_cast<float>(
+      costmap_ros_->getLayeredCostmap()->getInscribedRadius());
+  }
+
+  // Resolve InflationLayer (must be the new version that exposes ESDF)
+  const auto inflation_layer_if = nav2_costmap_2d::InflationLayerInterface::getInflationLayer(
+    costmap_ros_, inflation_layer_name_);
+  if (inflation_layer_if) {
+    inflation_layer_ =
+      std::dynamic_pointer_cast<nav2_costmap_2d::InflationLayer>(inflation_layer_if);
+  }
+
+  if (!inflation_layer_) {
+    RCLCPP_ERROR(
+      logger_,
+      "CorridorCritic requires an InflationLayer (not LegacyInflationLayer) "
+      "that exposes ESDF distances. No compatible layer found. Critic disabled.");
+    enabled_ = false;
+    return;
+  }
+
+  RCLCPP_INFO(
+    logger_,
+    "CorridorCritic instantiated with %d power, %.2f weight, "
+    "robot_radius=%.3f m, max_corridor_width=%.2f m.",
+    power_, weight_, robot_radius_, max_corridor_width_);
+}
+
+void CorridorCritic::score(CriticData & data)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  // Skip when very close to the goal — the path near the goal may have little
+  // clearance, and other critics handle the final approach
+  if (data.state.local_path_length < threshold_to_consider_) {
+    return;
+  }
+
+  const Eigen::Index path_len =
+    static_cast<Eigen::Index>(data.path.x.size());
+  const int traj_len = static_cast<int>(data.trajectories.x.cols());
+  const int batch_size = static_cast<int>(data.trajectories.x.rows());
+
+  if (path_len < 2) {
+    return;
+  }
+
+  // ------------------------------------------------------------------
+  // 1. Precompute corridor widths at every path point.
+  //    width[k] = clamp(esdf(path[k]) - robot_radius, 0, max_corridor_width)
+  // ------------------------------------------------------------------
+  const Eigen::ArrayXf corridor_widths =
+    nav2_costmap_2d::SafeCorridorComputer::computeWidths(
+      data.path.x.head(path_len),
+      data.path.y.head(path_len),
+      *inflation_layer_,
+      *costmap_,
+      robot_radius_,
+      max_corridor_width_);
+
+  // ------------------------------------------------------------------
+  // 2. Score trajectories.
+  //
+  // For each time step j:
+  //   a) Find the reference path point by matching the mean trajectory
+  //      position at step j to the nearest path point (O(path_len)).
+  //   b) Compute cross-track distance for all batch samples vectorially.
+  //   c) Add max(0, dist - corridor_width) to each sample's cost.
+  // ------------------------------------------------------------------
+  Eigen::ArrayXf cost = Eigen::ArrayXf::Zero(batch_size);
+
+  // ArrayXXf is column-major: column j starts at data() + j * batch_size,
+  // giving a contiguous block of batch_size floats we can Map as ArrayXf.
+  for (int j = 0; j < traj_len; j++) {
+    Eigen::Map<const Eigen::ArrayXf> tx_j(
+      data.trajectories.x.data() + j * batch_size, batch_size);
+    Eigen::Map<const Eigen::ArrayXf> ty_j(
+      data.trajectories.y.data() + j * batch_size, batch_size);
+
+    // Representative position for this time step: mean over all samples
+    const float mean_x = tx_j.mean();
+    const float mean_y = ty_j.mean();
+
+    // Find the nearest path point to the mean position
+    Eigen::Index nk = 0;
+    float min_dist2 = std::numeric_limits<float>::max();
+    for (Eigen::Index k = 0; k < path_len; k++) {
+      const float dx = mean_x - data.path.x(k);
+      const float dy = mean_y - data.path.y(k);
+      const float d2 = dx * dx + dy * dy;
+      if (d2 < min_dist2) {
+        min_dist2 = d2;
+        nk = k;
+      }
+    }
+
+    const float corridor_w = corridor_widths(nk);
+    const float ref_x = data.path.x(nk);
+    const float ref_y = data.path.y(nk);
+
+    // Vectorized cross-track distances and corridor excess for all samples
+    const Eigen::ArrayXf dx = tx_j - ref_x;
+    const Eigen::ArrayXf dy = ty_j - ref_y;
+    const Eigen::ArrayXf dist = (dx.square() + dy.square()).sqrt();
+
+    cost += (dist - corridor_w).max(0.0f);
+  }
+
+  // Normalize by trajectory length so cost is per-step, then weight and apply power
+  const float norm = weight_ / static_cast<float>(traj_len);
+  if (power_ > 1u) {
+    data.costs += (norm * cost).pow(static_cast<float>(power_));
+  } else {
+    data.costs += norm * cost;
+  }
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(
+  mppi::critics::CorridorCritic,
+  mppi::critics::CriticFunction)

--- a/nav2_mppi_controller/src/critics/corridor_critic.cpp
+++ b/nav2_mppi_controller/src/critics/corridor_critic.cpp
@@ -88,8 +88,8 @@ void CorridorCritic::score(CriticData & data)
   // ------------------------------------------------------------------
   const Eigen::ArrayXf corridor_widths =
     nav2_costmap_2d::SafeCorridorComputer::computeWidths(
-      data.path.x.head(path_len),
-      data.path.y.head(path_len),
+      data.path.x,
+      data.path.y,
       *inflation_layer_,
       *costmap_,
       robot_radius_,

--- a/nav2_mppi_controller/src/critics/corridor_critic.cpp
+++ b/nav2_mppi_controller/src/critics/corridor_critic.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <limits>
+#include <string>
 
 #include "nav2_mppi_controller/critics/corridor_critic.hpp"
 #include "nav2_costmap_2d/inflation_layer_interface.hpp"

--- a/nav2_mppi_controller/src/critics/esdf_critic.cpp
+++ b/nav2_mppi_controller/src/critics/esdf_critic.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/critics/esdf_critic.hpp"
+#include "nav2_costmap_2d/inflation_layer_interface.hpp"
+#include "nav2_core/controller_exceptions.hpp"
+
+namespace mppi::critics
+{
+
+void EsdfCritic::initialize()
+{
+  auto getParam = parameters_handler_->getParamGetter(name_);
+  getParam(consider_footprint_, "consider_footprint", false);
+  getParam(power_, "cost_power", 1);
+  getParam(repulsion_weight_, "repulsion_weight", 1.5f);
+  getParam(critical_weight_, "critical_weight", 20.0f);
+  getParam(collision_cost_, "collision_cost", 100000.0f);
+  getParam(collision_margin_distance_, "collision_margin_distance", 0.10f);
+  getParam(near_goal_distance_, "near_goal_distance", 0.5f);
+  getParam(inflation_layer_name_, "inflation_layer_name", std::string(""));
+
+  collision_checker_.setCostmap(costmap_);
+
+  // Resolve the inflation layer and verify it exposes ESDF (new InflationLayer, not Legacy)
+  const auto inflation_layer_if = nav2_costmap_2d::InflationLayerInterface::getInflationLayer(
+    costmap_ros_, inflation_layer_name_);
+  if (inflation_layer_if) {
+    inflation_layer_ =
+      std::dynamic_pointer_cast<nav2_costmap_2d::InflationLayer>(inflation_layer_if);
+  }
+
+  if (!inflation_layer_) {
+    RCLCPP_ERROR(
+      logger_,
+      "EsdfCritic requires an InflationLayer (not LegacyInflationLayer) in the costmap. "
+      "No compatible inflation layer found. The critic is disabled. "
+      "Use ObstaclesCritic or CostCritic as a fallback.");
+    enabled_ = false;
+    return;
+  }
+
+  if (costmap_ros_->getUseRadius() == consider_footprint_) {
+    RCLCPP_WARN(
+      logger_,
+      "Inconsistent configuration: consider_footprint=%s but the costmap uses a %s. "
+      "Please verify robot shape settings.",
+      consider_footprint_ ? "true" : "false",
+      costmap_ros_->getUseRadius() ? "radius" : "footprint polygon");
+    if (costmap_ros_->getUseRadius()) {
+      throw nav2_core::ControllerException(
+              "EsdfCritic: consider_footprint=true but the costmap uses a circular radius. "
+              "Disable consider_footprint or provide a full footprint polygon.");
+    }
+  }
+
+  inscribed_radius_ = static_cast<float>(
+    costmap_ros_->getLayeredCostmap()->getInscribedRadius());
+  circumscribed_radius_ = static_cast<float>(
+    costmap_ros_->getLayeredCostmap()->getCircumscribedRadius());
+  inflation_radius_ = static_cast<float>(inflation_layer_->getInflationRadius());
+
+  RCLCPP_INFO(
+    logger_,
+    "EsdfCritic instantiated with %d power and %.2f / %.2f weights. "
+    "Inflation radius: %.3f m. Collision check: %s.",
+    power_, critical_weight_, repulsion_weight_, inflation_radius_,
+    consider_footprint_ ? "footprint" : "circular");
+}
+
+bool EsdfCritic::inCollision(float dist, float x, float y, float theta)
+{
+  // On or within inscribed radius of a lethal obstacle: always a collision
+  if (dist <= inscribed_radius_) {
+    return true;
+  }
+
+  // Between inscribed and circumscribed: full footprint check needed
+  if (consider_footprint_ && dist < circumscribed_radius_) {
+    const float fp_cost = static_cast<float>(
+      collision_checker_.footprintCostAtPose(
+        x, y, theta, costmap_ros_->getRobotFootprint()));
+    switch (static_cast<unsigned char>(fp_cost)) {
+      case nav2_costmap_2d::LETHAL_OBSTACLE:
+        return true;
+      case nav2_costmap_2d::NO_INFORMATION:
+        return !is_tracking_unknown_;
+      default:
+        break;
+    }
+  }
+
+  return false;
+}
+
+void EsdfCritic::score(CriticData & data)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  is_tracking_unknown_ = costmap_ros_->getLayeredCostmap()->isTrackingUnknown();
+
+  // Refresh radii in case footprint changed since initialization
+  inscribed_radius_ = static_cast<float>(
+    costmap_ros_->getLayeredCostmap()->getInscribedRadius());
+  inflation_radius_ = static_cast<float>(inflation_layer_->getInflationRadius());
+
+  // Cache costmap geometry for fast world→cell conversion
+  auto * cm = costmap_;
+  origin_x_ = static_cast<float>(cm->getOriginX());
+  origin_y_ = static_cast<float>(cm->getOriginY());
+  resolution_ = static_cast<float>(cm->getResolution());
+  size_x_ = cm->getSizeInCellsX();
+  size_y_ = cm->getSizeInCellsY();
+
+  const bool near_goal = (data.state.local_path_length < near_goal_distance_);
+
+  const unsigned int traj_len = data.trajectories.x.cols();
+  const unsigned int batch_size = data.trajectories.x.rows();
+
+  Eigen::ArrayXf raw_cost = Eigen::ArrayXf::Zero(data.costs.size());
+  Eigen::ArrayXf repulsive_cost = Eigen::ArrayXf::Zero(data.costs.size());
+  bool all_trajectories_collide = true;
+
+  auto & collisions = data.trajectories_in_collision;
+  const bool track_collisions = !collisions.empty();
+
+  for (unsigned int i = 0; i != batch_size; i++) {
+    bool trajectory_collide = false;
+    float traj_critical_cost = 0.0f;
+    const auto & traj = data.trajectories;
+
+    for (unsigned int j = 0; j != traj_len; j++) {
+      const float tx = traj.x(i, j);
+      const float ty = traj.y(i, j);
+
+      unsigned int mx, my;
+      if (!worldToMapFloat(tx, ty, mx, my)) {
+        trajectory_collide = true;
+        break;
+      }
+
+      // Check for NO_INFORMATION before querying ESDF
+      // (the ESDF only tracks lethal obstacles unless inflate_around_unknown is set)
+      const unsigned char cell_cost = cm->getCost(mx + my * size_x_);
+      if (cell_cost == nav2_costmap_2d::NO_INFORMATION) {
+        if (!is_tracking_unknown_) {
+          trajectory_collide = true;
+          break;
+        }
+        continue;
+      }
+
+      const float dist = inflation_layer_->getDistanceToObstacle(mx, my);
+
+      if (inCollision(dist, tx, ty, traj.yaws(i, j))) {
+        trajectory_collide = true;
+        break;
+      }
+
+      // Near-collision penalty: punish poses that are too close to obstacles
+      if (dist < collision_margin_distance_) {
+        traj_critical_cost += collision_margin_distance_ - dist;
+      }
+
+      // Repulsion: prefer trajectories further from obstacles
+      if (!near_goal && dist < inflation_radius_) {
+        repulsive_cost[i] += inflation_radius_ - dist;
+      }
+    }
+
+    if (!trajectory_collide) {all_trajectories_collide = false;}
+    raw_cost(i) = trajectory_collide ? collision_cost_ : traj_critical_cost;
+    if (trajectory_collide && track_collisions) {collisions[i] = true;}
+  }
+
+  // Normalize repulsive cost by trajectory length so it doesn't outweigh critical cost
+  const auto repulsive_cost_normalized =
+    (repulsive_cost - repulsive_cost.minCoeff()) / static_cast<float>(traj_len);
+
+  if (power_ > 1u) {
+    data.costs +=
+      ((critical_weight_ * raw_cost) +
+      (repulsion_weight_ * repulsive_cost_normalized)).pow(power_);
+  } else {
+    data.costs +=
+      (critical_weight_ * raw_cost) +
+      (repulsion_weight_ * repulsive_cost_normalized);
+  }
+
+  data.fail_flag = all_trajectories_collide;
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(
+  mppi::critics::EsdfCritic,
+  mppi::critics::CriticFunction)

--- a/nav2_mppi_controller/src/critics/esdf_critic.cpp
+++ b/nav2_mppi_controller/src/critics/esdf_critic.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
 #include "nav2_mppi_controller/critics/esdf_critic.hpp"
 #include "nav2_costmap_2d/inflation_layer_interface.hpp"
 #include "nav2_core/controller_exceptions.hpp"
@@ -182,9 +184,13 @@ void EsdfCritic::score(CriticData & data)
       }
     }
 
-    if (!trajectory_collide) {all_trajectories_collide = false;}
+    if (!trajectory_collide) {
+      all_trajectories_collide = false;
+    }
     raw_cost(i) = trajectory_collide ? collision_cost_ : traj_critical_cost;
-    if (trajectory_collide && track_collisions) {collisions[i] = true;}
+    if (trajectory_collide && track_collisions) {
+      collisions[i] = true;
+    }
   }
 
   // Normalize repulsive cost by trajectory length so it doesn't outweigh critical cost


### PR DESCRIPTION
Closes #5979

## Summary

- **ESDF in `InflationLayer`**: The Felzenszwalb-Huttenlocher transform was already running internally. This PR persists the result as a full-costmap `esdf_` matrix and exposes `getDistanceToObstacle(mx, my)` and `getEsdf()`. Overhead is a single Eigen block-copy per costmap update — not a second DT pass.
- **`SafeCorridorComputer`** (`nav2_costmap_2d`): Header-only utility computing per-path-point corridor widths as `clamp(esdf(path[k]) − robot_radius, 0, max_width)`. Reusable by any controller.
- **`EsdfCritic`** (MPPI): Drop-in replacement for `ObstaclesCritic` using exact ESDF distances instead of the lossy log-inversion approximation.
- **`CorridorCritic`** (MPPI): Penalizes trajectory samples that deviate beyond the ESDF-derived safe corridor around the reference path.

## Test plan
- [ ] `testEsdfDistances`: obstacle=0m, axis neighbor=0.1m, diagonal=√2·0.1m, matrix dimensions match costmap
- [ ] `testEsdfMatchSizeReset`: DT_INF before first update, dimensions track map resize
- [ ] Manual: `EsdfCritic` vs `ObstaclesCritic` collision avoidance in simulation
- [ ] Manual: `CorridorCritic` prevents samples wandering into narrow gaps

## Future work
- Integrate `SafeCorridorComputer` into RPP/Graceful as a cross-track tolerance bound instead of full collision checks
- Directional (asymmetric) corridor widths using binary search on the ESDF gradient