### PR TITLE
[nav2_rotation_shim_controller] Jazzy backport - Add `max_cost_threshold` parameter for rotation shim

### DIFF
--- a/nav2_rotation_shim_controller/README.md
+++ b/nav2_rotation_shim_controller/README.md
@@ -36,6 +36,7 @@ See its [Configuration Guide Page](https://docs.nav2.org/configuration/packages/
 | `rotate_to_heading_angular_vel` | Angular rotational velocity, in rad/s, to rotate to the path heading |
 | `primary_controller` | Internal controller plugin to use for actual control behavior after rotating to heading |
 | `max_angular_accel` | Maximum angular acceleration for rotation to heading |
+| `max_cost_threshold` | Maximum footprint cost threshold to detect a collision. Defaults to 254.0 i.e., LETHAL_OBSTACLE. 
 | `simulate_ahead_time` | Time in seconds to forward simulate a rotation command to check for collisions. If a collision is found, forwards control back to the primary controller plugin. |
 | `rotate_to_goal_heading` | If true, the rotationShimController will take back control of the robot when in XY tolerance of the goal and start rotating to the goal heading |
 | `use_path_orientations` | If true, the controller will use the orientations of the path points to compute the heading of the path instead of computing the heading from the path points. If true, the controller will use the orientations of the path points to compute the heading of the path instead of computing the heading from the path points. Use for for feasible planners like the Smac Planner which generate feasible paths with orientations for forward and reverse motion. |
@@ -69,6 +70,7 @@ controller_server:
       forward_sampling_distance: 0.5
       rotate_to_heading_angular_vel: 1.8
       max_angular_accel: 3.2
+      max_cost_threshold: 254.0
       simulate_ahead_time: 1.0
       rotate_to_goal_heading: false
       use_path_orientations: false

--- a/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp
+++ b/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp
@@ -189,6 +189,7 @@ protected:
   double forward_sampling_distance_, angular_dist_threshold_, angular_disengage_threshold_;
   double rotate_to_heading_angular_vel_, max_angular_accel_;
   double control_duration_, simulate_ahead_time_;
+  double max_cost_threshold_;
   bool rotate_to_goal_heading_, in_rotation_, rotate_to_heading_once_;
   bool closed_loop_;
   bool use_path_orientations_;

--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -62,6 +62,9 @@ void RotationShimController::configure(
   nav2_util::declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_angular_accel", rclcpp::ParameterValue(3.2));
   nav2_util::declare_parameter_if_not_declared(
+    node, plugin_name_ + ".max_cost_threshold",
+    rclcpp::ParameterValue(static_cast<double>(nav2_costmap_2d::LETHAL_OBSTACLE)));
+  nav2_util::declare_parameter_if_not_declared(
     node, plugin_name_ + ".simulate_ahead_time", rclcpp::ParameterValue(1.0));
   nav2_util::declare_parameter_if_not_declared(
     node, plugin_name_ + ".primary_controller", rclcpp::PARAMETER_STRING);
@@ -81,6 +84,7 @@ void RotationShimController::configure(
     plugin_name_ + ".rotate_to_heading_angular_vel",
     rotate_to_heading_angular_vel_);
   node->get_parameter(plugin_name_ + ".max_angular_accel", max_angular_accel_);
+  node->get_parameter(plugin_name_ + ".max_cost_threshold", max_cost_threshold_);
   node->get_parameter(plugin_name_ + ".simulate_ahead_time", simulate_ahead_time_);
 
   primary_controller = node->get_parameter(plugin_name_ + ".primary_controller").as_string();
@@ -369,7 +373,7 @@ void RotationShimController::isCollisionFree(
               "RotationShimController detected a potential collision ahead!");
     }
 
-    if (footprint_cost >= static_cast<double>(LETHAL_OBSTACLE)) {
+    if (footprint_cost >= max_cost_threshold_) {
       throw nav2_core::NoValidControl("RotationShimController detected collision ahead!");
     }
   }
@@ -427,6 +431,8 @@ RotationShimController::dynamicParametersCallback(std::vector<rclcpp::Parameter>
         max_angular_accel_ = parameter.as_double();
       } else if (name == plugin_name_ + ".simulate_ahead_time") {
         simulate_ahead_time_ = parameter.as_double();
+      } else if (name == plugin_name_ + ".max_cost_threshold") {
+        max_cost_threshold_ = parameter.as_double();
       }
     } else if (type == ParameterType::PARAMETER_BOOL) {
       if (name == plugin_name_ + ".rotate_to_goal_heading") {

--- a/nav2_rotation_shim_controller/test/test_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/test/test_shim_controller.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_controller/plugins/simple_goal_checker.hpp"
 #include "nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp"
@@ -627,6 +628,8 @@ TEST(RotationShimControllerTest, testDynamicParameter)
       rclcpp::Parameter("test.max_angular_accel", 7.0),
       rclcpp::Parameter("test.simulate_ahead_time", 7.0),
       rclcpp::Parameter("test.primary_controller", std::string("HI")),
+      rclcpp::Parameter("test.max_cost_threshold",
+      static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)),
       rclcpp::Parameter("test.rotate_to_goal_heading", true),
       rclcpp::Parameter("test.rotate_to_heading_once", true),
       rclcpp::Parameter("test.closed_loop", false),
@@ -641,8 +644,41 @@ TEST(RotationShimControllerTest, testDynamicParameter)
   EXPECT_EQ(node->get_parameter("test.rotate_to_heading_angular_vel").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("test.max_angular_accel").as_double(), 7.0);
   EXPECT_EQ(node->get_parameter("test.simulate_ahead_time").as_double(), 7.0);
+  EXPECT_EQ(node->get_parameter("test.max_cost_threshold").as_double(),
+    static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE));
   EXPECT_EQ(node->get_parameter("test.rotate_to_goal_heading").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.rotate_to_heading_once").as_bool(), true);
   EXPECT_EQ(node->get_parameter("test.closed_loop").as_bool(), false);
   EXPECT_EQ(node->get_parameter("test.use_path_orientations").as_bool(), true);
+}
+
+TEST(RotationShimControllerTest, maxCostThresholdTest)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("ShimControllerTest");
+  std::string name = "test";
+  auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
+  costmap->configure();
+  node->declare_parameter(
+    "test.primary_controller",
+    std::string("nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"));
+  node->declare_parameter("controller_frequency", 20.0);
+  node->declare_parameter("test.max_cost_threshold",
+    static_cast<double>(nav2_costmap_2d::FREE_SPACE));
+  auto controller = std::make_shared<RotationShimShim>();
+  controller->configure(node, name, tf, costmap);
+  controller->activate();
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "base_link";
+  path.poses.resize(4);
+  path.poses[1].pose.position.x = 0.15;
+  path.poses[1].pose.position.y = 0.15;
+  path.poses[2].pose.position.x = 1.0;
+  path.poses[2].pose.position.y = 1.0;
+  controller->setPlan(path);
+  const geometry_msgs::msg::Twist velocity;
+  // With max_cost_threshold=0, even FREE_SPACE cells should trigger collision
+  EXPECT_THROW(
+    controller->computeRotateToHeadingCommandWrapper(1.5, path.poses[1], velocity),
+    nav2_core::NoValidControl);
 }


### PR DESCRIPTION
As promised, backporting https://github.com/ros-navigation/navigation2/pull/6146 to Jazzy.