### PR TITLE
[mppi] Add per-axis delay compensation with cmd-history replay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN mkdir -p $ROOT_SRV
 RUN apt-get update && apt-get install -y \
       ros-$ROS_DISTRO-rviz2
 
-# install gzweb dependacies
+# install gzweb dependencies
 RUN apt-get install -y --no-install-recommends \
       imagemagick \
       libboost-all-dev \
@@ -197,14 +197,14 @@ RUN cd $GZWEB_WS && . /usr/share/gazebo/setup.sh && \
     ln -s $GZWEB_WS/http/client/assets http/client/assets/models && \
     ln -s $GZWEB_WS/http/client $ROOT_SRV/gzweb
 
-# patch gzsever
+# patch gzserver
 RUN GZSERVER=$(which gzserver) && \
     mv $GZSERVER $GZSERVER.orig && \
     echo '#!/bin/bash' > $GZSERVER && \
     echo 'exec xvfb-run -s "-screen 0 1280x1024x24" gzserver.orig "$@"' >> $GZSERVER && \
     chmod +x $GZSERVER
 
-# install foxglove dependacies
+# install foxglove dependencies
 RUN apt-get install -y --no-install-recommends \
       ros-$ROS_DISTRO-foxglove-bridge
 

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -134,6 +134,9 @@ controller_server:
       plugin: "nav2_mppi_controller::MPPIController"
       time_steps: 56
       model_dt: 0.05
+      model_delay_vx: 0.0
+      model_delay_vy: 0.0
+      model_delay_wz: 0.0
       batch_size: 2000
       open_loop: false
       ax_max: 3.0

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
@@ -31,6 +31,9 @@ struct OptimizerSettings
   models::ControlConstraints constraints{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
   models::SamplingStd sampling_std{0.0f, 0.0f, 0.0f};
   float model_dt{0.0f};
+  float model_delay_vx{0.0f};
+  float model_delay_vy{0.0f};
+  float model_delay_wz{0.0f};
   float controller_period{0.0f};
   float temperature{0.0f};
   float gamma{0.0f};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -152,12 +152,7 @@ public:
     const unsigned int offset_wz = std::floor((model_delay_wz_ / model_dt_) + 0.5);
 
     if (offset_vx > 0u || offset_wz > 0u || (is_holo && offset_vy > 0u)) {
-      auto state_copy = state;
-      applyDelayShift(state.vx, state_copy.vx, cmd_history_vx_, offset_vx);
-      applyDelayShift(state.wz, state_copy.wz, cmd_history_wz_, offset_wz);
-      if (is_holo) {
-        applyDelayShift(state.vy, state_copy.vy, cmd_history_vy_, offset_vy);
-      }
+      applyDelayShift(state, is_holo, offset_vx, offset_vy, offset_wz);
     }
   }
 
@@ -180,26 +175,33 @@ protected:
     * For j in [1, offset) — the delay window — fill `dst` with history[j]
     */
   void applyDelayShift(
-    Eigen::ArrayXXf & dst,
-    const Eigen::ArrayXXf & src,
-    const std::vector<float> & history,
-    unsigned int offset) const
+    models::State & state, bool is_holo,
+    unsigned int offset_vx, unsigned int offset_vy, unsigned int offset_wz) const
   {
-    if (offset == 0u) {
-      return;
-    }
+    auto shift = [](Eigen::ArrayXXf & velocities, unsigned int offset,
+      const std::vector<float> & history) {
+        const unsigned int cols = static_cast<unsigned int>(velocities.cols());
+        if (offset == 0u || cols == 0u) {
+          return;
+        }
 
-    const auto cols = static_cast<unsigned int>(dst.cols());
-    const unsigned int replay_end = std::min<unsigned int>(offset, cols);
+        // Shift cols in-place right-to-left by offset
+        for (unsigned int k = (offset < cols) ? cols - offset : 0u; k > 0; --k) {
+          velocities.col(offset + k - 1) = velocities.col(k);
+        }
 
-    // Replay from command history
-    for (unsigned int j = 1; j < replay_end; j++) {
-      dst.col(j).setConstant(history[j]);
-    }
+        // Fill delay window cols with the in-flight commands from history.
+        const unsigned int end = std::min(offset, cols);
+        for (unsigned int j = 1; j < end; ++j) {
+          velocities.col(j).setConstant(history[j]);
+        }
+      };
 
-    if (offset < cols) {
-      const auto n = static_cast<Eigen::Index>(cols - offset);
-      dst.rightCols(n) = src.middleCols(1, n);
+    shift(state.vx, offset_vx, cmd_history_vx_);
+    shift(state.wz, offset_wz, cmd_history_wz_);
+
+    if (is_holo) {
+      shift(state.vy, offset_vy, cmd_history_vy_);
     }
   }
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <string>
 #include <algorithm>
+#include <vector>
 
 #include "nav2_mppi_controller/models/control_sequence.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
@@ -63,10 +64,40 @@ public:
     * @param control_constraints Constraints on control
     * @param model_dt duration of a time step
     */
-  void setConstraints(const models::ControlConstraints & control_constraints, float model_dt)
+  void setConstraints(
+    const models::ControlConstraints & control_constraints, float model_dt,
+    float model_delay_vx, float model_delay_vy, float model_delay_wz)
   {
     control_constraints_ = control_constraints;
     model_dt_ = model_dt;
+    model_delay_vx_ = model_delay_vx;
+    model_delay_vy_ = model_delay_vy;
+    model_delay_wz_ = model_delay_wz;
+
+    cmd_history_vx_.resize(offsetSteps(model_delay_vx_), 0.0f);
+    cmd_history_vy_.resize(offsetSteps(model_delay_vy_), 0.0f);
+    cmd_history_wz_.resize(offsetSteps(model_delay_wz_), 0.0f);
+  }
+
+  /**
+    * @brief Push the most recently published command to the per-axis history
+    *        ring buffers. Called once per controller cycle from the optimizer.
+    */
+  void pushCommandHistory(float vx, float vy, float wz)
+  {
+    pushOne(cmd_history_vx_, vx);
+    pushOne(cmd_history_vy_, vy);
+    pushOne(cmd_history_wz_, wz);
+  }
+
+  /**
+    * @brief Zero the ring buffers
+    */
+  void clearCommandHistory()
+  {
+    std::fill(cmd_history_vx_.begin(), cmd_history_vx_.end(), 0.0f);
+    std::fill(cmd_history_vy_.begin(), cmd_history_vy_.end(), 0.0f);
+    std::fill(cmd_history_wz_.begin(), cmd_history_wz_.end(), 0.0f);
   }
 
   /**
@@ -115,6 +146,19 @@ public:
           .cwiseMin(upper_bound_vy);
       }
     }
+
+    const unsigned int offset_vx = std::floor((model_delay_vx_ / model_dt_) + 0.5);
+    const unsigned int offset_vy = std::floor((model_delay_vy_ / model_dt_) + 0.5);
+    const unsigned int offset_wz = std::floor((model_delay_wz_ / model_dt_) + 0.5);
+
+    if (offset_vx > 0u || offset_wz > 0u || (is_holo && offset_vy > 0u)) {
+      auto state_copy = state;
+      applyDelayShift(state.vx, state_copy.vx, cmd_history_vx_, offset_vx);
+      applyDelayShift(state.wz, state_copy.wz, cmd_history_wz_, offset_wz);
+      if (is_holo) {
+        applyDelayShift(state.vy, state_copy.vy, cmd_history_vy_, offset_vy);
+      }
+    }
   }
 
   /**
@@ -130,7 +174,66 @@ public:
   virtual void applyConstraints(models::ControlSequence & /*control_sequence*/) {}
 
 protected:
+  /**
+    * @brief Apply the per-axis input-delay shift to velocity rollout.
+    *
+    * For j in [1, offset) — the delay window — fill `dst` with history[j]
+    */
+  void applyDelayShift(
+    Eigen::ArrayXXf & dst,
+    const Eigen::ArrayXXf & src,
+    const std::vector<float> & history,
+    unsigned int offset) const
+  {
+    if (offset == 0u) {
+      return;
+    }
+
+    const auto cols = static_cast<unsigned int>(dst.cols());
+    const unsigned int replay_end = std::min<unsigned int>(offset, cols);
+
+    // Replay from command history
+    for (unsigned int j = 1; j < replay_end; j++) {
+      dst.col(j).setConstant(history[j]);
+    }
+
+    if (offset < cols) {
+      const auto n = static_cast<Eigen::Index>(cols - offset);
+      dst.rightCols(n) = src.middleCols(1, n);
+    }
+  }
+
+  /**
+    * @brief Convert a delay in seconds to an offset in number of rollout steps, rounding to the nearest step.
+    */
+  std::size_t offsetSteps(float delay) const
+  {
+    if (delay <= 0.0f || model_dt_ <= 0.0f) {
+      return 0u;
+    }
+    return static_cast<std::size_t>(std::floor(delay / model_dt_ + 0.5f));
+  }
+
+  /**
+    * @brief Push a value to the back of a ring buffer and rotate the elements.
+    */
+  static void pushOne(std::vector<float> & buf, float v)
+  {
+    if (buf.empty()) {return;}
+    std::rotate(buf.begin(), buf.begin() + 1, buf.end());
+    buf.back() = v;
+  }
+
   float model_dt_{0.0};
+  float model_delay_vx_{0.0};
+  float model_delay_vy_{0.0};
+  float model_delay_wz_{0.0};
+
+  // Per-axis ring buffer of recently published commands
+  std::vector<float> cmd_history_vx_;
+  std::vector<float> cmd_history_vy_;
+  std::vector<float> cmd_history_wz_;
+
   models::ControlConstraints control_constraints_{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
     0.0f, 0.0f};
 };

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -102,6 +102,9 @@ void Optimizer::getParams()
   }
 
   getParam(s.model_dt, "model_dt", 0.05f);
+  getParam(s.model_delay_vx, "model_delay_vx", 0.0f);
+  getParam(s.model_delay_vy, "model_delay_vy", 0.0f);
+  getParam(s.model_delay_wz, "model_delay_wz", 0.0f);
   getParam(s.time_steps, "time_steps", 56);
   getParam(s.batch_size, "batch_size", 1000);
   getParam(s.iteration_count, "iteration_count", 1);
@@ -194,7 +197,9 @@ void Optimizer::reset(bool reset_dynamic_speed_limits)
   generated_trajectories_.reset(settings_.batch_size, settings_.time_steps);
 
   noise_generator_.reset(settings_, isHolonomic());
-  motion_model_->setConstraints(settings_.constraints, settings_.model_dt);
+  motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
+    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
+  motion_model_->clearCommandHistory();
   trajectory_validator_->initialize(
     parent_, name_ + ".TrajectoryValidator",
     costmap_ros_, parameters_handler_, tf_buffer_, settings_);
@@ -643,9 +648,11 @@ geometry_msgs::msg::TwistStamped Optimizer::getControlFromSequenceAsTwist(
 
   auto vx = control_sequence_.vx(offset);
   auto wz = control_sequence_.wz(offset);
+  auto vy = isHolonomic() ? control_sequence_.vy(offset) : 0.0f;
+
+  motion_model_->pushCommandHistory(vx, vy, wz);
 
   if (isHolonomic()) {
-    auto vy = control_sequence_.vy(offset);
     return utils::toTwistStamped(vx, vy, wz, stamp, costmap_ros_->getBaseFrameID());
   }
 
@@ -665,7 +672,8 @@ void Optimizer::setMotionModel(const std::string & motion_model_name)
     plugin_type = nav2::get_plugin_type_param(node, plugin_ns);
     motion_model_ = motion_model_loader_->createSharedInstance(plugin_type);
     motion_model_->initialize(parameters_handler_, plugin_ns);
-    motion_model_->setConstraints(settings_.constraints, settings_.model_dt);
+    motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
+      settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
   } catch (const pluginlib::PluginlibException & ex) {
     throw nav2_core::ControllerException(
             std::string("Failed to load motion model plugin '") + motion_model_name +
@@ -700,7 +708,8 @@ void Optimizer::setSpeedLimit(double speed_limit, bool percentage)
       s.constraints.wz = s.base_constraints.wz * ratio;
     }
   }
-  motion_model_->setConstraints(settings_.constraints, settings_.model_dt);
+  motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
+    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
 }
 
 models::Trajectories & Optimizer::getGeneratedTrajectories()

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -650,6 +650,7 @@ geometry_msgs::msg::TwistStamped Optimizer::getControlFromSequenceAsTwist(
   auto wz = control_sequence_.wz(offset);
   auto vy = isHolonomic() ? control_sequence_.vy(offset) : 0.0f;
 
+  // Update the command history for the motion model's latency compensation mechanism
   motion_model_->pushCommandHistory(vx, vy, wz);
 
   if (isHolonomic()) {

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -255,6 +255,99 @@ TEST(MotionModelTests, AckermannReversingTest)
   model.reset();
 }
 
+static models::ControlConstraints unboundedConstraints()
+{
+  return {100, -100, 100, 100, 1000, -1000, -1000, 1000, 1000};
+}
+
+TEST(MotionModelTests, DelayReplayAllAxes)
+{
+  // Omni model exercises all three axes (vx, vy, wz) in a single test.
+  // delay_vx = 0.10s -> offset 2; delay_wz = 0.15s -> offset 3.
+  models::State state;
+  state.reset(8, 20);
+
+  OmniMotionModel model;
+
+  // Set model_dt, model_delay_vx, model_delay_vy, model_delay_wz = 0.05f, 0.10f, 0.10f, 0.15f;
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.10f, 0.15f);
+
+  // Ring-buffer size of vx/vy/wz = 2/2/3 steps
+  // After 3 pushes per axis the rings hold the most-recent 2/2/3 values.
+  model.pushCommandHistory(1.0f, 2.0f, 3.0f);
+  model.pushCommandHistory(5.0f, 6.0f, 7.0f);
+  model.pushCommandHistory(9.0f, 8.0f, 4.0f);
+
+  model.predict(state);
+
+  // predict() populates starting at column 1; column 0 holds the current
+  // measurement / last command set by the optimizer before predict() runs.
+  EXPECT_TRUE(state.vx.col(0).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.vy.col(0).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.wz.col(0).isApproxToConstant(0.0f));
+
+  EXPECT_TRUE(state.vx.col(1).isApproxToConstant(9.0f));
+  EXPECT_TRUE(state.vy.col(1).isApproxToConstant(8.0f));
+  EXPECT_TRUE(state.wz.col(1).isApproxToConstant(7.0f));
+
+  // The wz buffer has a size of 3, so check the last value as well
+  EXPECT_TRUE(state.wz.col(2).isApproxToConstant(4.0f));
+
+  // Outside of the delay window are still zero
+  EXPECT_TRUE(state.vx.col(2).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.vy.col(2).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.vx.col(3).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.vy.col(3).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.wz.col(3).isApproxToConstant(0.0f));
+}
+
+TEST(MotionModelTests, DelayVyIgnoredOnDiffDrive)
+{
+  models::State state;
+  state.reset(8, 20);
+
+  DiffDriveMotionModel model;
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.10f, 0.0f);
+  model.pushCommandHistory(0.0f, 99.0f, 0.0f);
+  model.pushCommandHistory(0.0f, 99.0f, 0.0f);
+
+  EXPECT_NO_THROW(model.predict(state));
+  EXPECT_TRUE(state.vy.isApprox(Eigen::ArrayXXf::Zero(8, 20)));
+}
+
+TEST(MotionModelTests, DelayClearCommandHistory)
+{
+  models::State state;
+  state.reset(8, 20);
+
+  DiffDriveMotionModel model;
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.0f, 0.15f);
+  model.pushCommandHistory(7.0f, 0.0f, 7.0f);
+  model.clearCommandHistory();
+  model.predict(state);
+
+  EXPECT_TRUE(state.vx.col(1).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.wz.col(1).isApproxToConstant(0.0f));
+  EXPECT_TRUE(state.wz.col(2).isApproxToConstant(0.0f));
+}
+
+TEST(MotionModelTests, DelayZeroSkipsShift)
+{
+  models::State state;
+  state.reset(8, 20);
+
+  // Set non-zero velocity and check that it remains unchanged after predict()
+  state.vx.col(0).setConstant(2.0f);
+  state.cvx.setConstant(2.0f);
+
+  DiffDriveMotionModel model;
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.0f, 0.0f);
+  EXPECT_NO_THROW(model.pushCommandHistory(123.0f, 0.0f, 0.0f));
+  model.predict(state);
+
+  EXPECT_TRUE(state.vx.isApproxToConstant(2.0f));
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6065 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | will be tested on our own hardware|
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

This PR adds a feature to compensate per-axis delay as described in the conversation in PR #6066
* Added parameters: model_delay_vx, model_delay_vy and model_delay_wz
* In the mppi, the delayed seconds are filled with the actual past published commands to compensate for the transport delay of the actuators

Also fixed two small typos in the Dockerfile

## Description of documentation updates required from your changes
Need to add descriptions for the three new parameters (model_delay_vx, model_delay_vy and model_delay_wz)
Description could be something like:
`Actuator delay in seconds. The rollout shifts the control sequence by ``round(model_delay_vx / model_dt)`` steps and replays recently published commands during the delay window.`

## Description of how this change was tested
The changes was tested in simulation with our sweeper with nav2 jazzy. 

## Tests on real hardware (Four-wheel steered vehicle with hydraulic steering)
With delay compensation disabled, the vehicle oscillates after each serpentine turn. 
With it enabled, tracking is much better, but the vehicle starts to steer slightly too early and cuts the corner. I think that could be fixed by spending more time tuning the cost functions.

Serpentines:
<img width="4200" height="4400" alt="serpentines_vx_wz_xy" src="https://github.com/user-attachments/assets/8c751454-2a7f-4f2a-81ee-3ee522849b8d" />

Circle:
<img width="7000" height="2200" alt="circles_vx_wz_xy" src="https://github.com/user-attachments/assets/607fd1f9-6a0e-4708-ad45-8018e1450f75" />
In the case of driving a circle, the tracking is also much better with the enabled delay compensation.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
