### PR TITLE
fix for issue #6159

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -77,8 +77,14 @@ public:
       std::bind(&OdomSubscriber::odomCallback, this, std::placeholders::_1));
   }
 
-  inline nav_2d_msgs::msg::Twist2D getTwist() {return odom_vel_.velocity;}
-  inline nav_2d_msgs::msg::Twist2DStamped getTwistStamped() {return odom_vel_;}
+  inline nav_2d_msgs::msg::Twist2D getTwist() {
+    std::lock_guard<std::mutex> lock(odom_mutex_);
+    return odom_vel_.velocity;
+  }
+  inline nav_2d_msgs::msg::Twist2DStamped getTwistStamped() {
+    std::lock_guard<std::mutex> lock(odom_mutex_);
+    return odom_vel_;
+  }
 
 protected:
   void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -82,7 +82,8 @@ public:
     std::lock_guard<std::mutex> lock(odom_mutex_);
     return odom_vel_.velocity;
   }
-  inline nav_2d_msgs::msg::Twist2DStamped getTwistStamped() {
+  inline nav_2d_msgs::msg::Twist2DStamped getTwistStamped()
+  {
     std::lock_guard<std::mutex> lock(odom_mutex_);
     return odom_vel_;
   }

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -77,7 +77,8 @@ public:
       std::bind(&OdomSubscriber::odomCallback, this, std::placeholders::_1));
   }
 
-  inline nav_2d_msgs::msg::Twist2D getTwist() {
+  inline nav_2d_msgs::msg::Twist2D getTwist()
+  {
     std::lock_guard<std::mutex> lock(odom_mutex_);
     return odom_vel_.velocity;
   }


### PR DESCRIPTION
Add mutex locking for getTwist and getTwistStamped in OdomSubscriber, and prevent the race condition shown in issue 6159.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
