### PR TITLE
feat: add OccupancyGridUpdate message validation

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -322,7 +322,7 @@ StaticLayer::incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr u
     RCLCPP_ERROR(logger_, "Received map update is malformed. Rejecting.");
     return;
   }
-  
+
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (update->y < static_cast<int32_t>(y_) ||
     y_ + height_ < update->y + update->height ||

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -318,6 +318,11 @@ StaticLayer::incomingMap(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & ne
 void
 StaticLayer::incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update)
 {
+  if (!nav2::validateMsg(*update)) {
+    RCLCPP_ERROR(logger_, "Received map update is malformed. Rejecting.");
+    return;
+  }
+  
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (update->y < static_cast<int32_t>(y_) ||
     y_ + height_ < update->y + update->height ||

--- a/nav2_ros_common/CMakeLists.txt
+++ b/nav2_ros_common/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(lifecycle_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(map_msgs REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
@@ -34,7 +35,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE
   ${geometry_msgs_TARGETS}
   ${nav2_msgs_TARGETS}
   ${nav_msgs_TARGETS}
-  ${nav_msgs_TARGETS}
+  ${map_msgs_TARGETS}
   pluginlib::pluginlib
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
@@ -75,6 +76,7 @@ ament_export_dependencies(
   geometry_msgs
   nav2_msgs
   nav_msgs
+  map_msgs
   rclcpp
   rclcpp_action
   rclcpp_lifecycle

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -23,6 +23,7 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "map_msgs/msg/occupancy_grid_update.hpp"
 
 
 // @brief Validation Check
@@ -194,6 +195,35 @@ bool validateMsg(const nav_msgs::msg::OccupancyGrid & msg)
     return false;
   }
 
+
+  return true;
+}
+
+// for partial map updates as `OccupancyGridUpdate`
+bool validateMsg(const map_msgs::msg::OccupancyGridUpdate & msg)
+{
+  // check sub-type
+  if (!validateMsg(msg.header)) {return false;}
+
+  // check logic
+  if (msg.data.size() != static_cast<size_t>(msg.width) * msg.height) {
+    return false;                                                          // check update-size
+  }
+
+  // value check: x/y are int32, negative origin is invalid
+  if (msg.x < 0 || msg.y < 0) {return false;}
+
+  if (msg.x > INT16_MAX || msg.y > INT16_MAX ||
+      msg.width > INT16_MAX || msg.height > INT16_MAX) {
+    // avoid integer overflow in StaticLayer::incomingUpdate() 
+    return false;
+  }
+
+  uint32_t num_cells;
+  if (__builtin_mul_overflow(msg.width, msg.height, &num_cells)) {
+    // avoid overflow msg.width * msg.height in StaticLayer::incomingUpdate()
+    return false;
+  }
 
   return true;
 }

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -207,7 +207,7 @@ bool validateMsg(const map_msgs::msg::OccupancyGridUpdate & msg)
 
   // check logic
   if (msg.data.size() != static_cast<size_t>(msg.width) * msg.height) {
-    return false;                                                          // check update-size
+    return false;  // check update-size
   }
 
   // value check: x/y are int32, negative origin is invalid

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -214,8 +214,9 @@ bool validateMsg(const map_msgs::msg::OccupancyGridUpdate & msg)
   if (msg.x < 0 || msg.y < 0) {return false;}
 
   if (msg.x > INT16_MAX || msg.y > INT16_MAX ||
-      msg.width > INT16_MAX || msg.height > INT16_MAX) {
-    // avoid integer overflow in StaticLayer::incomingUpdate() 
+    msg.width > INT16_MAX || msg.height > INT16_MAX)
+  {
+    // avoid integer overflow in StaticLayer::incomingUpdate()
     return false;
   }
 

--- a/nav2_ros_common/package.xml
+++ b/nav2_ros_common/package.xml
@@ -19,6 +19,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>map_msgs</depend>
   <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>

--- a/nav2_ros_common/test/CMakeLists.txt
+++ b/nav2_ros_common/test/CMakeLists.txt
@@ -114,6 +114,7 @@ target_link_libraries(test_validation_messages
   ${lifecycle_msgs_TARGETS}
   ${nav2_msgs_TARGETS}
   ${nav_msgs_TARGETS}
+  ${map_msgs_TARGETS}
   ${rcl_interfaces_TARGETS}
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6210 |
| Primary OS tested on | Ubuntu 26.02 |
| Robotic platform tested on | -|
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* add message validation for `map_msgs::msg::OccupancyGridUpdate`
* check `msg.width * msg.heigth` is equal to `msg.data.size()` to prevent OOB reads
* check `msg.x` and `msg.y` is not negative to prevent OOB reads
* check field `x`, `y`, `width`, `heigth` is smaller or equal than `INT16_MAX` to prevent integer overflow on addition (e.g. `update->x + update->width`)
* check `msg.width * msg.heigth` is not overflowed
* if so, `return true`

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
* if publish `/map_updates` with
* negative `msg.x` or `msg.y`, returns `false`
* mismatched `msg.data.size()` with `msg.width * msg.height`, returns `false`
* values thas leads to any integer overflow (e.g. `msg.y = 1`, `msg.heigth = 4294967295`), returns `false`

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
* dose it need any test code?

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
