### PR TITLE
nav2_behavior_tree: use portable Tree::sleep() in LoopRate

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/utils/loop_rate.hpp
@@ -61,15 +61,22 @@ public:
       return false;
     }
     // Sleep until the target time, preemptible by emitWakeUpSignal().
-    auto wake_up = tree_->wakeUpSignal();
+    // Tree::sleep() blocks on the tree's WakeUpSignal and returns true if the
+    // signal was received (i.e. the sleep was interrupted) rather than timing
+    // out. It is the portable interruptible-sleep entry point: the
+    // tree_->wakeUpSignal() accessor is not part of the public API in
+    // BehaviorTree.CPP 4.8/4.9, whereas Tree::sleep() is available across 4.x.
     const bool is_sim_time =
       clock_->get_clock_type() == RCL_ROS_TIME &&
       clock_->ros_time_is_active();
     if (is_sim_time) {
       // Sim time diverges from wall time — poll the target clock in short
       // intervals while remaining interruptible by emitWakeUpSignal().
+      // Tree::sleep() truncates its timeout to whole milliseconds, so poll at
+      // 1ms granularity: a sub-millisecond value would round to zero and busy
+      // spin.
       while (clock_->now() < next_interval) {
-        if (wake_up->waitFor(std::chrono::microseconds(500))) {
+        if (tree_->sleep(std::chrono::milliseconds(1))) {
           return true;  // preempted
         }
       }
@@ -77,7 +84,7 @@ public:
       // Steady/system clock agrees with wall time — sleep for the exact
       // remaining duration, still interruptible by emitWakeUpSignal().
       auto remaining = next_interval - clock_->now();
-      wake_up->waitFor(
+      tree_->sleep(
         std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::nanoseconds(remaining.nanoseconds())));
     }

--- a/nav2_behavior_tree/test/test_loop_rate.cpp
+++ b/nav2_behavior_tree/test/test_loop_rate.cpp
@@ -293,3 +293,35 @@ TEST_F(LoopRateTest, test_consecutive_sleeps_maintain_cadence_sim_time)
   // Wall time should be much less than 250ms (running at ~10x)
   EXPECT_LE(wall_elapsed, 100ms);
 }
+
+// Verify that emitWakeUpSignal() preempts an in-progress sleep() in sim time
+TEST_F(LoopRateTest, test_wake_up_signal_preempts_sleep_sim_time)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto * rcl_clock = clock->get_clock_handle();
+  ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(rcl_clock));
+
+  // Freeze sim time so the poll loop never reaches its deadline; the only way
+  // sleep() can return is via wake-up preemption.
+  const rcl_time_point_value_t t0 = RCL_S_TO_NS(1);
+  ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(rcl_clock, t0));
+
+  const auto period = 100ms;
+  nav2_behavior_tree::LoopRate rate(period, tree_.get(), clock);
+
+  // Fire the wake-up signal after a short wall delay
+  std::thread waker([this]() {
+      std::this_thread::sleep_for(10ms);
+      tree_->rootNode()->emitWakeUpSignal();
+    });
+
+  auto before = std::chrono::steady_clock::now();
+  bool result = rate.sleep();
+  auto elapsed = std::chrono::steady_clock::now() - before;
+
+  waker.join();
+
+  // Should have been preempted and returned early (well under the 100ms period)
+  EXPECT_TRUE(result);
+  EXPECT_LE(elapsed, 50ms);
+}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | n/a (build break against BT.CPP 4.8/4.9) |
| Primary OS tested on | Ubuntu 26 |
| Robotic platform tested on | gazebo sim jetty and lyrical robotics platform |
| Does this PR contain AI generated software? | Yes (the code change and test were AI-assisted) |
| Was this PR description generated by AI software? | No |

---

## Description of contribution 

* LoopRate::sleep() performs its interruptible sleep through tree_->wakeUpSignal() (added in https://github.com/ros-navigation/navigation2/pull/6063). However, the wakeUpSignal() accessor is not part of the public BT::Tree API in BehaviorTree.CPP. On 4.8.x / 4.9.x, wake_up_ is private with no public getter. This change was needed to get building on lyrical based on the ros-lyrical-behaviortree-cpp package.
* Fix: LoopRate's sleep is routed through the public BT::Tree::sleep(), same as the WakeUpSignal-backed sleep and is public across all 4.x versions. Additionally, changed the 500µs to 1ms poll detail and added sim-time pre-emption test.

## Description of documentation updates required from your changes

* N/A

## Description of how this change was tested

* Tested on lyrical ros2 workspace in gazebo sim and live nav2 operation

---

## Future work that may be required in bullet points

* None anticipated.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
