### PR TITLE
docs(doxygen): add XML usage examples for BT nodes (backport to jazzy)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
@@ -26,6 +26,12 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::AssistedTeleop
+ *
+ * Usage in XML:
+ * @code
+ * <AssistedTeleop is_recovery="false" server_name="assisted_teleop_server" server_timeout="10"
+ *                 error_code_id="{assisted_teleop_error_code}"/>
+ * @endcode
  */
 class AssistedTeleopAction : public BtActionNode<nav2_msgs::action::AssistedTeleop>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::BackUp
+ *
+ * Usage in XML:
+ * @code
+ * <CancelAssistedTeleop server_name="assisted_teleop" server_timeout="10"/>
+ * @endcode
  */
 class AssistedTeleopCancel : public BtCancelActionNode<nav2_msgs::action::AssistedTeleop>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -25,6 +25,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::BackUp
+ *
+ * Usage in XML:
+ * @code
+ * <BackUp backup_dist="-0.2" backup_speed="0.05"
+ *         server_name="backup_server" server_timeout="10"
+ *         error_code_id="{backup_error_code}"/>
+ * @endcode
  */
 class BackUpAction : public BtActionNode<nav2_msgs::action::BackUp>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::BackUp
+ *
+ * Usage in XML:
+ * @code
+ * <CancelBackUp server_name="BackUp" server_timeout="10"/>
+ * @endcode
  */
 class BackUpCancel : public BtCancelActionNode<nav2_msgs::action::BackUp>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/clear_costmap_service.hpp
@@ -28,6 +28,12 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtServiceNode class that wraps nav2_msgs::srv::ClearEntireCostmap
+ *
+ * Usage in XML:
+ * @code
+ * <ClearEntireCostmap name="ClearLocalCostmap-Subtree"
+ *                     service_name="local_costmap/clear_entirely_local_costmap"/>
+ * @endcode
  */
 class ClearEntireCostmapService : public BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>
 {
@@ -51,6 +57,13 @@ public:
 /**
  * @brief A nav2_behavior_tree::BtServiceNode class that
  * wraps nav2_msgs::srv::ClearCostmapExceptRegion
+ *
+ * Usage in XML:
+ * @code
+ * <ClearCostmapExceptRegion name="ClearLocalCostmap-Subtree"
+ *                           service_name="local_costmap/clear_except_local_costmap"
+ *                           reset_distance="2.0"/>
+ * @endcode
  */
 class ClearCostmapExceptRegionService
   : public BtServiceNode<nav2_msgs::srv::ClearCostmapExceptRegion>
@@ -89,6 +102,13 @@ public:
 /**
  * @brief A nav2_behavior_tree::BtServiceNode class that
  * wraps nav2_msgs::srv::ClearCostmapAroundRobot
+ *
+ * Usage in XML:
+ * @code
+ * <ClearCostmapAroundRobot name="ClearLocalCostmap-Subtree"
+ *                          service_name="local_costmap/clear_around_local_costmap"
+ *                          reset_distance="2.0"/>
+ * @endcode
  */
 class ClearCostmapAroundRobotService : public BtServiceNode<nav2_msgs::srv::ClearCostmapAroundRobot>
 {
@@ -128,6 +148,14 @@ public:
  * wraps nav2_msgs::srv::ClearCostmapAroundPose
  * @note This is an Asynchronous (long-running) node which may return a RUNNING state while executing.
  *       It will re-initialize when halted.
+ *
+ * Usage in XML:
+ * @code
+ * <ClearCostmapAroundPose name="ClearLocalCostmapAroundPose"
+ *                         service_name="local_costmap/clear_around_pose_local_costmap"
+ *                         pose="{goal_pose}"
+ *                         reset_distance="2.0"/>
+ * @endcode
  */
 class ClearCostmapAroundPoseService : public BtServiceNode<nav2_msgs::srv::ClearCostmapAroundPose>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
@@ -27,6 +27,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::ComputeAndTrackRoute
+ *
+ * Usage in XML:
+ * @code
+ * <ComputeAndTrackRoute start="{start}" goal="{goal}" use_poses="{true}" use_start="{true}"
+ *                       server_name="ComputeAndTrackRoute" server_timeout="10"
+ *                       error_code_id="{compute_route_error_code}"/>
+ * @endcode
  */
 class ComputeAndTrackRouteAction : public BtActionNode<nav2_msgs::action::ComputeAndTrackRoute>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_cancel_node.hpp
@@ -29,6 +29,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A nav2_behavior_tree::BtActionNode class
  * that wraps nav2_msgs::action::ComputeAndTrackRoute cancellation
+ *
+ * Usage in XML:
+ * @code
+ * <CancelComputeAndTrackRoute server_name="compute_and_track_route" server_timeout="10"/>
+ * @endcode
  */
 class ComputeAndTrackRouteCancel
   : public BtCancelActionNode<nav2_msgs::action::ComputeAndTrackRoute>

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -29,6 +29,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::ComputePathThroughPoses
+ *
+ * Usage in XML:
+ * @code
+ * <ComputePathThroughPoses goals="{goals}" path="{path}" planner_id="GridBased"
+ *                          server_name="ComputePathThroughPoses" server_timeout="10"
+ *                          error_code_id="{compute_path_error_code}"/>
+ * @endcode
  */
 class ComputePathThroughPosesAction
   : public BtActionNode<nav2_msgs::action::ComputePathThroughPoses>

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -27,6 +27,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::ComputePathToPose
+ *
+ * Usage in XML:
+ * @code
+ * <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"
+ *                    server_name="ComputePathToPose" server_timeout="10"
+ *                    error_code_id="{compute_path_error_code}"/>
+ * @endcode
  */
 class ComputePathToPoseAction : public BtActionNode<nav2_msgs::action::ComputePathToPose>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
@@ -27,6 +27,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::ComputeRoute
+ *
+ * Usage in XML:
+ * @code
+ * <ComputeRoute start="{start}" goal="{goal}" use_poses="{true}" use_start="{true}" path="{path}"
+ *               server_name="ComputeRoute" server_timeout="10"
+ *               error_code_id="{compute_route_error_code}"/>
+ * @endcode
  */
 class ComputeRouteAction : public BtActionNode<nav2_msgs::action::ComputeRoute>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/concatenate_paths_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/concatenate_paths_action.hpp
@@ -30,6 +30,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A BT::ActionNodeBase to shorten path by some distance
+ *
+ * Usage in XML:
+ * @code
+ * <ConcatenatePaths input_path1="{main_path}" input_path2="{last_mile_path}" output_path="{path}"/>
+ * @endcode
  */
 class ConcatenatePaths : public BT::ActionNodeBase
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <CancelControl server_name="FollowPath" server_timeout="10"/>
+ * @endcode
  */
 class ControllerCancel : public BtCancelActionNode<nav2_msgs::action::FollowPath>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
@@ -34,6 +34,12 @@ namespace nav2_behavior_tree
  * to get the decision about what controller must be used. It is usually used before of
  * the FollowPath. The selected_controller output port is passed to controller_id
  * input port of the FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath"
+ *                     topic_name="controller_selector"/>
+ * @endcode
  */
 class ControllerSelector : public BT::SyncActionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
@@ -25,6 +25,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::DriveOnHeading
+ *
+ * Usage in XML:
+ * @code
+ * <DriveOnHeading dist_to_travel="0.2" speed="0.05"
+ *                 server_name="backup_server" server_timeout="10"
+ *                 error_code_id="{drive_on_heading_error_code}"/>
+ * @endcode
  */
 class DriveOnHeadingAction : public BtActionNode<nav2_msgs::action::DriveOnHeading>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::DriveOnHeading
+ *
+ * Usage in XML:
+ * @code
+ * <CancelDriveOnHeading server_name="drive_on_heading" server_timeout="10"/>
+ * @endcode
  */
 class DriveOnHeadingCancel : public BtCancelActionNode<nav2_msgs::action::DriveOnHeading>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -27,6 +27,14 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <FollowPath path="{path}" controller_id="FollowPath"
+ *             goal_checker_id="precise_goal_checker"
+ *             server_name="FollowPath" server_timeout="10"
+ *             error_code_id="{follow_path_error_code}"/>
+ * @endcode
  */
 class FollowPathAction : public BtActionNode<nav2_msgs::action::FollowPath>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_current_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_current_pose_action.hpp
@@ -32,6 +32,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief Action Node to get the current robot pose from TF
+ *
+ * Usage in XML:
+ * @code
+ * <GetCurrentPose current_pose="{current_pose}"/>
+ * @endcode
  */
 class GetCurrentPoseAction : public BT::ActionNodeBase
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_pose_from_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_pose_from_path_action.hpp
@@ -30,6 +30,12 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <GetPoseFromPath path="{path}" index="-1" pose="{goal}"/>
+ * @endcode
+ */
 class GetPoseFromPath : public BT::ActionNodeBase
 {
 public:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
@@ -34,6 +34,12 @@ namespace nav2_behavior_tree
  * to get the decision about what goal_checker must be used. It is usually used before of
  * the FollowPath. The selected_goal_checker output port is passed to goal_checker_id
  * input port of the FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <GoalCheckerSelector selected_goal_checker="{selected_goal_checker}"
+ *                      default_goal_checker="precise_goal_checker" topic_name="goal_checker_selector"/>
+ * @endcode
  */
 class GoalCheckerSelector : public BT::SyncActionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -29,6 +29,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::NavigateThroughPoses
+ *
+ * Usage in XML:
+ * @code
+ * <NavigateThroughPoses goals="{goals}" server_name="NavigateThroughPoses" server_timeout="10"
+ *                       error_code_id="{navigate_through_poses_error_code}"
+ *                       behavior_tree="<some-path>/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml"/>
+ * @endcode
  */
 class NavigateThroughPosesAction : public BtActionNode<nav2_msgs::action::NavigateThroughPoses>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
@@ -28,6 +28,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::NavigateToPose
+ *
+ * Usage in XML:
+ * @code
+ * <NavigateToPose goal="{goal}" server_name="NavigateToPose" server_timeout="10"
+ *                 error_code_id="{navigate_to_pose_error_code}"
+ *                 behavior_tree="<some-path>/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml"/>
+ * @endcode
  */
 class NavigateToPoseAction : public BtActionNode<nav2_msgs::action::NavigateToPose>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
@@ -34,6 +34,12 @@ namespace nav2_behavior_tree
  * to get the decision about what planner must be used. It is usually used before of
  * the ComputePathToPoseAction. The selected_planner output port is passed to planner_id
  * input port of the ComputePathToPoseAction
+ *
+ * Usage in XML:
+ * @code
+ * <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased"
+ *                  topic_name="planner_selector"/>
+ * @endcode
  */
 class PlannerSelector : public BT::SyncActionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
@@ -33,6 +33,13 @@ namespace nav2_behavior_tree
  * to get the decision about what progress_checker must be used. It is usually used before of
  * the FollowPath. The selected_progress_checker output port is passed to progress_checker_id
  * input port of the FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <ProgressCheckerSelector selected_progress_checker="{selected_progress_checker}"
+ *                          default_progress_checker="precise_progress_checker"
+ *                          topic_name="progress_checker_selector"/>
+ * @endcode
  */
 class ProgressCheckerSelector : public BT::SyncActionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.hpp
@@ -25,6 +25,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtServiceNode class that wraps nav2_msgs::srv::Empty
+ *
+ * Usage in XML:
+ * @code
+ * <ReinitializeGlobalLocalization service_name="reinitialize_global_localization"/>
+ * @endcode
  */
 class ReinitializeGlobalLocalizationService : public BtServiceNode<std_srvs::srv::Empty>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
@@ -30,6 +30,12 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <RemovePassedGoals radius="0.6" input_goals="{goals}" output_goals="{goals}"/>
+ * @endcode
+ */
 class RemovePassedGoals : public BT::ActionNodeBase
 {
 public:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
@@ -28,6 +28,14 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::SmoothPath
+ *
+ * Usage in XML:
+ * @code
+ * <SmoothPath unsmoothed_path="{path}" smoothed_path="{path}" max_smoothing_duration="3.0"
+ *             smoother_id="simple_smoother" check_for_collisions="false"
+ *             smoothing_duration="{smoothing_duration_used}" was_completed="{smoothing_completed}"
+ *             error_code_id="{smoothing_path_error_code}"/>
+ * @endcode
  */
 class SmoothPathAction : public nav2_behavior_tree::BtActionNode<nav2_msgs::action::SmoothPath>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
@@ -34,6 +34,12 @@ namespace nav2_behavior_tree
  * to get the decision about what smoother must be used. It is usually used before of
  * the FollowPath. The selected_smoother output port is passed to smoother_id
  * input port of the FollowPath
+ *
+ * Usage in XML:
+ * @code
+ * <SmootherSelector selected_smoother="{selected_smoother}" default_smoother="SimpleSmoother"
+ *                   topic_name="smoother_selector"/>
+ * @endcode
  */
 class SmootherSelector : public BT::SyncActionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
@@ -25,6 +25,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::Spin
+ *
+ * Usage in XML:
+ * @code
+ * <Spin spin_dist="1.57" server_name="spin"
+ *       server_timeout="10" is_recovery="true"
+ *       error_code_id="{spin_error_code}"/>
+ * @endcode
  */
 class SpinAction : public BtActionNode<nav2_msgs::action::Spin>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::Wait
+ *
+ * Usage in XML:
+ * @code
+ * <CancelSpin server_name="Spin" server_timeout="10"/>
+ * @endcode
  */
 class SpinCancel : public BtCancelActionNode<nav2_msgs::action::Spin>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_action.hpp
@@ -30,6 +30,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A BT::ActionNodeBase to shorten path by some distance
+ *
+ * Usage in XML:
+ * @code
+ * <TruncatePath distance="1.0" input_path="{path}" output_path="{truncated_path}"/>
+ * @endcode
  */
 class TruncatePath : public BT::ActionNodeBase
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
@@ -32,6 +32,12 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A BT::ActionNodeBase to shorten path to some distance around robot
+ *
+ * Usage in XML:
+ * @code
+ * <TruncatePathLocal input_path="{path}" output_path="{path_local}"
+ *                    distance_forward="3.5" distance_backward="2.0" robot_frame="base_link"/>
+ * @endcode
  */
 class TruncatePathLocal : public BT::ActionNodeBase
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
@@ -25,6 +25,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::Wait
+ *
+ * Usage in XML:
+ * @code
+ * <Wait wait_duration="1.0" server_name="wait_server" server_timeout="10"/>
+ * @endcode
  */
 class WaitAction : public BtActionNode<nav2_msgs::action::Wait>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_cancel_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_cancel_node.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::Wait
+ *
+ * Usage in XML:
+ * @code
+ * <CancelWait server_name="Wait" server_timeout="10"/>
+ * @endcode
  */
 class WaitCancel : public BtCancelActionNode<nav2_msgs::action::Wait>
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp
@@ -26,6 +26,16 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <!-- Error codes to check are defined in another port. -->
+ * <AreErrorCodesPresent error_code="{error_code}" error_codes_to_check="{error_codes_to_check}"/>
+ *
+ * <!-- Error codes to check are defined to be 101, 107 and 119. -->
+ * <AreErrorCodesPresent error_code="{error_code}" error_codes_to_check="101;107;119"/>
+ * @endcode
+ */
 class AreErrorCodesPresent : public BT::ConditionNode
 {
 public:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_poses_near_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_poses_near_condition.hpp
@@ -32,6 +32,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS when a specified goal
  * is reached and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <ArePosesNear ref_pose="{init_pose}" target_pose="{goal_pose}" tolerance="0.10"/>
+ * @endcode
  */
 class ArePosesNearCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/distance_traveled_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/distance_traveled_condition.hpp
@@ -32,6 +32,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS every time the robot
  * travels a specified distance and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <DistanceTraveled distance="0.8" global_frame="map" robot_base_frame="base_link"/>
+ * @endcode
  */
 class DistanceTraveledCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
@@ -32,6 +32,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS when goal is
  * updated on the blackboard and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <GlobalUpdatedGoal/>
+ * @endcode
  */
 class GloballyUpdatedGoalCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
@@ -31,6 +31,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS when a specified goal
  * is reached and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <GoalReached goal="{goal}" global_frame="map" robot_base_frame="base_link"/>
+ * @endcode
  */
 class GoalReachedCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
@@ -30,6 +30,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS when goal is
  * updated on the blackboard and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <GoalUpdated/>
+ * @endcode
  */
 class GoalUpdatedCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.hpp
@@ -24,6 +24,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS if initial pose
  * has been received and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <InitialPoseReceived/>
+ * @endcode
  */
 class InitialPoseReceived : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
@@ -29,6 +29,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that listens to a battery topic and
  * returns SUCCESS when battery is charging and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <IsBatteryCharging battery_topic="/battery_status"/>
+ * @endcode
  */
 class IsBatteryChargingCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
@@ -30,6 +30,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that listens to a battery topic and
  * returns SUCCESS when battery is low and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <IsBatteryLow min_battery="0.5" battery_topic="/battery_status" is_voltage="false"/>
+ * @endcode
  */
 class IsBatteryLowCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_path_valid_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_path_valid_condition.hpp
@@ -31,6 +31,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS when the IsPathValid
  * service returns true and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <IsPathValid server_timeout="10" path="{path}"/>
+ * @endcode
  */
 class IsPathValidCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_stuck_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_stuck_condition.hpp
@@ -29,6 +29,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that tracks robot odometry and returns SUCCESS
  * if robot is stuck somewhere and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <IsStuck/>
+ * @endcode
  */
 class IsStuckCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.hpp
@@ -30,6 +30,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS every time a specified
  * time period passes and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <PathExpiringTimer seconds="15" path="{path}"/>
+ * @endcode
  */
 class PathExpiringTimerCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/time_expired_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/time_expired_condition.hpp
@@ -27,6 +27,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS every time a specified
  * time period passes and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <TimeExpired seconds="1.0"/>
+ * @endcode
  */
 class TimeExpiredCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/transform_available_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/transform_available_condition.hpp
@@ -29,6 +29,11 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::ConditionNode that returns SUCCESS if there is a valid transform
  * between two specified frames and FAILURE otherwise
+ *
+ * Usage in XML:
+ * @code
+ * <TransformAvailable parent="odom" child="base_link"/>
+ * @endcode
  */
 class TransformAvailableCondition : public BT::ConditionNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp
@@ -23,6 +23,12 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <WouldAControllerRecoveryHelp error_code="{follow_path_error_code}"/>
+ * @endcode
+ */
 class WouldAControllerRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::FollowPath;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
@@ -24,6 +24,12 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <WouldAPlannerRecoveryHelp error_code="{compute_path_to_pose_error_code}"/>
+ * @endcode
+ */
 class WouldAPlannerRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::ComputePathToPose;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp
@@ -24,6 +24,12 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * Usage in XML:
+ * @code
+ * <WouldASmootherRecoveryHelp error_code="{smoother_error_code}"/>
+ * @endcode
+ */
 class WouldASmootherRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::SmoothPath;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/pipeline_sequence.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/pipeline_sequence.hpp
@@ -50,7 +50,12 @@ namespace nav2_behavior_tree
  * If any children at any time had returned FAILURE. PipelineSequence would have returned FAILURE
  * and halted all children, ending the sequence.
  *
- * Usage in XML: <PipelineSequence>
+ * Usage in XML:
+ * @code
+ * <PipelineSequence>
+ *     <!--Add tree components here-->
+ * </PipelineSequence>
+ * @endcode
  */
 class PipelineSequence : public BT::ControlNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -31,6 +31,12 @@ namespace nav2_behavior_tree
  *
  * - If the second child returns FAILURE, this control node will stop the loop and returns FAILURE.
  *
+ * Usage in XML:
+ * @code
+ * <RecoveryNode number_of_retries="1">
+ *     <!--Add tree components here-->
+ * </RecoveryNode>
+ * @endcode
  */
 class RecoveryNode : public BT::ControlNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -49,7 +49,12 @@ namespace nav2_behavior_tree
  * If all children return FAILURE, RoundRobin will return FAILURE
  * and halt all children, ending the sequence.
  *
- * Usage in XML: <RoundRobin>
+ * Usage in XML:
+ * @code
+ * <RoundRobin>
+ *     <!--Add tree components here-->
+ * </RoundRobin>
+ * @endcode
  */
 class RoundRobinNode : public BT::ControlNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/distance_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/distance_controller.hpp
@@ -31,6 +31,13 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::DecoratorNode that ticks its child every time the robot
  * travels a specified distance
+ *
+ * Usage in XML:
+ * @code
+ * <DistanceController distance="0.5" global_frame="map" robot_base_frame="base_link">
+ *     <!--Add tree components here-->
+ * </DistanceController>
+ * @endcode
  */
 class DistanceController : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
@@ -32,6 +32,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A BT::DecoratorNode that ticks its child if the goal was updated
+ *
+ * Usage in XML:
+ * @code
+ * <GoalUpdatedController goal="{goal}" goals="{goals}">
+ *     <!--Add tree components here-->
+ * </GoalUpdatedController>
+ * @endcode
  */
 class GoalUpdatedController : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
@@ -33,6 +33,13 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::DecoratorNode that subscribes to a goal topic and updates
  * the current goal on the blackboard
+ *
+ * Usage in XML:
+ * @code
+ * <GoalUpdater input_goal="{goal}" output_goal="{goal}">
+ *     <!--Add tree components here-->
+ * </GoalUpdater>
+ * @endcode
  */
 class GoalUpdater : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
@@ -32,6 +32,13 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::DecoratorNode that ticks its child everytime when the length of
  * the new path is smaller than the old one by the length given by the user.
+ *
+ * Usage in XML:
+ * @code
+ * <PathLongerOnApproach path="{path}" prox_len="3.0" length_factor="2.0">
+ *     <!--Add tree components here-->
+ * </PathLongerOnApproach>
+ * @endcode
  */
 class PathLongerOnApproach : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/rate_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/rate_controller.hpp
@@ -25,6 +25,13 @@ namespace nav2_behavior_tree
 
 /**
  * @brief A BT::DecoratorNode that ticks its child at a specified rate
+ *
+ * Usage in XML:
+ * @code
+ * <RateController hz="1.0">
+ *     <!--Add tree components here-->
+ * </RateController>
+ * @endcode
  */
 class RateController : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/single_trigger_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/single_trigger_node.hpp
@@ -26,6 +26,13 @@ namespace nav2_behavior_tree
 /**
  * @brief A BT::DecoratorNode that triggers its child only once and returns FAILURE
  * for every succeeding tick
+ *
+ * Usage in XML:
+ * @code
+ * <SingleTrigger>
+ *     <!--Add tree components here-->
+ * </SingleTrigger>
+ * @endcode
  */
 class SingleTrigger : public BT::DecoratorNode
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
@@ -36,6 +36,13 @@ namespace nav2_behavior_tree
  * @brief A BT::DecoratorNode that ticks its child every at a rate proportional to
  * the speed of the robot. If the robot travels faster, this node will tick its child at a
  * higher frequency and reduce the tick frequency if the robot slows down
+ *
+ * Usage in XML:
+ * @code
+ * <SpeedController min_rate="0.1" max_rate="1.0" min_speed="0.0" max_speed="0.5">
+ *     <!--Add tree components here-->
+ * </SpeedController>
+ * @endcode
  */
 class SpeedController : public BT::DecoratorNode
 {

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
@@ -28,6 +28,11 @@ namespace opennav_docking_bt
 
 /**
  * @brief nav2_behavior_tree::BtActionNode class that wraps opnav2_msgsennav_docking_msgs/DockRobot
+ *
+ * Usage in XML:
+ * @code
+ * <DockRobot dock_id="{dock_id}" error_code_id="{dock_error_code}"/>
+ * @endcode
  */
 class DockRobotAction
   : public nav2_behavior_tree::BtActionNode<

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
@@ -28,6 +28,11 @@ namespace opennav_docking_bt
 
 /**
  * @brief nav2_behavior_tree::BtActionNode class that wraps nav2_msgs/UndockRobot
+ *
+ * Usage in XML:
+ * @code
+ * <UndockRobot dock_type="{dock_type}" error_code_id={undock_error_code}/>
+ * @endcode
  */
 class UndockRobotAction
   : public nav2_behavior_tree::BtActionNode<


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A  |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points


Backport  [PR 6101](https://github.com/ros-navigation/navigation2/pull/6101) to Jazzy.
The examples have been taken from the current documentation, taking into account the differences that exist in Jazzy. For convenience, I'll list these changes below:

- Added `global_frame` to `GoalReached`
Ref: `1221d0f` - Remove global_frame input port from the GoalReached and RemovePassedGoals behavior nodes

- Renamed and simplified `IsPathValid` (`ValidatePath` in Rolling) example.
Ref (commit state): `3d3061c` - Replan only if path becomes invalid (256)

- Removed `error_msg` from:
	- `AssistedTeleop`
	- `BackUp`
	- `ComputePathThroughPoses`
	- `ComputePathToPose`
	- `DockRobot`
	- `DriveOnHeading`
	- `FollowPath`
	- `NavigateThroughPoses`
	- `NavigateToPose`
	- `SmoothPath`
	- `Spin`
	- `UndockRobot`
	- `Wait` (and `error_code_id`)
Ref: `f6a11d8` - Document bt_navigator error_code_name_prefixes and error_msg

- Removed `input_waypoint_statuses` and `output_waypoint_statuses` from `RemovePassedGoals`
Ref: `a1bcd6d` - Make NavigateThroughPoses navigator report waypoint statuses information. (669)

- Used a path instead of `NavigateThroughPosesWReplanningAndRecovery` for the `behavior_tree` port in `NavigateToPose`
Ref: `991bc08` - Fixed Docs for Behavior tree (772)

- Removed `wrap_around` from `RoundRobin` 
Ref: `2021275` - docs: Add wrap_around parameter documentation for RoundRobin BT node (818)

- Removed from `FollowPath` 
	- `path_handler_id`; Ref: `29b79d4` - Centralize path handler logic in controller server (816)
	- `tracking_feedback`; Ref: `736d6ca` - Add tracking feedback to followpath output port (841)

- Removed `plugins` ports from:
	- `ClearCostmapAroundPose`
	- `ClearCostmapAroundRobot`
	- `ClearCostmapExceptRegion`
	- `ClearEntireCostmap`
Ref: `5132ae1` - Feature/clear individual costmap layers

- Removed `input_goals` and `output_goals` from `GoalUpdater`
  Ref: `90c2e60` - Update GoalUpdater docs (621)

- Removed `disable_collision_checks` from:
	- `DriveOnHeading`
	- `BackUp`
	- `Spin`
Ref: `fe19009` - document the new disable_collision_checks param (617)

- Removed `filter_duration` from `SpeedController`. This is some obsolete port, which also needs to be removed in Rolling docs/doxygen. 

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
