### PR TITLE
Catch parameter changes done in INACTIVE

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1042,6 +1042,10 @@ AmclNode::initParameters()
       get_logger(), "You've set min_particles to be greater than max particles,"
       " this isn't allowed so max_particles will be set to min_particles.");
     max_particles_ = min_particles_;
+    
+    // Mirror to value in store to avoid ambiguity AND avoid detecting
+    // a changed when activating
+    set_parameter(rclcpp::Parameter("max_particles", max_particles_));
   }
 
   if (resample_interval_ <= 0) {
@@ -1126,127 +1130,164 @@ AmclNode::updateParametersCallback(
       continue;
     }
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      if (param_name == "alpha1") {
+      if (param_name == "alpha1" && alpha1_ != parameter.as_double()) {
         alpha1_ = parameter.as_double();
         reinit_odom = true;
-      } else if (param_name == "alpha2") {
+      } else if (param_name == "alpha2" && alpha2_ != parameter.as_double()) {
         alpha2_ = parameter.as_double();
         reinit_odom = true;
-      } else if (param_name == "alpha3") {
+      } else if (param_name == "alpha3" && alpha3_ != parameter.as_double()) {
         alpha3_ = parameter.as_double();
         reinit_odom = true;
-      } else if (param_name == "alpha4") {
+      } else if (param_name == "alpha4" && alpha4_ != parameter.as_double()) {
         alpha4_ = parameter.as_double();
         reinit_odom = true;
-      } else if (param_name == "alpha5") {
+      } else if (param_name == "alpha5" && alpha5_ != parameter.as_double()) {
         alpha5_ = parameter.as_double();
         reinit_odom = true;
-      } else if (param_name == "beam_skip_distance") {
+      } else if (param_name == "beam_skip_distance" &&  // NOLINT(readability/braces)
+        beam_skip_distance_ != parameter.as_double())
+      {
         beam_skip_distance_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "beam_skip_error_threshold") {
+      } else if (param_name == "beam_skip_error_threshold" &&  // NOLINT(readability/braces)
+        beam_skip_error_threshold_ != parameter.as_double())
+      {
         beam_skip_error_threshold_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "beam_skip_threshold") {
+      } else if (param_name == "beam_skip_threshold" &&  // NOLINT(readability/braces)
+        beam_skip_threshold_ != parameter.as_double())
+      {
         beam_skip_threshold_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "lambda_short") {
+      } else if (param_name == "lambda_short" && lambda_short_ != parameter.as_double()) {
         lambda_short_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "laser_likelihood_max_dist") {
+      } else if (param_name == "laser_likelihood_max_dist" &&  // NOLINT(readability/braces)
+        laser_likelihood_max_dist_ != parameter.as_double())
+      {
         laser_likelihood_max_dist_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "laser_max_range") {
+      } else if (param_name == "laser_max_range" &&  // NOLINT(readability/braces)
+        laser_max_range_ != parameter.as_double())
+      {
         laser_max_range_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "laser_min_range") {
+      } else if (param_name == "laser_min_range" &&  // NOLINT(readability/braces)
+        laser_min_range_ != parameter.as_double())
+      {
         laser_min_range_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "pf_err") {
+      } else if (param_name == "pf_err" && pf_err_ != parameter.as_double()) {
         pf_err_ = parameter.as_double();
         reinit_pf = true;
-      } else if (param_name == "pf_z") {
+      } else if (param_name == "pf_z" && pf_z_ != parameter.as_double()) {
         pf_z_ = parameter.as_double();
         reinit_pf = true;
-      } else if (param_name == "recovery_alpha_fast") {
+      } else if (param_name == "recovery_alpha_fast" &&  // NOLINT(readability/braces)
+        alpha_fast_ != parameter.as_double())
+      {
         alpha_fast_ = parameter.as_double();
         reinit_pf = true;
-      } else if (param_name == "recovery_alpha_slow") {
+      } else if (param_name == "recovery_alpha_slow" &&  // NOLINT(readability/braces)
+        alpha_slow_ != parameter.as_double())
+      {
         alpha_slow_ = parameter.as_double();
         reinit_pf = true;
-      } else if (param_name == "save_pose_rate") {
+      } else if (param_name == "save_pose_rate" &&  // NOLINT(readability/braces)
+        save_pose_rate_ != parameter.as_double())
+      {
         save_pose_rate_ = parameter.as_double();
-      } else if (param_name == "sigma_hit") {
+      } else if (param_name == "sigma_hit" && sigma_hit_ != parameter.as_double()) {
         sigma_hit_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "transform_tolerance") {
-        double tmp_tol = parameter.as_double();
-        transform_tolerance_ = tf2::durationFromSec(tmp_tol);
+      } else if (param_name == "transform_tolerance" &&  // NOLINT(readability/braces)
+        transform_tolerance_ != tf2::durationFromSec(parameter.as_double()))
+      {
+        transform_tolerance_ = tf2::durationFromSec(parameter.as_double());
         reinit_laser = true;
-      } else if (param_name == "update_min_a") {
+      } else if (param_name == "update_min_a" && a_thresh_ != parameter.as_double()) {
         a_thresh_ = parameter.as_double();
-      } else if (param_name == "update_min_d") {
+      } else if (param_name == "update_min_d" && d_thresh_ != parameter.as_double()) {
         d_thresh_ = parameter.as_double();
-      } else if (param_name == "z_hit") {
+      } else if (param_name == "z_hit" && z_hit_ != parameter.as_double()) {
         z_hit_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "z_max") {
+      } else if (param_name == "z_max" && z_max_ != parameter.as_double()) {
         z_max_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "z_rand") {
+      } else if (param_name == "z_rand" && z_rand_ != parameter.as_double()) {
         z_rand_ = parameter.as_double();
         reinit_laser = true;
-      } else if (param_name == "z_short") {
+      } else if (param_name == "z_short" && z_short_ != parameter.as_double()) {
         z_short_ = parameter.as_double();
         reinit_laser = true;
       }
     } else if (param_type == ParameterType::PARAMETER_STRING) {
-      if (param_name == "base_frame_id") {
+      if (param_name == "base_frame_id" && base_frame_id_ != parameter.as_string()) {
         base_frame_id_ = parameter.as_string();
-      } else if (param_name == "global_frame_id") {
+      } else if (param_name == "global_frame_id" &&  // NOLINT(readability/braces)
+        global_frame_id_ != parameter.as_string())
+      {
         global_frame_id_ = parameter.as_string();
-      } else if (param_name == "map_topic") {
+      } else if (param_name == "map_topic" && map_topic_ != parameter.as_string()) {
         map_topic_ = parameter.as_string();
         reinit_map = true;
-      } else if (param_name == "laser_model_type") {
+      } else if (param_name == "laser_model_type" &&  // NOLINT(readability/braces)
+        sensor_model_type_ != parameter.as_string())
+      {
         sensor_model_type_ = parameter.as_string();
         reinit_laser = true;
-      } else if (param_name == "odom_frame_id") {
+      } else if (param_name == "odom_frame_id" &&  // NOLINT(readability/braces)
+        odom_frame_id_ != parameter.as_string())
+      {
         odom_frame_id_ = parameter.as_string();
         reinit_laser = true;
-      } else if (param_name == "scan_topic") {
+      } else if (param_name == "scan_topic" && scan_topic_ != parameter.as_string()) {
         scan_topic_ = parameter.as_string();
         reinit_laser = true;
-      } else if (param_name == "robot_model_type") {
+      } else if (param_name == "robot_model_type" &&  // NOLINT(readability/braces)
+        robot_model_type_ != parameter.as_string())
+      {
         robot_model_type_ = parameter.as_string();
         reinit_odom = true;
-      } else if (param_name == "saved_pose_filepath") {
+      } else if (param_name == "saved_pose_filepath" &&  // NOLINT(readability/braces)
+        saved_pose_filepath_ != parameter.as_string())
+      {
         saved_pose_filepath_ = parameter.as_string();
       }
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
-      if (param_name == "do_beamskip") {
+      if (param_name == "do_beamskip" && do_beamskip_ != parameter.as_bool()) {
         do_beamskip_ = parameter.as_bool();
         reinit_laser = true;
-      } else if (param_name == "tf_broadcast") {
+      } else if (param_name == "tf_broadcast" && tf_broadcast_ != parameter.as_bool()) {
         tf_broadcast_ = parameter.as_bool();
-      } else if (param_name == "set_initial_pose") {
+      } else if (param_name == "set_initial_pose" &&  // NOLINT(readability/braces)
+        set_initial_pose_ != parameter.as_bool())
+      {
         set_initial_pose_ = parameter.as_bool();
-      } else if (param_name == "first_map_only") {
+      } else if (param_name == "first_map_only" &&  // NOLINT(readability/braces)
+        first_map_only_ != parameter.as_bool())
+      {
         first_map_only_ = parameter.as_bool();
-      } else if (param_name == "initialize_at_saved_pose") {
+      } else if (param_name == "initialize_at_saved_pose" &&  // NOLINT(readability/braces)
+        initialize_at_saved_pose_ != parameter.as_bool())
+      {
         initialize_at_saved_pose_ = parameter.as_bool();
       }
     } else if (param_type == ParameterType::PARAMETER_INTEGER) {
-      if (param_name == "max_beams") {
+      if (param_name == "max_beams" && max_beams_ != parameter.as_int()) {
         max_beams_ = parameter.as_int();
         reinit_laser = true;
-      } else if (param_name == "max_particles") {
+      } else if (param_name == "max_particles" && max_particles_ != parameter.as_int()) {
         max_particles_ = parameter.as_int();
         reinit_pf = true;
-      } else if (param_name == "min_particles") {
+      } else if (param_name == "min_particles" && min_particles_ != parameter.as_int()) {
         min_particles_ = parameter.as_int();
         reinit_pf = true;
-      } else if (param_name == "resample_interval") {
+      } else if (param_name == "resample_interval" &&  // NOLINT(readability/braces)
+        resample_interval_ != parameter.as_int())
+      {
         resample_interval_ = parameter.as_int();
       }
     }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -164,6 +164,20 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
       &AmclNode::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
 
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
+
   // create bond connection
   createBond();
 

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -98,6 +98,20 @@ void InflationLayer::activate()
     std::bind(
       &InflationLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
 }
 
 void InflationLayer::deactivate()

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -810,6 +810,21 @@ ObstacleLayer::activate()
     std::bind(
       &ObstacleLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
+
   for (auto & notifier : observation_notifiers_) {
     notifier->clear();
   }

--- a/nav2_costmap_2d/plugins/plugin_container_layer.cpp
+++ b/nav2_costmap_2d/plugins/plugin_container_layer.cpp
@@ -127,6 +127,20 @@ void PluginContainerLayer::activate()
       &PluginContainerLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
 
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
+
   for (vector<std::shared_ptr<Layer>>::iterator plugin = plugins_.begin(); plugin != plugins_.end();
     ++plugin)
   {

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -118,6 +118,20 @@ StaticLayer::activate()
     std::bind(
       &StaticLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
 }
 
 void

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -113,6 +113,20 @@ void VoxelLayer::activate()
     std::bind(
       &VoxelLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
 }
 
 void VoxelLayer::deactivate()

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -121,6 +121,20 @@ void KinematicsHandler::activate()
     std::bind(
       &KinematicsHandler::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
 }
 
 void KinematicsHandler::deactivate()

--- a/nav2_util/include/nav2_util/parameter_handler.hpp
+++ b/nav2_util/include/nav2_util/parameter_handler.hpp
@@ -76,7 +76,8 @@ public:
     for (const auto & name : node->list_parameters({}, 0).names) {
       rclcpp::Parameter p;
       if (node->get_parameter(name, p) &&
-        p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+        p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET &&
+        validateParameterUpdatesCallback({p}).successful)
       {
         initialized.push_back(p);
       }

--- a/nav2_util/include/nav2_util/parameter_handler.hpp
+++ b/nav2_util/include/nav2_util/parameter_handler.hpp
@@ -70,6 +70,20 @@ public:
       std::bind(&ParameterHandler::updateParametersCallback, this, std::placeholders::_1));
     on_set_params_handler_ = node->add_on_set_parameters_callback(
       std::bind(&ParameterHandler::validateParameterUpdatesCallback, this, std::placeholders::_1));
+
+    // Resync cached params with the parameter store
+    std::vector<rclcpp::Parameter> initialized;
+    for (const auto & name : node->list_parameters({}, 0).names) {
+      rclcpp::Parameter p;
+      if (node->get_parameter(name, p) &&
+        p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+      {
+        initialized.push_back(p);
+      }
+    }
+    if (!initialized.empty()) {
+      updateParametersCallback(initialized);
+    }
   }
 
   /**

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -182,6 +182,20 @@ VelocitySmoother::on_activate(const rclcpp_lifecycle::State &)
       &VelocitySmoother::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
 
+  // Resync cached params with the parameter store
+  std::vector<rclcpp::Parameter> initialized;
+  for (const auto & name : node->list_parameters({}, 0).names) {
+    rclcpp::Parameter p;
+    if (node->get_parameter(name, p) &&
+      p.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    {
+      initialized.push_back(p);
+    }
+  }
+  if (!initialized.empty()) {
+    updateParametersCallback(initialized);
+  }
+
   // create bond connection
   createBond();
   return nav2::CallbackReturn::SUCCESS;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory Robot |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

Many Nav2 lifecycle nodes register the on-set parameter callback only in `activate()`/`on_activate()`. As a result, any `set_parameters` call made while a node is INACTIVE updates the parameter store but leaves the cached members stale The value isn't picked up until that same parameter is set again after the node is active. Symptom: `ros2 param get` reports the new value while the node keeps running on the old one.

### Fix

After re-registering the callbacks on activation, replay the current parameter store through the node's existing `updateParametersCallback` to resync the cache. Declared but uninitialized parameters (`PARAMETER_NOT_SET`) are skipped, since a bulk get on those throws `ParameterUninitializedException`.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

I first made the change to nav2_util/parameter_handler and velocity_smoother.cpp for the behavior I needed to fix. And I extensively tested these on a real robot running continuously for the last weeks.

Then I did the same for the other nodes that could be affected. And for these last ones, I did not test as extensively, so a proper second pair of eyes (and a CI run) would be appreciated.


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
