### PR TITLE
feat: add map resolution validation to check if it is too small or ne…

### DIFF
--- a/nav2_util/include/nav2_util/validate_messages.hpp
+++ b/nav2_util/include/nav2_util/validate_messages.hpp
@@ -145,6 +145,7 @@ bool validateMsg(const geometry_msgs::msg::PoseWithCovarianceStamped & msg)
   return true;
 }
 
+const double MIN_MAP_RESOLUTION = 1e-6;
 
 // Function to verify map meta information
 bool validateMsg(const nav_msgs::msg::MapMetaData & msg)
@@ -152,6 +153,9 @@ bool validateMsg(const nav_msgs::msg::MapMetaData & msg)
   // check sub-type
   if (!validateMsg(msg.origin)) {return false;}
   if (!validateMsg(msg.resolution)) {return false;}
+
+  // check logic
+  if (msg.resolution <= MIN_MAP_RESOLUTION) {return false;}          // check map-resolution
 
   // logic check
   // 1> we don't need an empty map
@@ -167,10 +171,6 @@ bool validateMsg(const nav_msgs::msg::OccupancyGrid & msg)
   // msg.data :  @todo any check for it ?
   if (!validateMsg(msg.info)) {return false;}
 
-  // check logic
-  if (msg.info.resolution <= 0.0) {
-    return false;                                                          // check map-resolution
-  }
   if (msg.data.size() != msg.info.width * msg.info.height) {
     return false;                                                          // check map-size
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6206 https://github.com/ros-navigation/navigation2/issues/6188 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* backport validation(from `main` to `jazzy`) for `nav_msgs::msg::MapMetaData`
* check `msg.info` is smaller than `MIN_MAP_RESOLUTION`(1e-6), if so, reject message.
* this validation prevents heap buffer overflow caused by abnormal map resolution.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements


## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
* create `nav2_amcl` node(e.g. `ros2 run nav2_amcl amcl`) and transit to activate state
* publish `/map` message with too small or negative resolution (e.g. 1e-10, -1)
* finally, rejects the message by `nav2_util::validateMsg()`

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
