### PR TITLE
docs: update BT XML data 

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
@@ -40,7 +40,7 @@ namespace nav2_behavior_tree
  *
  * Usage in XML:
  * @code
- * <SpeedController min_rate="0.1" max_rate="1.0" min_speed="0.0" max_speed="0.5" filter_duration="0.3">
+ * <SpeedController min_rate="0.1" max_rate="1.0" min_speed="0.0" max_speed="0.5">
  *     <!--Add tree components here-->
  * </SpeedController>
  * @endcode

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -222,8 +222,8 @@
       <input_port name="behavior_tree" type="string">Behavior tree absolute path or ID. If none is specified, NavigateToPose action server uses a default behavior tree.</input_port>
       <input_port name="server_name" type="string">Action server name. If not specified, `navigate_to_pose` is used.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Action server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <output_port name="error_code_id" type="uint16">The lowest error code in the list of the `error_code_names_prefixes` + `_error_code` suffix parameter.</output_port>
-      <output_port name="error_msg" type="string">The error messages associated with the lowest error code in the list of the `error_code_name_prefixes` + `_error_code` parameter.</output_port>
+      <output_port name="error_code_id" type="uint16">The lowest error code in the list of the `error_code_name_prefixes` + `_error_code` suffix parameter.</output_port>
+      <output_port name="error_msg" type="string">The error messages associated with the lowest error code in the list of the `error_code_name_prefixes` + `_error_code` suffix parameter.</output_port>
     </Action>
 
     <Action ID="NavigateThroughPoses">
@@ -231,8 +231,8 @@
       <input_port name="behavior_tree" type="string">Behavior tree absolute path or ID. If none is specified, NavigateThroughPoses action server uses a default behavior tree.</input_port>
       <input_port name="server_name" type="string">Action server name. If not specified, `navigate_through_poses` is used.</input_port>
       <input_port name="server_timeout" type="chrono::milliseconds">Action server timeout (ms). If not provided, uses the BT Navigator's `default_server_timeout` parameter value (20 ms by default).</input_port>
-      <output_port name="error_code_id" type="uint16">The lowest error code in the list of the `error_code_name_prefixes` parameter.</output_port>
-      <output_port name="error_msg" type="string">The error message associated with the lowest error code in the list of the `error_code_name_prefixes` parameter.</output_port>
+      <output_port name="error_code_id" type="uint16">The lowest error code in the list of the `error_code_name_prefixes` + `_error_code` suffix parameter.</output_port>
+      <output_port name="error_msg" type="string">The error message associated with the lowest error code in the list of the `error_code_name_prefixes` + `_error_code` suffix parameter.</output_port>
     </Action>
 
     <Action ID="ReinitializeGlobalLocalization">


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | N/A |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Removed non-existent port `filter_duration` from the Doxygen XML usage example (`SpeedController` node).
It was found and removed during the backport to Jazzy #6203, and now I’m just updating the main branch so that the changes are in sync.
- Updated the parameter name from `error_code_names_prefixes` to `error_code_name_prefixes` in `NavigateToPose`.
- Added information about `_error_code` suffix to `NavigateThroughPoses` BT Node by analogy with `NavigateToPose`. This part isn’t related to the backport, but I just noticed this difference whilst working on it.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
