### PR TITLE
feat: add semgrep rules to enforce Nav2 C++ coding standards

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,27 @@
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  semgrep:
+    name: Semgrep Nav2 Coding Standards
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep:1.76.0
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run semgrep rules
+        run: |
+          semgrep \
+            --config .semgrep/nav2_coding_standards.yml \
+            --verbose \
+            --exclude "nav2_ros_common/" \
+            --include "*.cpp" \
+            --include "*.hpp" \
+            --include "*.h" \
+            .

--- a/.semgrep/nav2_coding_standards.yml
+++ b/.semgrep/nav2_coding_standards.yml
@@ -1,0 +1,123 @@
+# Nav2 Coding Standards - Semgrep Rules
+#
+# Enforces Nav2 type conventions over raw rclcpp:: equivalents.
+# See: https://github.com/ros-navigation/navigation2/issues/6079
+#
+# Prefer:
+#   nav2::Publisher<T>       over  rclcpp::Publisher<T>
+#   nav2::ServiceClient<T>   over  rclcpp::Client<T>
+#   nav2::ServiceServer<T>   over  rclcpp::Service<T>
+#   nav2::Subscription<T>    over  rclcpp::Subscription<T>
+#   declare_or_get_parameter over  separate declare_parameter + get_parameter
+
+rules:
+  - id: nav2-use-nav2-publisher
+    patterns:
+      - pattern: rclcpp::Publisher<$T>
+      - pattern-not-inside: |
+          using $ALIAS = rclcpp::Publisher<$T>;
+    message: >
+      Use nav2::Publisher<$T> instead of rclcpp::Publisher<$T>.
+      nav2::Publisher is a lifecycle-aware publisher following Nav2 conventions.
+      Include: #include "nav2_ros_common/publisher.hpp"
+    languages: [cpp]
+    severity: WARNING
+    metadata:
+      category: style
+      subcategory: [maintainability]
+      references:
+        - https://github.com/ros-navigation/navigation2/issues/6079
+    paths:
+      exclude:
+        - "nav2_ros_common/**"
+        - "**/test/**"
+        - "**/*_test.cpp"
+
+  - id: nav2-use-nav2-service-client
+    patterns:
+      - pattern: rclcpp::Client<$T>
+      - pattern-not-inside: |
+          using $ALIAS = rclcpp::Client<$T>;
+    message: >
+      Use nav2::ServiceClient<$T> instead of rclcpp::Client<$T>.
+      nav2::ServiceClient provides lifecycle awareness and a simpler call interface.
+      Include: #include "nav2_ros_common/service_client.hpp"
+    languages: [cpp]
+    severity: WARNING
+    metadata:
+      category: style
+      subcategory: [maintainability]
+      references:
+        - https://github.com/ros-navigation/navigation2/issues/6079
+    paths:
+      exclude:
+        - "nav2_ros_common/**"
+        - "**/test/**"
+        - "**/*_test.cpp"
+
+  - id: nav2-use-nav2-service-server
+    patterns:
+      - pattern: rclcpp::Service<$T>
+      - pattern-not-inside: |
+          using $ALIAS = rclcpp::Service<$T>;
+    message: >
+      Use nav2::ServiceServer<$T> instead of rclcpp::Service<$T>.
+      nav2::ServiceServer integrates with the Nav2 lifecycle and bond system.
+      Include: #include "nav2_ros_common/service_server.hpp"
+    languages: [cpp]
+    severity: WARNING
+    metadata:
+      category: style
+      subcategory: [maintainability]
+      references:
+        - https://github.com/ros-navigation/navigation2/issues/6079
+    paths:
+      exclude:
+        - "nav2_ros_common/**"
+        - "**/test/**"
+        - "**/*_test.cpp"
+
+  - id: nav2-use-nav2-subscription
+    patterns:
+      - pattern: rclcpp::Subscription<$T>
+      - pattern-not-inside: |
+          using $ALIAS = rclcpp::Subscription<$T>;
+    message: >
+      Use nav2::Subscription<$T> instead of rclcpp::Subscription<$T>
+      for Nav2 naming consistency and potential future API extensions.
+      Include: #include "nav2_ros_common/subscription.hpp"
+    languages: [cpp]
+    severity: WARNING
+    metadata:
+      category: style
+      subcategory: [maintainability]
+      references:
+        - https://github.com/ros-navigation/navigation2/issues/6079
+    paths:
+      exclude:
+        - "nav2_ros_common/**"
+        - "**/test/**"
+        - "**/*_test.cpp"
+
+  - id: nav2-use-declare-or-get-parameter
+    pattern: |
+      $NODE->declare_parameter($PARAM_NAME, ...);
+      ...
+      $NODE->get_parameter($PARAM_NAME, ...);
+    message: >
+      Prefer nav2::declare_or_get_parameter() over calling declare_parameter() and
+      get_parameter() separately. This consolidates parameter declaration and retrieval
+      and follows Nav2 parameter conventions.
+      See: nav2_ros_common/node_utils.hpp
+    languages: [cpp]
+    severity: WARNING
+    metadata:
+      category: style
+      subcategory: [maintainability]
+      references:
+        - https://github.com/ros-navigation/navigation2/issues/6079
+    paths:
+      exclude:
+        - "nav2_ros_common/**"
+        - "**/test/**"
+        - "**/*_test.cpp"


### PR DESCRIPTION
## Basic Info

| Info | Value |
|------|-------|
| Ticket(s) this addresses | #6079 |
| Primary OS tested on | Ubuntu 24.04 |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description

Adds semgrep static-analysis rules to enforce Nav2 C++ coding conventions, as discussed in #6079 and the review thread on #6062.

Starting small with the two most impactful areas the maintainer highlighted: **`nav2::` interface types vs raw `rclcpp::` equivalents**, and **parameter declaration patterns**.

### Rules added (`.semgrep/nav2_coding_standards.yml`)

| Rule ID | Flags | Prefer instead |
|---|---|---|
| `nav2-use-nav2-publisher` | `rclcpp::Publisher<T>` | `nav2::Publisher<T>` |
| `nav2-use-nav2-service-client` | `rclcpp::Client<T>` | `nav2::ServiceClient<T>` |
| `nav2-use-nav2-service-server` | `rclcpp::Service<T>` | `nav2::ServiceServer<T>` |
| `nav2-use-nav2-subscription` | `rclcpp::Subscription<T>` | `nav2::Subscription<T>` |
| `nav2-use-declare-or-get-parameter` | Sequential `declare_parameter` + `get_parameter` calls | `nav2::declare_or_get_parameter()` |

All rules exclude `nav2_ros_common/` (which defines the canonical types) and test files.

### CI added (`.github/workflows/semgrep.yml`)

- Runs on every PR and push to `main`
- Scans all `*.cpp`, `*.hpp`, `*.h` files
- Uses `returntocorp/semgrep:1.76.0` (pinned for reproducibility)
- Reports violations in job output without blocking merges — so the existing codebase can be migrated incrementally

### Why these rules matter

- `nav2::Publisher` is lifecycle-aware (`rclcpp_lifecycle::LifecyclePublisher`) — raw `rclcpp::Publisher` won't activate/deactivate with the node lifecycle
- `nav2::ServiceClient` / `nav2::ServiceServer` provide timeout handling and lifecycle integration not available in the raw rclcpp types
- `declare_or_get_parameter` prevents the subtle bug of declaring and getting parameters in separate calls that can silently diverge

---

## Test plan

- [x] Rules file validates: `semgrep --validate --config .semgrep/nav2_coding_standards.yml`
- [ ] CI job passes on this PR
- [ ] Maintainer review of rule patterns for false-positive rate