### PR TITLE
chore: remove isort hook from pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,6 @@ repos:
       - id: trailing-whitespace
         exclude_types: [rst]
       - id: fix-byte-order-marker
--   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        args: ["tools/pyproject.toml"]
-        name: isort (python)
-
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -8,10 +8,6 @@ quiet = 34
 skip="*.pgm,./build/*,./install/*,./log*,./.venv/*,./.git*,*.toml"
 uri-ignore-words-list = "segue"
 write-changes = true
-[tool.isort]
-profile = "google"
-force_single_line = false
-line_length = 99
 
 [tool.mypy]
 explicit_package_bases = true


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6161 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Removed `isort` hook from pre-commit configuration to avoid library ordering conflicts with `ament_flake8`. More detailed information in the associated ticket.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Checked `pre-commit run -a` locally.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
