### PR TITLE
[nav2_costmap_2d] Added `custom_inscribed_radius` param to overwrite inscribed radius

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -215,7 +215,7 @@ protected:
    */
   void updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters);
 
-  double inflation_radius_, inscribed_radius_, cost_scaling_factor_;
+  double inflation_radius_, inscribed_radius_, custom_inscribed_radius_, cost_scaling_factor_;
   bool inflate_unknown_, inflate_around_unknown_;
   unsigned int cell_inflation_radius_;
   int num_threads_;  // Number of OpenMP threads (-1 = auto)

--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -215,6 +215,12 @@ protected:
    */
   void updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters);
 
+  /**
+   * @brief Update inscribed_radius_ from custom_inscribed_radius_ or the footprint,
+   * logging a warning when the custom value is in use.
+   */
+  void updateInscribedRadius();
+
   double inflation_radius_, inscribed_radius_, custom_inscribed_radius_, cost_scaling_factor_;
   bool inflate_unknown_, inflate_around_unknown_;
   unsigned int cell_inflation_radius_;

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -44,6 +44,7 @@ namespace nav2_costmap_2d
 InflationLayer::InflationLayer()
 : inflation_radius_(0),
   inscribed_radius_(0),
+  custom_inscribed_radius_(-1.0),
   cost_scaling_factor_(0),
   inflate_unknown_(false),
   inflate_around_unknown_(false),
@@ -73,6 +74,8 @@ InflationLayer::onInitialize()
     }
     enabled_ = node->declare_or_get_parameter(name_ + "." + "enabled", true);
     inflation_radius_ = node->declare_or_get_parameter(name_ + "." + "inflation_radius", 0.55);
+    custom_inscribed_radius_ = node->declare_or_get_parameter(
+      name_ + "." + "custom_inscribed_radius", -1.0);
     cost_scaling_factor_ = node->declare_or_get_parameter(
       name_ + "." + "cost_scaling_factor", 10.0);
     inflate_unknown_ = node->declare_or_get_parameter(name_ + "." + "inflate_unknown", false);
@@ -81,7 +84,8 @@ InflationLayer::onInitialize()
     num_threads_ = node->declare_or_get_parameter(
       name_ + "." + "num_threads", -1);
   }
-
+  inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
+    custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
   setCurrent(true);
   need_reinflation_ = false;
   matchSize();
@@ -190,16 +194,17 @@ void
 InflationLayer::onFootprintChanged()
 {
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
-  inscribed_radius_ = layered_costmap_->getInscribedRadius();
+  inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
+    custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
   need_reinflation_ = true;
 
   if (inflation_radius_ < inscribed_radius_) {
-    RCLCPP_ERROR(
+    RCLCPP_WARN(
       logger_,
       "The configured inflation radius (%.3f) is smaller than "
-      "the computed inscribed radius (%.3f) of your footprint, "
+      "the computed/custom inscribed radius (%.3f) of your footprint, "
       "it is highly recommended to set inflation radius to be at "
       "least as big as the inscribed radius to avoid collisions",
       inflation_radius_, inscribed_radius_);
@@ -356,7 +361,9 @@ rcl_interfaces::msg::SetParametersResult InflationLayer::validateParameterUpdate
       continue;
     }
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      if (parameter.as_double() < 0.0) {
+      if (param_name != name_ + "." + "custom_inscribed_radius" &&
+        parameter.as_double() < 0.0)
+      {
         RCLCPP_WARN(
         logger_, "The value of parameter '%s' is incorrectly set to %f, "
         "it should be >=0. Ignoring parameter update.",
@@ -391,6 +398,14 @@ InflationLayer::updateParametersCallback(
         need_reinflation_ = true;
         need_cache_recompute = true;
         setCurrent(false);
+      } else if (param_name == name_ + "." + "custom_inscribed_radius" && // NOLINT
+        custom_inscribed_radius_ != parameter.as_double())
+      {
+        custom_inscribed_radius_ = parameter.as_double();
+        inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
+          custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
+        need_reinflation_ = true;
+        need_cache_recompute = true;
       } else if (param_name == name_ + "." + "cost_scaling_factor" && // NOLINT
         getCostScalingFactor() != parameter.as_double())
       {

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -65,6 +65,25 @@ InflationLayer::~InflationLayer()
 }
 
 void
+InflationLayer::updateInscribedRadius()
+{
+  if (custom_inscribed_radius_ >= 0.0) {
+    RCLCPP_WARN(
+      logger_,
+      "POTENTIAL SAFETY ISSUE!!! Make sure you fully understand the consequences of changing the "
+      "inscribed radius! Inflation layer is set to use a custom inscribed radius of %.3f m instead "
+      "of the footprint's inscribed radius of %.3f m. This can have serious implications on the "
+      "robot's safety and is not recommended unless specifically needed. This practice is intended "
+      "only for controllers that are customized explicitly to feed on such data. It is NOT "
+      "intended for global path planners or setups that depend on the footprint inscribed radius!",
+      custom_inscribed_radius_, layered_costmap_->getInscribedRadius());
+    inscribed_radius_ = custom_inscribed_radius_;
+  } else {
+    inscribed_radius_ = layered_costmap_->getInscribedRadius();
+  }
+}
+
+void
 InflationLayer::onInitialize()
 {
   {
@@ -84,8 +103,7 @@ InflationLayer::onInitialize()
     num_threads_ = node->declare_or_get_parameter(
       name_ + "." + "num_threads", -1);
   }
-  inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
-    custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
+  updateInscribedRadius();
   setCurrent(true);
   need_reinflation_ = false;
   matchSize();
@@ -194,8 +212,7 @@ void
 InflationLayer::onFootprintChanged()
 {
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
-  inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
-    custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
+  updateInscribedRadius();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
   need_reinflation_ = true;
@@ -402,8 +419,7 @@ InflationLayer::updateParametersCallback(
         custom_inscribed_radius_ != parameter.as_double())
       {
         custom_inscribed_radius_ = parameter.as_double();
-        inscribed_radius_ = custom_inscribed_radius_ >= 0.0 ?
-          custom_inscribed_radius_ : layered_costmap_->getInscribedRadius();
+        updateInscribedRadius();
         need_reinflation_ = true;
         need_cache_recompute = true;
       } else if (param_name == name_ + "." + "cost_scaling_factor" && // NOLINT

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -795,9 +795,98 @@ TEST_F(TestNode, testDynParamsSet)
 
   EXPECT_EQ(costmap->get_parameter("inflation_layer.inflation_radius").as_double(), 0.0);
 
+  auto result_custom_inscribed_radius = parameter_client->set_parameters_atomically(
+  {
+    rclcpp::Parameter("inflation_layer.custom_inscribed_radius", 0.3)
+  });
+  rclcpp::spin_until_future_complete(
+    costmap->get_node_base_interface(),
+    result_custom_inscribed_radius);
+  EXPECT_TRUE(result_custom_inscribed_radius.get().successful);
+  EXPECT_EQ(
+    costmap->get_parameter("inflation_layer.custom_inscribed_radius").as_double(), 0.3);
+
+  // Setting custom_inscribed_radius to -1.0 should be accepted
+  auto result_custom_inscribed_radius_neg = parameter_client->set_parameters_atomically(
+  {
+    rclcpp::Parameter("inflation_layer.custom_inscribed_radius", -1.0)
+  });
+  rclcpp::spin_until_future_complete(
+    costmap->get_node_base_interface(),
+    result_custom_inscribed_radius_neg);
+  EXPECT_TRUE(result_custom_inscribed_radius_neg.get().successful);
+  EXPECT_EQ(
+    costmap->get_parameter("inflation_layer.custom_inscribed_radius").as_double(), -1.0);
+
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
+}
+
+/**
+ * Test that custom_inscribed_radius overrides the footprint-derived inscribed radius,
+ * and that resetting it to -1.0 restores the footprint-derived behavior.
+ *
+ * A footprint with inscribed_radius=5.0 is used. With custom_inscribed_radius=2.0,
+ * cells at distance 3-5 should NOT be INSCRIBED_INFLATED_OBSTACLE. After resetting
+ * custom_inscribed_radius to -1.0, the footprint radius takes effect again and those
+ * cells should become INSCRIBED_INFLATED_OBSTACLE.
+ */
+TEST_F(TestNode, testCustomInscribedRadius)
+{
+  std::vector<rclcpp::Parameter> parameters;
+  parameters.push_back(rclcpp::Parameter("inflation.cost_scaling_factor", 1.0));
+  parameters.push_back(rclcpp::Parameter("inflation.inflation_radius", 10.5));
+  parameters.push_back(rclcpp::Parameter("inflation.custom_inscribed_radius", 2.0));
+  initNode(parameters);
+
+  tf2_ros::Buffer tf(node_->get_clock());
+  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  layers.resizeMap(100, 100, 1, 0, 0);
+
+  // Footprint with inscribed_radius = 5.0; without the custom param this would
+  // mark cells up to 5 cells away as INSCRIBED_INFLATED_OBSTACLE.
+  std::vector<Point> polygon = setRadii(layers, 5.0, 6.25);
+
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
+  addObstacleLayer(layers, tf, node_, olayer);
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> ilayer = nullptr;
+  addInflationLayer(layers, tf, node_, ilayer);
+  layers.setFootprint(polygon);
+
+  addObservation(olayer, 50, 50, MAX_Z);
+  layers.updateMap(0, 0, 0);
+  nav2_costmap_2d::Costmap2D * map = layers.getCostmap();
+
+  // Cells within 2 cells should be INSCRIBED_INFLATED_OBSTACLE
+  for (int i = 1; i <= 2; i++) {
+    EXPECT_EQ(map->getCost(50 + i, 50), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
+      << "Cell at distance " << i << " should be INSCRIBED_INFLATED_OBSTACLE";
+  }
+
+  // Cells between 3 and 5 cells away should have intermediate cost, NOT INSCRIBED,
+  // because custom_inscribed_radius=2.0 overrides the footprint's inscribed_radius=5.0
+  for (int i = 3; i <= 5; i++) {
+    EXPECT_LT(map->getCost(50 + i, 50), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
+      << "Cell at distance " << i << " should NOT be INSCRIBED_INFLATED_OBSTACLE "
+      "(custom_inscribed_radius=2.0 < footprint inscribed_radius=5.0)";
+    EXPECT_GT(map->getCost(50 + i, 50), nav2_costmap_2d::FREE_SPACE)
+      << "Cell at distance " << i << " should still have inflated cost";
+  }
+
+  // Set custom_inscribed_radius to -1.0 to restore the footprint-derived inscribed_radius=5.0.
+  ilayer->activate();
+  node_->set_parameter(rclcpp::Parameter("inflation.custom_inscribed_radius", -1.0));
+  layers.updateMap(0, 0, 0);
+
+  // All cells within 5 cells should now be INSCRIBED_INFLATED_OBSTACLE
+  for (int i = 1; i <= 5; i++) {
+    EXPECT_EQ(map->getCost(50 + i, 50), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
+      << "After reset to -1.0, cell at distance " << i
+      << " should be INSCRIBED_INFLATED_OBSTACLE";
+  }
+
+  ilayer->deactivate();
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Hi,

When someone wants to check for the footprint collision they would use the [`footprintCost`](https://github.com/ros-navigation/navigation2/blob/main/nav2_costmap_2d/src/footprint_collision_checker.cpp#L48C45-L48C58) which basically returns the highest cost along the footprint lines. Ofcourse this seems like a logical operation. But the problem starts with what information we use for this cost calculation.

If we consider an inflated costmap, then we are comparing the footprint to a costmap which mainly includes three regions:

- Lethal
- Inscribed inflated
- an exponential decay region 

<img width="1045" height="562" alt="image" src="https://github.com/user-attachments/assets/edd9762e-acc6-4b52-bf22-b30f7804b301" />

Now the problem is that, no matter the overlap between the footprint and inscribed inflated region, we always get the same cost value. So a controller gets the same footprint cost for either slightly going over the inscribed inflated region or being almost completely in it (yet not hitting the lethal region). In both these situations we get a footprint cost of `253.0`:

<img width="731" height="558" alt="image" src="https://github.com/user-attachments/assets/fd60d3ae-e9a9-42ea-a742-970182b5d29b" />

<img width="731" height="558" alt="image" src="https://github.com/user-attachments/assets/0b4c5b73-b93b-4315-8eaa-2ba5306b20c1" />


Inscribed radius is important when comparing `base_link` distance to the lethal region, but it does not give enough information when trying to calculate the footprint cost. Let's say that my robot should avoid a lethal obstacle. Of course the baselink should not enter the inscribed inflated region, but still it may be allowed to get close to it. In other words, the way footprint cost is currently calculated, does not give any gradiant for footprint cost values overlapping with the inscribed inflated region. This problem becomes more highlighted if we are dealing with larger robots. Then we have a large inscribed inflated region that we treat the same way regardless.

A workaround here would be to be able to manipulate this inscribed region manually. So I have introduced a parameter here called `custom_inscribed_radius`. When negative (default value, allowing backward compatibility), costmap uses the calculated inscribed radius based on the robot footprint. But when changed to a value bigger than or equal to zero, then it sets the inscribed radius manually. This way, for instance, I can set it to `0.0`, and have a cost gradiant starting from after my lethal zone which would give footprint cost calculation more resolution. And hence, my controller can make a smarter decision than treating a whole inscribed inflated region the same way. Here you can see `custom_inscribed_radius` being set to `0.0`.

<img width="1045" height="562" alt="image" src="https://github.com/user-attachments/assets/223b78cd-580f-4b07-9dee-dccd54db6ff1" />


Or `0.5`:

<img width="1045" height="562" alt="image" src="https://github.com/user-attachments/assets/a39c4442-2826-4709-bd32-71b65da6b56a" />


This was a problem that my friend @Rayman and I had been dealing with already for a while with different controllers and we thought let's do something about it.

By the way, I know that it requires also adding the parameter description to the docs as well as extending the tests. Upon confirmation of the solution proposed here, I will extend them accordingly. But first want to know if this is fine.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
