### PR TITLE
[nav2_util] Use end path orientation when interpolate_after_goal triggers

### DIFF
--- a/nav2_util/src/controller_utils.cpp
+++ b/nav2_util/src/controller_utils.cpp
@@ -128,6 +128,8 @@ geometry_msgs::msg::PoseStamped getLookAheadPoint(
       geometry_msgs::msg::PoseStamped interpolated_pose;
       interpolated_pose.header = last_pose_it->header;
       interpolated_pose.pose.position = interpolated_position;
+      interpolated_pose.pose.orientation =
+        geometry_utils::orientationAroundZAxis(end_path_orientation);
 
       return interpolated_pose;
     } else {


### PR DESCRIPTION
Hi,

Currently, when getting the look ahead point beyond the plan using interpolate_after_goal, orientation of the end path is not taken into account. This means that the orientation in the message remains as unity which causes the robot to keep whatever orientation it has towards the end of the path.

In my specific usecase, I am designing a custom controller based on RPP and if my robot is off the plan towards the end of it, it would continue with the wrong orientation as soon as interpolate_after_goal kicks in:

[without_end_path_orientation.webm](https://github.com/user-attachments/assets/80918d1f-b4c5-412c-959e-fdcf5c332eac)

I wonder if this was intentional and whether I am missing something or not.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
