### PR TITLE
Use nav2 interface for behavior_tree_log publisher

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
@@ -26,6 +26,7 @@
 #include "nav2_msgs/msg/behavior_tree_status_change.hpp"
 #include "tf2/time.hpp"
 #include "tf2_ros/buffer_interface.hpp"
+#include "nav2_ros_common/interface_factories.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -51,8 +52,8 @@ public:
     auto node = ros_node.lock();
     clock_ = node->get_clock();
     logger_ = node->get_logger().get_child("ros_topic_logger");
-    log_pub_ = node->create_publisher<nav2_msgs::msg::BehaviorTreeLog>(
-      "behavior_tree_log");
+    log_pub_ = nav2::interfaces::create_publisher<nav2_msgs::msg::BehaviorTreeLog>(
+      node, "behavior_tree_log");
     enableTransitionToIdle(log_idle);
   }
 
@@ -109,7 +110,7 @@ protected:
   static constexpr size_t kStatusWidth = 7;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_{rclcpp::get_logger("bt_navigator")};
-  rclcpp::Publisher<nav2_msgs::msg::BehaviorTreeLog>::SharedPtr log_pub_;
+  nav2::Publisher<nav2_msgs::msg::BehaviorTreeLog>::SharedPtr log_pub_;
   std::vector<nav2_msgs::msg::BehaviorTreeStatusChange> event_log_;
 };
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Robot|
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

Convert 

## Description of documentation updates required from your changes

This PR make the behavior_tree_log publisher use nav2::interfaces.
I needed this to be able to override the QoS of the publisher (when needed).

## Description of how this change was tested

On a Dexory robot.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
