### PR TITLE
[DEX] Fix inconsistant plan and pose frame for goal checker usage in RPP and Graceful controller

### DIFF
--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -163,9 +163,11 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
   // Compute distance to goal as the path's integrated distance to account for path curvatures
   double dist_to_goal = nav2_util::geometry_utils::calculate_path_length(transformed_plan);
 
-  // If we've reached the XY goal tolerance, just rotate
+  // If we've reached the XY goal tolerance, just rotate.
+  // Feed the goal checker the GLOBAL-frame plan (same frame as `pose` / `global_goal`), not the
+  // base_link-frame `transformed_plan` used for control.
   if (goal_checker->isGoalXYReached(pose.pose, global_goal.pose, velocity,
-      transformed_plan))
+      transformed_global_plan))
   {
     double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
     // Check for collisions between our current pose and goal pose

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -216,7 +216,12 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   //        - equal to "normal" carrot_pose when curvature_lookahead_pose = false
   //        - otherwise equal to curvature_lookahead_pose (which can be interpolated after goal)
   double angle_to_heading;
-  if (shouldRotateToGoalHeading(goal_checker, pose, global_goal, speed, transformed_plan)) {
+  // Feed the goal checker the GLOBAL-frame plan (same frame as `pose` / `global_goal`), not the
+  // base_link-frame `transformed_plan` used for lookahead. The custom AxisGoalChecker derives the
+  // path-progress direction from the plan geometry, so a base-frame plan combined with global
+  // query/goal poses yields a wrong end-of-path direction and a spurious goal-reached. This keeps
+  // the check identical to controller_server::isGoalReached(), which uses the global-frame plan.
+  if (shouldRotateToGoalHeading(goal_checker, pose, global_goal, speed, transformed_global_plan)) {
     is_rotating_to_heading_ = true;
     double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
     rotateToHeading(linear_vel, angular_vel, angle_to_goal, speed);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/pull/6071#issuecomment-4605627242|
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory's robot |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

This PR fixes the goal checker regression introduced by https://github.com/ros-navigation/navigation2/pull/6071.
`RegulatedPurePursuitController` and `GracefulController` pass the **base_link-frame** transformed plan to `GoalChecker::isGoalXYReached()` while passing the robot pose and goal pose in the **global (costmap) frame**.
That create an inconsistency for any goal checker using both plan and poses. E.g. the AxisGoalChecker in nav2 but potentially other customs ones outside of nav2 (though I doubt they exist).

Fixed by passing the global-frame `transformed_global_plan` to the goal-XY check, instead of the base-frame `transformed_plan`:
- `nav2_regulated_pure_pursuit_controller`: pass `transformed_global_plan` to `shouldRotateToGoalHeading(...)`.
- `nav2_graceful_controller`: pass `transformed_global_plan` to `goal_checker->isGoalXYReached(...)`.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Passed the Dexory CI system tests (previously failing), and tested manually on a robot.
Disclaimer: we don't use the Graceful controller so I didn't test that one.

cc @tonynajjar 
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.



