### PR TITLE
Backport #5987 to Kilted

### DIFF
--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -75,6 +75,14 @@ BehaviorTreeEngine::run(
           1.0 / (loopRate.period().count() * 1.0e-9));
       }
     }
+  } catch (const BT::NodeExecutionError & ex) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BehaviorTreeEngine"),
+      "BT Exception at Node: [%s] (Path: %s). Original error: %s. Exiting with failure.",
+      ex.failedNode().registration_name.c_str(),
+      ex.failedNode().node_path.c_str(),
+      ex.originalMessage().c_str());
+    return BtStatus::FAILED;
   } catch (const std::exception & ex) {
     RCLCPP_ERROR(
       rclcpp::get_logger("BehaviorTreeEngine"),

--- a/nav2_behavior_tree/test/plugins/control/test_pipeline_sequence.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_pipeline_sequence.cpp
@@ -62,7 +62,7 @@ PipelineSequenceTestFixture::third_child_ = nullptr;
 TEST_F(PipelineSequenceTestFixture, test_failure_on_idle_child)
 {
   first_child_->changeStatus(BT::NodeStatus::IDLE);
-  EXPECT_THROW(bt_node_->executeTick(), std::runtime_error);
+  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
 }
 
 TEST_F(PipelineSequenceTestFixture, test_failure)

--- a/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
@@ -103,10 +103,10 @@ TEST_F(RecoveryNodeTestFixture, test_running)
 TEST_F(RecoveryNodeTestFixture, test_failure_on_idle_child)
 {
   first_child_->changeStatus(BT::NodeStatus::IDLE);
-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
+  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
   first_child_->changeStatus(BT::NodeStatus::FAILURE);
   second_child_->changeStatus(BT::NodeStatus::IDLE);
-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
+  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
 }
 
 TEST_F(RecoveryNodeTestFixture, test_success_one_retry)

--- a/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<nav2_behavior_tree::DummyNode> RoundRobinNodeTestFixture::third_
 TEST_F(RoundRobinNodeTestFixture, test_failure_on_idle_child)
 {
   first_child_->changeStatus(BT::NodeStatus::IDLE);
-  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
+  EXPECT_THROW(bt_node_->executeTick(), BT::NodeExecutionError);
 }
 
 TEST_F(RoundRobinNodeTestFixture, test_failure)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Manual backport of https://github.com/ros-navigation/navigation2/pull/5987 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
