### PR TITLE
Add omni (SE2) analytic expansion to SmacPlannerLattice (backport Jazzy)

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/constants.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/constants.hpp
@@ -26,6 +26,7 @@ enum class MotionModel
   DUBIN = 2,
   REEDS_SHEPP = 3,
   STATE_LATTICE = 4,
+  OMNI = 5,
 };
 
 inline std::string toString(const MotionModel & n)

--- a/nav2_smac_planner/src/analytic_expansion.cpp
+++ b/nav2_smac_planner/src/analytic_expansion.cpp
@@ -135,6 +135,12 @@ typename AnalyticExpansion<NodeT>::NodePtr AnalyticExpansion<NodeT>::tryAnalytic
         float score = std::numeric_limits<float>::max();
         float min_turn_rad = node->motion_table.min_turning_radius;
         const float max_min_turn_rad = 4.0 * min_turn_rad;  // Up to 4x the turning radius
+
+        // SE2 produces straight-line paths independent of turning radius, skip refinement
+        if (node->motion_table.motion_model == MotionModel::OMNI) {
+          return setAnalyticPath(node, goal_node, analytic_nodes);
+        }
+
         while (min_turn_rad < max_min_turn_rad) {
           min_turn_rad += 0.5;  // In Grid Coords, 1/2 cell steps
           ompl::base::StateSpacePtr state_space;

--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -26,6 +26,7 @@
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"
 #include "ompl/base/spaces/ReedsSheppStateSpace.h"
+#include "ompl/base/spaces/SE2StateSpace.h"
 
 #include "nav2_smac_planner/node_lattice.hpp"
 
@@ -75,7 +76,11 @@ void LatticeMotionTable::initMotionModel(
   num_angle_quantization = lattice_metadata.number_of_headings;
 
   if (!state_space) {
-    if (!allow_reverse_expansion) {
+    if (lattice_metadata.motion_model == "omni") {
+      // Holonomic robots: straight-line analytic expansion
+      state_space = std::make_shared<ompl::base::SE2StateSpace>();
+      motion_model = MotionModel::OMNI;
+    } else if (!allow_reverse_expansion) {
       state_space = std::make_shared<ompl::base::DubinsStateSpace>(
         lattice_metadata.min_turning_radius);
       motion_model = MotionModel::DUBIN;
@@ -442,8 +447,15 @@ void NodeLattice::precomputeDistanceHeuristic(
   const unsigned int & dim_3_size,
   const SearchInfo & search_info)
 {
-  // Dubin or Reeds-Shepp shortest distances
-  if (!search_info.allow_reverse_expansion) {
+  motion_table.lattice_metadata =
+    LatticeMotionTable::getLatticeMetadata(search_info.lattice_filepath);
+
+  // Select state space based on motion model from lattice file
+  if (motion_table.lattice_metadata.motion_model == "omni") {
+    // Holonomic robots: Euclidean distance heuristic
+    motion_table.state_space = std::make_shared<ompl::base::SE2StateSpace>();
+    motion_table.motion_model = MotionModel::OMNI;
+  } else if (!search_info.allow_reverse_expansion) {
     motion_table.state_space = std::make_shared<ompl::base::DubinsStateSpace>(
       search_info.minimum_turning_radius);
     motion_table.motion_model = MotionModel::DUBIN;
@@ -452,8 +464,6 @@ void NodeLattice::precomputeDistanceHeuristic(
       search_info.minimum_turning_radius);
     motion_table.motion_model = MotionModel::REEDS_SHEPP;
   }
-  motion_table.lattice_metadata =
-    LatticeMotionTable::getLatticeMetadata(search_info.lattice_filepath);
 
   ompl::base::ScopedState<> from(motion_table.state_space), to(motion_table.state_space);
   to[0] = 0.0;

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -146,6 +146,13 @@ void SmacPlannerLattice::configure(
     _metadata.min_turning_radius / (_costmap->getResolution());
   _motion_model = MotionModel::STATE_LATTICE;
 
+  if (_metadata.motion_model == "omni" && _search_info.allow_reverse_expansion) {
+    RCLCPP_WARN(
+      _logger,
+      "allow_reverse_expansion is not applicable for omnidirectional robots. Disabling.");
+    _search_info.allow_reverse_expansion = false;
+  }
+
   if (_max_on_approach_iterations <= 0) {
     RCLCPP_INFO(
       _logger, "On approach iteration selected as <= 0, "
@@ -203,6 +210,9 @@ void SmacPlannerLattice::configure(
   // Initialize path smoother
   SmootherParams params;
   params.get(node, name);
+  if (_metadata.motion_model == "omni") {
+    params.holonomic_ = true;
+  }
   if (smooth_path) {
     _smoother = std::make_unique<Smoother>(params);
     _smoother->initialize(_metadata.min_turning_radius);
@@ -633,12 +643,21 @@ SmacPlannerLattice::dynamicParametersCallback(std::vector<rclcpp::Parameter> par
       auto node = _node.lock();
       SmootherParams params;
       params.get(node, _name);
+      if (_metadata.motion_model == "omni") {
+        params.holonomic_ = true;
+      }
       _smoother = std::make_unique<Smoother>(params);
       _smoother->initialize(_metadata.min_turning_radius);
     }
 
     // Re-Initialize A* template
     if (reinit_a_star) {
+      if (_metadata.motion_model == "omni" && _search_info.allow_reverse_expansion) {
+        RCLCPP_WARN(
+          _logger,
+          "allow_reverse_expansion is not applicable for omnidirectional robots. Disabling.");
+        _search_info.allow_reverse_expansion = false;
+      }
       _a_star = std::make_unique<AStarAlgorithm<NodeLattice>>(_motion_model, _search_info);
       _a_star->initialize(
         _allow_unknown,

--- a/nav2_smac_planner/test/test_nodelattice.cpp
+++ b/nav2_smac_planner/test/test_nodelattice.cpp
@@ -19,7 +19,10 @@
 #include <memory>
 #include <unordered_map>
 #include <limits>
+#include "ompl/base/spaces/SE2StateSpace.h"
+#include "ompl/base/spaces/ReedsSheppStateSpace.h"
 #include "nav2_smac_planner/node_lattice.hpp"
+#include "nav2_smac_planner/a_star.hpp"
 #include "gtest/gtest.h"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "nav2_util/lifecycle_node.hpp"
@@ -396,4 +399,114 @@ TEST(NodeLatticeTest, test_node_lattice_custom_footprint)
   }
 
   delete costmap;
+}
+
+TEST(NodeLatticeTest, test_omni_selects_se2_state_space)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
+  std::string pkg_share_dir = ament_index_cpp::get_package_share_directory("nav2_smac_planner");
+  std::string filePath =
+    pkg_share_dir +
+    "/sample_primitives/5cm_resolution/0.5m_turning_radius/omni" +
+    "/output.json";
+
+  nav2_smac_planner::SearchInfo info;
+  info.minimum_turning_radius = 0.5;
+  info.non_straight_penalty = 1;
+  info.change_penalty = 1;
+  info.reverse_penalty = 1;
+  info.cost_penalty = 1;
+  info.retrospective_penalty = 0.0;
+  info.analytic_expansion_ratio = 1;
+  info.lattice_filepath = filePath;
+  info.cache_obstacle_heuristic = true;
+  info.allow_reverse_expansion = true;
+
+  nav2_smac_planner::AStarAlgorithm<nav2_smac_planner::NodeLattice> a_star(
+    nav2_smac_planner::MotionModel::STATE_LATTICE, info);
+  int max_iterations = 10000;
+  int terminal_checking_interval = 5000;
+  double max_planning_time = 120.0;
+  unsigned int angle_quantization = 16;
+
+  a_star.initialize(
+    false, max_iterations,
+    std::numeric_limits<int>::max(), terminal_checking_interval,
+    max_planning_time, 401, angle_quantization);
+
+  nav2_costmap_2d::Costmap2D costmapA(100, 100, 0.05, 0.0, 0.0, 0);
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>();
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+  auto costmap = costmap_ros->getCostmap();
+  *costmap = costmapA;
+
+  std::unique_ptr<nav2_smac_planner::GridCollisionChecker> checker =
+    std::make_unique<nav2_smac_planner::GridCollisionChecker>(
+    costmap_ros, 72, node);
+  checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
+  a_star.setCollisionChecker(checker.get());
+
+  // Verify omni motion model selects SE2StateSpace
+  EXPECT_EQ(
+    nav2_smac_planner::NodeLattice::motion_table.motion_model,
+    nav2_smac_planner::MotionModel::OMNI);
+  EXPECT_NE(
+    dynamic_cast<ompl::base::SE2StateSpace *>(
+      nav2_smac_planner::NodeLattice::motion_table.state_space.get()),
+    nullptr);
+}
+
+TEST(NodeLatticeTest, test_non_omni_selects_reeds_shepp)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test");
+  std::string pkg_share_dir = ament_index_cpp::get_package_share_directory("nav2_smac_planner");
+  std::string filePath =
+    pkg_share_dir +
+    "/sample_primitives/5cm_resolution/0.5m_turning_radius/ackermann" +
+    "/output.json";
+
+  nav2_smac_planner::SearchInfo info;
+  info.minimum_turning_radius = 0.5;
+  info.non_straight_penalty = 1;
+  info.change_penalty = 1;
+  info.reverse_penalty = 1;
+  info.cost_penalty = 1;
+  info.retrospective_penalty = 0.0;
+  info.analytic_expansion_ratio = 1;
+  info.lattice_filepath = filePath;
+  info.cache_obstacle_heuristic = true;
+  info.allow_reverse_expansion = true;
+
+  nav2_smac_planner::AStarAlgorithm<nav2_smac_planner::NodeLattice> a_star(
+    nav2_smac_planner::MotionModel::STATE_LATTICE, info);
+  int max_iterations = 10000;
+  int terminal_checking_interval = 5000;
+  double max_planning_time = 120.0;
+  unsigned int angle_quantization = 16;
+
+  a_star.initialize(
+    false, max_iterations,
+    std::numeric_limits<int>::max(), terminal_checking_interval,
+    max_planning_time, 401, angle_quantization);
+
+  nav2_costmap_2d::Costmap2D costmapA(100, 100, 0.05, 0.0, 0.0, 0);
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>();
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+  auto costmap = costmap_ros->getCostmap();
+  *costmap = costmapA;
+
+  std::unique_ptr<nav2_smac_planner::GridCollisionChecker> checker =
+    std::make_unique<nav2_smac_planner::GridCollisionChecker>(
+    costmap_ros, 72, node);
+  checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
+  a_star.setCollisionChecker(checker.get());
+
+  // Verify non-omni (ackermann with reverse) selects Reeds-Shepp
+  EXPECT_EQ(
+    nav2_smac_planner::NodeLattice::motion_table.motion_model,
+    nav2_smac_planner::MotionModel::REEDS_SHEPP);
+  EXPECT_NE(
+    dynamic_cast<ompl::base::ReedsSheppStateSpace *>(
+      nav2_smac_planner::NodeLattice::motion_table.state_space.get()),
+    nullptr);
 }

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "ament_index_cpp/get_package_share_directory.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
@@ -43,6 +44,21 @@ public:
   void callDynamicParams(std::vector<rclcpp::Parameter> parameters)
   {
     dynamicParametersCallback(parameters);
+  }
+
+  bool getAllowReverseExpansion()
+  {
+    return _search_info.allow_reverse_expansion;
+  }
+
+  std::string getMotionModelName()
+  {
+    return _metadata.motion_model;
+  }
+
+  bool hasSmootherInitialized()
+  {
+    return _smoother != nullptr;
   }
 };
 
@@ -156,4 +172,78 @@ TEST(SmacTest, test_smac_lattice_reconfigure)
   std::vector<rclcpp::Parameter> parameters;
   parameters.push_back(rclcpp::Parameter("test.lattice_filepath", std::string("HI")));
   EXPECT_THROW(planner->callDynamicParams(parameters), std::runtime_error);
+}
+
+TEST(SmacTest, test_smac_lattice_omni_configure)
+{
+  rclcpp_lifecycle::LifecycleNode::SharedPtr nodeLattice =
+    std::make_shared<rclcpp_lifecycle::LifecycleNode>("SmacLatticeOmniTest");
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  std::string omni_filepath =
+    ament_index_cpp::get_package_share_directory("nav2_smac_planner") +
+    "/sample_primitives/5cm_resolution/0.5m_turning_radius/omni/output.json";
+
+  nodeLattice->declare_parameter("test_omni.lattice_filepath", omni_filepath);
+  nodeLattice->declare_parameter("test_omni.allow_reverse_expansion", true);
+
+  auto planner = std::make_unique<LatticeWrap>();
+  planner->configure(nodeLattice, "test_omni", nullptr, costmap_ros);
+
+  // Verify OMNI was loaded and reverse expansion was auto-disabled
+  EXPECT_EQ(planner->getMotionModelName(), "omni");
+  EXPECT_FALSE(planner->getAllowReverseExpansion());
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  planner->activate();
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  nodeLattice.reset();
+}
+
+TEST(SmacTest, test_smac_lattice_omni_reconfigure)
+{
+  rclcpp_lifecycle::LifecycleNode::SharedPtr nodeLattice =
+    std::make_shared<rclcpp_lifecycle::LifecycleNode>("SmacLatticeOmniReconfigTest");
+
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros =
+    std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  auto planner = std::make_unique<LatticeWrap>();
+  try {
+    planner->configure(nodeLattice, "test_omni_reconf", nullptr, costmap_ros);
+  } catch (...) {
+  }
+  planner->activate();
+
+  std::string omni_filepath =
+    ament_index_cpp::get_package_share_directory("nav2_smac_planner") +
+    "/sample_primitives/5cm_resolution/0.5m_turning_radius/omni/output.json";
+
+  // Reconfigure to OMNI with reverse expansion enabled
+  std::vector<rclcpp::Parameter> parameters;
+  parameters.push_back(
+    rclcpp::Parameter("test_omni_reconf.lattice_filepath", omni_filepath));
+  parameters.push_back(
+    rclcpp::Parameter("test_omni_reconf.allow_reverse_expansion", true));
+  EXPECT_NO_THROW(planner->callDynamicParams(parameters));
+
+  // Verify OMNI reconfigure disabled reverse expansion and re-initialized smoother
+  EXPECT_EQ(planner->getMotionModelName(), "omni");
+  EXPECT_FALSE(planner->getAllowReverseExpansion());
+  EXPECT_TRUE(planner->hasSmootherInitialized());
+
+  planner->deactivate();
+  planner->cleanup();
+  planner.reset();
+  costmap_ros->on_cleanup(rclcpp_lifecycle::State());
+  costmap_ros.reset();
+  nodeLattice.reset();
 }


### PR DESCRIPTION
## Basic Info

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses | #2683, related: #5231, #4262 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Simulated rectangled shape holonomic AMR |
| Does this PR contain AI generated software? | Yes, not marked inline |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Backport of #5965 (already merged into `main`) to jazzy.
* Code structure differs from `main`: `distance_heuristic.cpp` does not exist on jazzy, so the omni SE2 state-space selection is folded into `node_lattice.cpp`'s `precomputeDistanceHeuristic`, and the analytic refinement skip is applied inline. The behavior is identical to #5965.
* Mergify auto-backport is not viable because of that structural difference (a new file on `main` that is absent on jazzy), so this is a manual backport PR.
* Also adds the missing `#include "nav2_smac_planner/a_star.hpp"` in `test_nodelattice.cpp` so the OMNI unit tests compile under `BUILD_TESTING=ON`.

## Description of documentation updates required from your changes

* No new parameters added — the omni motion model is auto-detected from the existing `motion_model` field in the lattice primitives file (same as #5965).

---

## Description of how this change was tested

* Ported the plugin-level `test_smac_lattice_omni_configure` / `test_smac_lattice_omni_reconfigure` tests from #5965, plus the existing `test_omni_selects_se2_state_space` / `test_non_omni_selects_reeds_shepp` node tests.
* `colcon build --packages-select nav2_smac_planner --cmake-args -DBUILD_TESTING=ON` on jazzy (Ubuntu 24.04): clean build, `test_smac_lattice` 4/4 and `test_lattice_node` 8/8 passing, `ament_uncrustify` + `ament_cpplint` clean.
* Manually tested with a holonomic AMR configuration and confirmed straight-line analytic expansions instead of arcs.
