### PR TITLE
Fix: Added loop_rate.reset() to solve control loop missed its desired…

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -416,6 +416,7 @@ void ControllerServer::computeControl()
         RCLCPP_WARN(
           get_logger(), "Control loop missed its desired rate of %.4fHz",
           controller_frequency_);
+        loop_rate.reset();
       }
     }
   } catch (nav2_core::PlannerException & e) {


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Custom Jetson Orin Nano Super platform |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | Yes, and it is marked inline in the code |

---

## Description of contribution in a few bullet points

* Fixed persistent "Control loop missed its desired rate" warnings.
* The `controller_server` was not resetting the `loop_rate` after a missed cycle, which caused the timing logic to incorrectly attempt to compensate for historical lag.
* Added `loop_rate.reset()` in `controller_server.cpp` to ensure the loop begins a fresh timing window after a missed iteration, stabilizing the control frequency at 20Hz.

## Description of documentation updates required from your changes

* None required.

## Description of how this change was tested

* This change has been verified to compile successfully under ROS 2 Humble. 
* Identified the logic issue through code analysis; currently performing validation in a local navigation environment.

---

## Future work that may be required in bullet points

* None.

#### For Maintainers: - [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins are added to the plugins page
- [ ] If BT Node, additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.