### PR TITLE
docs: copy information about new 'plugins' ports

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
@@ -35,7 +35,9 @@ namespace nav2_behavior_tree
  *
  * Usage in XML:
  * @code
- * <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+ * <ClearEntireCostmap name="ClearLocalCostmap-Subtree"
+ *                     service_name="local_costmap/clear_entirely_local_costmap"
+ *                     plugins="obstacle_layer;voxel_layer"/>
  * @endcode
  */
 class ClearEntireCostmapService : public BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>
@@ -85,7 +87,10 @@ public:
  *
  * Usage in XML:
  * @code
- * <ClearCostmapExceptRegion name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_except_local_costmap"/>
+ * <ClearCostmapExceptRegion name="ClearLocalCostmap-Subtree"
+ *                           service_name="local_costmap/clear_except_local_costmap"
+ *                           reset_distance="2.0"
+ *                           plugins="obstacle_layer;voxel_layer"/>
  * @endcode
  */
 class ClearCostmapExceptRegionService
@@ -139,7 +144,10 @@ public:
  *
  * Usage in XML:
  * @code
- * <ClearCostmapAroundRobot name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_around_local_costmap"/>
+ * <ClearCostmapAroundRobot name="ClearLocalCostmap-Subtree"
+ *                          service_name="local_costmap/clear_around_local_costmap"
+ *                          reset_distance="2.0"
+ *                          plugins="obstacle_layer;voxel_layer"/>
  * @endcode
  */
 class ClearCostmapAroundRobotService : public BtServiceNode<nav2_msgs::srv::ClearCostmapAroundRobot>
@@ -195,7 +203,8 @@ public:
  * <ClearCostmapAroundPose name="ClearLocalCostmapAroundPose"
  *                         service_name="local_costmap/clear_around_pose_local_costmap"
  *                         pose="{goal_pose}"
- *                         reset_distance="2.0"/>
+ *                         reset_distance="2.0"
+ *                         plugins="obstacle_layer;voxel_layer"/>
  * @endcode
  */
 class ClearCostmapAroundPoseService : public BtServiceNode<nav2_msgs::srv::ClearCostmapAroundPose>

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -77,21 +77,21 @@
     <Action ID="ClearEntireCostmap">
       <input_port name="service_name" type="string">Costmap service name responsible for clearing the costmap.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Service server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <input_port name="plugins" type="vector&lt;string&gt;">List of specific plugins to clear.</input_port>
+      <input_port name="plugins" type="vector&lt;string&gt;">Optional. A list of costmap plugin names to be cleared. If specified, only these costmap plugins and the master costmap will be cleared. Otherwise, the entire costmap will be cleared.</input_port>
     </Action>
 
     <Action ID="ClearCostmapExceptRegion">
       <input_port name="reset_distance" type="double" default="1.0">Side size of the square area centered on the robot that will not be cleared on the costmap (all the rest of the costmap will).</input_port>
       <input_port name="service_name" type="string">Costmap service name responsible for clearing the costmap.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Service server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <input_port name="plugins" type="vector&lt;string&gt;">List of specific plugins to clear.</input_port>
+      <input_port name="plugins" type="vector&lt;string&gt;">Optional. A list of costmap plugin names to be cleared. If specified, only these costmap plugins will be cleared. Otherwise, all "clearable" costmap plugins will be cleared.</input_port>
     </Action>
 
     <Action ID="ClearCostmapAroundRobot">
       <input_port name="reset_distance" type="double" default="1.0">Side size of the square area centered on the robot that will be cleared on the costmap (the rest of the costmap won't).</input_port>
       <input_port name="service_name" type="string">Costmap service name responsible for clearing the costmap.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Service server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <input_port name="plugins" type="vector&lt;string&gt;">List of specific plugins to clear.</input_port>
+      <input_port name="plugins" type="vector&lt;string&gt;">Optional. A list of costmap plugin names to be cleared. If specified, only these costmap plugins will be cleared. Otherwise, all "clearable" costmap plugins will be cleared.</input_port>
     </Action>
 
     <Action ID="ClearCostmapAroundPose">
@@ -99,7 +99,7 @@
       <input_port name="reset_distance" type="double" default="1.0">Distance from the pose under which obstacles are cleared.</input_port>
       <input_port name="service_name" type="string">Costmap service name responsible for clearing the costmap.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Service server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <input_port name="plugins" type="vector&lt;string&gt;">List of specific plugins to clear.</input_port>
+      <input_port name="plugins" type="vector&lt;string&gt;">Optional. A list of costmap plugin names to be cleared. If specified, only these costmap plugins will be cleared. Otherwise, all "clearable" costmap plugins will be cleared.</input_port>
     </Action>
 
     <Action ID="ComputePathToPose">


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | N/A |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
A recent commit https://github.com/ros-navigation/docs.nav2.org/pull/918 adds new port information and examples to the documentation that are not included in the main project. Since the new documentation will be generated based on data from the project itself, I'm duplicating this info so that it won’t be lost later:
- Updated port descriptions in `nav2_tree_nodes.xml`.
- Updated usage examples in the Doxygen descriptions.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Verified the information displays correctly on the generated docs pages.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
