### PR TITLE
feat: add valiation to avoid overflow in mapMetaData

### DIFF
--- a/nav2_util/include/nav2_util/validate_messages.hpp
+++ b/nav2_util/include/nav2_util/validate_messages.hpp
@@ -156,6 +156,13 @@ bool validateMsg(const nav_msgs::msg::MapMetaData & msg)
   // logic check
   // 1> we don't need an empty map
   if (msg.height == 0 || msg.width == 0) {return false;}
+
+  // avoid overflow by multiplying width and height
+  if (msg.width > INT16_MAX || msg.height > INT16_MAX) {return false;}
+  uint32_t num_cells;
+  if (__builtin_mul_overflow(msg.width, msg.height, &num_cells)) {
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6206 https://github.com/ros-navigation/navigation2/issues/5610 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* backport validation(from `main` to `jazzy`) for `nav_msgs::msg::MapMetaData` to avoid **interger overflow**
* checks if `msg.width` and `msg.height` are smaller than `INT_MAX` and their multiplication may leads to overflow(`__builtin_mul_overflow`)
* almost same implementation of `main` branch

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements


## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---
* create `nav2_amcl` node (e.g. `ros2 run nav2_amcl amcl`) and transit to activate state
* publish `/map` message with overflowed width and height(e.g. 65536*65536=0)
* finally, rejects the message by `nav2_util::validateMsg`

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
