### PR TITLE
feat: add validation of subscribed footprint has a least one point

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -501,6 +501,12 @@ Costmap2DROS::getParameters()
 void
 Costmap2DROS::setRobotFootprint(const std::vector<geometry_msgs::msg::Point> & points)
 {
+  if (points.empty()) {
+    RCLCPP_ERROR(
+      get_logger(), "You try to set an empty footprint"
+      " this isn't allowed, a footprint must contain at least one point.");
+    return;
+  }
   unpadded_footprint_ = points;
   padded_footprint_ = points;
   padFootprint(padded_footprint_, footprint_padding_);

--- a/nav2_dwb_controller/dwb_critics/test/obstacle_footprint_test.cpp
+++ b/nav2_dwb_controller/dwb_critics/test/obstacle_footprint_test.cpp
@@ -56,6 +56,18 @@ public:
   }
 };
 
+class OpenCostmap2DROS : public nav2_costmap_2d::Costmap2DROS
+{
+public:
+  using nav2_costmap_2d::Costmap2DROS::Costmap2DROS;
+
+  void clearRobotFootprint()
+  {
+    unpadded_footprint_.clear();
+    padded_footprint_.clear();
+  }
+};
+
 // Rotate the given point for angle radians around the origin.
 geometry_msgs::msg::Point rotate_origin(geometry_msgs::msg::Point p, double angle)
 {
@@ -134,7 +146,7 @@ TEST(ObstacleFootprint, Prepare)
   std::string ns = "/ns";
   std::string costmap_name = "test_global_costmap";
   auto costmap_ros =
-    std::make_shared<nav2_costmap_2d::Costmap2DROS>(costmap_name, ns, false);
+    std::make_shared<OpenCostmap2DROS>(costmap_name, ns, false);
   costmap_ros->configure();
 
   std::string name = "name";
@@ -146,8 +158,7 @@ TEST(ObstacleFootprint, Prepare)
   nav_msgs::msg::Path global_plan;
 
   // no footprint set in the costmap. Prepare should return false;
-  std::vector<geometry_msgs::msg::Point> footprint;
-  costmap_ros->setRobotFootprint(footprint);
+  costmap_ros->clearRobotFootprint();
   ASSERT_FALSE(critic->prepare(pose, vel, goal, global_plan));
 
   costmap_ros->setRobotFootprint(getFootprint());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6212 |
| Primary OS tested on | Ubuntu 26.04 |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* same PR for `main` https://github.com/ros-navigation/navigation2/pull/6214
* add validation of subscribed `/footprint`(`std::vector<geometry_msgs::msg::Point>`) in `Costmap2DROS::setRobotFootprint()`
* if `points` is a empty vector, rejects current footprint change.
* this validation prevents invalid footprint configurations and the resulting memory corruption.
* also change the test code to check if `prepare()` returns `false` for empty footprint
* generate empty footprint by clearing current fooprint, not assign new. 
 
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
* creates `controller_server` node, and activates it
* publish `/footprint` with empty point vector
* finally, new footprint setting(`setRobotFootprint()`) is rejected, and print error log about it

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
* I think, at least three points is required for footprint setting.
* however, in this patch, I modify to only prevents memory corruption caused by empty footprint without any sementic changes.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
