### PR TITLE
Validate costmap resolution parameter

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -40,6 +40,8 @@
 
 #include <memory>
 #include <chrono>
+#include <cmath>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <utility>
@@ -478,7 +480,8 @@ Costmap2DROS::getParameters()
     }
   }
 
-  // 4. The width and height of map cannot be negative or 0 (to avoid abnoram memory usage)
+  // 4. The width, height, and resolution of map cannot be negative or 0
+  // (to avoid abnormal memory usage)
   if (map_width_meters_ <= 0) {
     RCLCPP_ERROR(
       get_logger(), "You try to set width of map to be negative or zero,"
@@ -488,6 +491,10 @@ Costmap2DROS::getParameters()
     RCLCPP_ERROR(
       get_logger(), "You try to set height of map to be negative or zero,"
       " this isn't allowed, please give a positive value.");
+  }
+  if (resolution_ <= 0.0 || !std::isfinite(resolution_)) {
+    throw std::invalid_argument(
+            "Costmap resolution must be a positive finite value.");
   }
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #6174 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Added validation for the costmap `resolution` parameter during costmap configuration.
- Rejects non-positive or non-finite `resolution` values.
- Prevents invalid `resolution: 0.0` configurations from propagating into controller logic where they may cause unbounded loops or OOM failures.

## Description of documentation updates required from your changes

- N/A. This does not add a new parameter or change the documented behavior of valid `resolution` values.

## Description of how this change was tested

- Built `nav2_costmap_2d` from source.
- Launched Nav2 and verified `/local_costmap/local_costmap` reached the active lifecycle state.
- Verified on Jazzy that setting `/local_costmap/local_costmap` `resolution` to `0.0` is rejected after applying the equivalent validation.

---

## Future work that may be required in bullet points

- N/A.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.