### PR TITLE
Validate costmap resolution parameter

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -40,6 +40,8 @@
 
 #include <memory>
 #include <chrono>
+#include <cmath>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <utility>
@@ -462,7 +464,8 @@ Costmap2DROS::getParameters()
     }
   }
 
-  // 4. The width and height of map cannot be negative or 0 (to avoid abnoram memory usage)
+  // 4. The width, height, and resolution of map cannot be negative or 0
+  // (to avoid abnormal memory usage)
   if (map_width_meters_ <= 0) {
     RCLCPP_ERROR(
       get_logger(), "You try to set width of map to be negative or zero,"
@@ -472,6 +475,10 @@ Costmap2DROS::getParameters()
     RCLCPP_ERROR(
       get_logger(), "You try to set height of map to be negative or zero,"
       " this isn't allowed, please give a positive value.");
+  }
+  if (resolution_ <= 0.0 || !std::isfinite(resolution_)) {
+    throw std::invalid_argument(
+            "Costmap resolution must be a positive finite value.");
   }
 }
 
@@ -755,8 +762,17 @@ Costmap2DROS::dynamicParametersCallback(std::vector<rclcpp::Parameter> parameter
           publish_cycle_ = rclcpp::Duration(-1s);
         }
       } else if (name == "resolution") {
+        const double new_resolution = parameter.as_double();
+        if (new_resolution <= 0.0 || !std::isfinite(new_resolution)) {
+          RCLCPP_ERROR(
+            get_logger(),
+            "You try to set resolution of map to be negative, zero, or non-finite,"
+            " this isn't allowed, please give a positive finite value.");
+          result.successful = false;
+          return result;
+        }
         resize_map = true;
-        resolution_ = parameter.as_double();
+        resolution_ = new_resolution;
       } else if (name == "origin_x") {
         resize_map = true;
         origin_x_ = parameter.as_double();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #6174 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Added validation for the costmap `resolution` parameter during costmap configuration.
- Rejects non-positive or non-finite `resolution` values.
- Also rejects invalid dynamic updates to the `resolution` parameter before resizing the costmap.
- Prevents invalid `resolution: 0.0` configurations from propagating into controller logic where they may cause unbounded loops or OOM failures.

## Description of documentation updates required from your changes

- N/A. This does not add a new parameter or change the documented behavior of valid `resolution` values.

## Description of how this change was tested

- Built `nav2_costmap_2d` from source.
- Launched Nav2 and verified `/local_costmap/local_costmap` reached the active lifecycle state.
- Verified that setting `/local_costmap/local_costmap` `resolution` to `0.0` is rejected by the dynamic parameter callback.

---

## Future work that may be required in bullet points

- N/A.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.