### PR TITLE
MPPI: Reduce computation time, add OpenMP support to CostCritic

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -22,7 +22,13 @@ find_package(visualization_msgs REQUIRED)
 find_package(nav2_ros_common REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-find_package(OpenMP REQUIRED)
+option(ENABLE_OPENMP "Enable OpenMP parallelization" OFF)
+if(ENABLE_OPENMP)
+  find_package(OpenMP REQUIRED)
+  message(STATUS "OpenMP ENABLED for nav2_mppi_controller (${OpenMP_CXX_VERSION})")
+else()
+  message(STATUS "OpenMP DISABLED for nav2_mppi_controller")
+endif()
 
 include_directories(
   include
@@ -134,8 +140,12 @@ target_link_libraries(mppi_critics PUBLIC
 )
 target_link_libraries(mppi_critics PRIVATE
   pluginlib::pluginlib
-  OpenMP::OpenMP_CXX
 )
+if(ENABLE_OPENMP)
+  target_link_libraries(mppi_critics PRIVATE OpenMP::OpenMP_CXX)
+else()
+  target_compile_options(mppi_critics PRIVATE -Wno-unknown-pragmas)
+endif()
 
 add_library(mppi_trajectory_validators SHARED
   src/trajectory_validators/optimal_trajectory_validator.cpp

--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(visualization_msgs REQUIRED)
 find_package(nav2_ros_common REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+find_package(OpenMP REQUIRED)
+
 include_directories(
   include
   ${EIGEN3_INCLUDE_DIR}
@@ -69,6 +71,7 @@ target_link_libraries(mppi_controller PUBLIC
   tf2_geometry_msgs::tf2_geometry_msgs
   tf2_ros::tf2_ros
   ${visualization_msgs_TARGETS}
+  Eigen3::Eigen
 )
 
 target_link_libraries(mppi_controller PRIVATE
@@ -131,6 +134,7 @@ target_link_libraries(mppi_critics PUBLIC
 )
 target_link_libraries(mppi_critics PRIVATE
   pluginlib::pluginlib
+  OpenMP::OpenMP_CXX
 )
 
 add_library(mppi_trajectory_validators SHARED

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
@@ -56,7 +56,8 @@ protected:
     * @param theta theta of pose
     * @return bool if in collision
     */
-  inline bool inCollision(float cost, float x, float y, float theta)
+  inline bool inCollision(float cost, float x, float y, float theta,
+    const nav2_costmap_2d::Footprint & footprint)
   {
     // If consider_footprint_ check footprint score for collision
     float score_cost = cost;
@@ -65,7 +66,7 @@ protected:
     {
       score_cost = static_cast<float>(collision_checker_.footprintCostAtPose(
           static_cast<double>(x), static_cast<double>(y), static_cast<double>(theta),
-          costmap_ros_->getRobotFootprint()));
+          footprint));
     }
 
     switch (static_cast<unsigned char>(score_cost)) {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
@@ -58,7 +58,7 @@ protected:
     */
   inline bool inCollision(float cost, float x, float y, float theta)
   {
-    // If consider_footprint_ check footprint scort for collision
+    // If consider_footprint_ check footprint score for collision
     float score_cost = cost;
     if (consider_footprint_ &&
       (cost >= possible_collision_cost_ || possible_collision_cost_ < 1.0f))

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
@@ -59,6 +59,12 @@ protected:
   inline bool inCollision(float cost, float x, float y, float theta,
     const nav2_costmap_2d::Footprint & footprint)
   {
+    // if the center cost guarantees a collision, return before doing an expensive footprint check
+    if (cost == nav2_costmap_2d::LETHAL_OBSTACLE ||
+      cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
+      return true;
+    }
+
     // If consider_footprint_ check footprint score for collision
     float score_cost = cost;
     if (consider_footprint_ &&

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
@@ -18,6 +18,10 @@
 #include <memory>
 #include <string>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
 #include "nav2_costmap_2d/inflation_layer.hpp"
 
@@ -97,6 +101,15 @@ protected:
   inline float findCircumscribedCost(std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap);
 
   /**
+   * @brief Determine the number of threads to use for OpenMP parallelization.
+   *        If num_threads_ > 0, use that value directly.
+   *        If num_threads_ == -1 (auto), use half the available cores (memory-bound heuristic).
+   *        If OpenMP is disabled at build time, always returns 1.
+   * @return Number of threads to use
+   */
+  int getOptimalThreadCount();
+
+  /**
     * @brief An implementation of worldToMap fully using floats
     * @param wx Float world X coord
     * @param wy Float world Y coord
@@ -150,6 +163,7 @@ protected:
   float near_goal_distance_;
   std::string inflation_layer_name_;
 
+  int num_threads_{-1};
   unsigned int power_{0};
 };
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/cost_critic.hpp
@@ -60,12 +60,14 @@ protected:
     * @param theta theta of pose
     * @return bool if in collision
     */
-  inline bool inCollision(float cost, float x, float y, float theta,
+  inline bool inCollision(
+    float cost, float x, float y, float theta,
     const nav2_costmap_2d::Footprint & footprint)
   {
     // if the center cost guarantees a collision, return before doing an expensive footprint check
     if (cost == nav2_costmap_2d::LETHAL_OBSTACLE ||
-      cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
+      cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
+    {
       return true;
     }
 

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -222,7 +222,8 @@ void CostCritic::score(CriticData & data)
     float pose_cost = 0.0f;
     float & traj_cost = repulsive_cost(i);
 
-    // iterate over the trajectory backwards, as collisions are more likely towards the end of the trajectory
+    // iterate over the trajectory backwards, as collisions are more likely towards the end of
+    // the trajectory
     for (int j = strided_traj_cols - 1; j >=0; j--) {
       float Tx = traj_x(i, j);
       float Ty = traj_y(i, j);

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cmath>
 #include "nav2_mppi_controller/critics/cost_critic.hpp"
 #include "nav2_costmap_2d/inflation_layer_interface.hpp"
@@ -33,6 +34,7 @@ void CostCritic::initialize()
   getParam(collision_cost_, "collision_cost", 1000000.0f);
   getParam(near_goal_distance_, "near_goal_distance", 0.5f);
   getParam(inflation_layer_name_, "inflation_layer_name", std::string(""));
+  getParam(num_threads_, "num_threads", -1);
   getParam(trajectory_point_step_, "trajectory_point_step", 2);
 
   // Normalized by cost value to put in same regime as other weights
@@ -128,6 +130,32 @@ float CostCritic::findCircumscribedCost(
   return circumscribed_cost_;
 }
 
+int CostCritic::getOptimalThreadCount()
+{
+#ifdef _OPENMP
+  if (num_threads_ > 0) {
+    RCLCPP_INFO_ONCE(
+      logger_,
+      "OpenMP: Using configured num_threads: %d",
+      num_threads_);
+    return num_threads_;
+  }
+  // Auto (-1): use half of available cores — costmap lookups are memory-bound,
+  // so more threads hit diminishing returns and increase cache contention.
+  // omp_get_max_threads() respects OMP_NUM_THREADS if set.
+  const int cpu_cores = omp_get_max_threads();
+  const int optimal = std::max(1, cpu_cores / 2);
+  RCLCPP_INFO_ONCE(
+    logger_,
+    "OpenMP: %d cores available, using %d threads (auto)",
+    cpu_cores, optimal);
+
+  return std::max(1, optimal);
+#else
+  return 1;
+#endif
+}
+
 void CostCritic::score(CriticData & data)
 {
   if (!enabled_) {
@@ -180,13 +208,15 @@ void CostCritic::score(CriticData & data)
     data.trajectories.yaws.data(), strided_traj_rows, strided_traj_cols,
     Eigen::Stride<-1, -1>(outer_stride, 1));
 
-#pragma omp parallel for \
-  default(none) \
-  shared(repulsive_cost, costmap, near_goal, footprint, \
-    strided_traj_rows, strided_traj_cols, traj_x, traj_y, traj_yaw) \
-  reduction(&&:all_trajectories_collide) \
-  schedule(dynamic) \
-  num_threads(4)
+#ifdef _OPENMP
+  #pragma omp parallel for \
+    default(none) \
+    shared(repulsive_cost, costmap, near_goal, footprint, \
+      strided_traj_rows, strided_traj_cols, traj_x, traj_y, traj_yaw) \
+    reduction(&&:all_trajectories_collide) \
+    schedule(dynamic) \
+    num_threads(getOptimalThreadCount())
+#endif
   for (int i = 0; i < strided_traj_rows; ++i) {
     bool trajectory_collide = false;
     float pose_cost = 0.0f;

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -143,9 +143,11 @@ void CostCritic::score(CriticData & data)
   size_x_ = costmap->getSizeInCellsX();
   size_y_ = costmap->getSizeInCellsY();
 
+  nav2_costmap_2d::Footprint footprint;
   if (consider_footprint_) {
     // footprint may have changed since initialization if user has dynamic footprints
     possible_collision_cost_ = findCircumscribedCost(costmap_ros_);
+    footprint = costmap_ros_->getRobotFootprint();
   }
 
   // If near the goal, don't apply the preferential term since the goal is near obstacles
@@ -200,7 +202,7 @@ void CostCritic::score(CriticData & data)
         }
       }
 
-      if (inCollision(pose_cost, Tx, Ty, traj_yaw(i, j))) {
+      if (inCollision(pose_cost, Tx, Ty, traj_yaw(i, j), footprint)) {
         traj_cost = collision_cost_;
         trajectory_collide = true;
         if (track_collisions) {collisions[i] = true;}

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -210,12 +210,12 @@ void CostCritic::score(CriticData & data)
 
 #ifdef _OPENMP
   #pragma omp parallel for \
-    default(none) \
-    shared(repulsive_cost, costmap, near_goal, footprint, \
-      strided_traj_rows, strided_traj_cols, traj_x, traj_y, traj_yaw) \
-    reduction(&&:all_trajectories_collide) \
-    schedule(dynamic) \
-    num_threads(getOptimalThreadCount())
+  default(none) \
+  shared(repulsive_cost, costmap, near_goal, footprint, \
+  strided_traj_rows, strided_traj_cols, traj_x, traj_y, traj_yaw) \
+  reduction(&&:all_trajectories_collide) \
+  schedule(dynamic) \
+  num_threads(getOptimalThreadCount())
 #endif
   for (int i = 0; i < strided_traj_rows; ++i) {
     bool trajectory_collide = false;
@@ -224,7 +224,7 @@ void CostCritic::score(CriticData & data)
 
     // iterate over the trajectory backwards, as collisions are more likely towards the end of
     // the trajectory
-    for (int j = strided_traj_cols - 1; j >=0; j--) {
+    for (int j = strided_traj_cols - 1; j >= 0; j--) {
       float Tx = traj_x(i, j);
       float Ty = traj_y(i, j);
       unsigned int x_i = 0u, y_i = 0u;

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -185,7 +185,8 @@ void CostCritic::score(CriticData & data)
     float pose_cost = 0.0f;
     float & traj_cost = repulsive_cost(i);
 
-    for (int j = 0; j < strided_traj_cols; j++) {
+    // iterate over the trajectory backwards, as collisions are more likely towards the end of the trajectory
+    for (int j = strided_traj_cols - 1; j >=0; j--) {
       float Tx = traj_x(i, j);
       float Ty = traj_y(i, j);
       unsigned int x_i = 0u, y_i = 0u;

--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -180,6 +180,13 @@ void CostCritic::score(CriticData & data)
     data.trajectories.yaws.data(), strided_traj_rows, strided_traj_cols,
     Eigen::Stride<-1, -1>(outer_stride, 1));
 
+#pragma omp parallel for \
+  default(none) \
+  shared(repulsive_cost, costmap, near_goal, footprint, \
+    strided_traj_rows, strided_traj_cols, traj_x, traj_y, traj_yaw) \
+  reduction(&&:all_trajectories_collide) \
+  schedule(dynamic) \
+  num_threads(4)
   for (int i = 0; i < strided_traj_rows; ++i) {
     bool trajectory_collide = false;
     float pose_cost = 0.0f;

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -630,11 +630,11 @@ void Optimizer::updateControlSequence()
   softmaxes /= softmaxes.sum();
 
   auto softmax_mat = softmaxes.matrix();
-  control_sequence_.vx = state_.cvx.transpose().matrix() * softmax_mat;
-  control_sequence_.wz = state_.cwz.transpose().matrix() * softmax_mat;
+  control_sequence_.vx.matrix().noalias() = state_.cvx.transpose().matrix() * softmax_mat;
+  control_sequence_.wz.matrix().noalias() = state_.cwz.transpose().matrix() * softmax_mat;
 
   if (is_holo) {
-    control_sequence_.vy = state_.cvy.transpose().matrix() * softmax_mat;
+    control_sequence_.vy.matrix().noalias() = state_.cvy.transpose().matrix() * softmax_mat;
   }
 
   utils::savitskyGolayFilter(control_sequence_, control_history_, settings_);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -630,11 +630,11 @@ void Optimizer::updateControlSequence()
   softmaxes /= softmaxes.sum();
 
   auto softmax_mat = softmaxes.matrix();
-  control_sequence_.vx.matrix().noalias() = state_.cvx.transpose().matrix() * softmax_mat;
-  control_sequence_.wz.matrix().noalias() = state_.cwz.transpose().matrix() * softmax_mat;
+  control_sequence_.vx = state_.cvx.transpose().matrix() * softmax_mat;
+  control_sequence_.wz = state_.cwz.transpose().matrix() * softmax_mat;
 
   if (is_holo) {
-    control_sequence_.vy.matrix().noalias() = state_.cvy.transpose().matrix() * softmax_mat;
+    control_sequence_.vy = state_.cvy.transpose().matrix() * softmax_mat;
   }
 
   utils::savitskyGolayFilter(control_sequence_, control_history_, settings_);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -625,7 +625,8 @@ void Optimizer::updateControlSequence()
 
   auto costs_normalized = costs_ - costs_.minCoeff();
   const float inv_temp = 1.0f / s.temperature;
-  auto softmaxes = (-inv_temp * costs_normalized).exp().eval();
+  constexpr float kMaxExponent = 80.0f;
+  auto softmaxes = ((-inv_temp * costs_normalized).cwiseMax(-kMaxExponent)).exp().eval();
   softmaxes /= softmaxes.sum();
 
   auto softmax_mat = softmaxes.matrix();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazeno simulation, robots test |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Reduce computation time of MPPI & add OpenMP support to Cost critic.
Without this PR, on our robot, MPPI consistently cannot achieve 20Hz when driving near obstacles, which causes degraded performance.
The main culprit are the collision checks in `CostCritic`, which take a big percentage of the runtime, especially when driving near a long obstacles (such as a wall)

Cost critic:
- Check for collisions backwards, starting from the end of the trajectory, since collisions are more probable away from robot.
	- reduces by avg of 2ms & 5000 footprint checks (avg over 50m, ~ 2000 iterations)
- Check center cost before doing a collision check (minor improvement)
- Call costmap_ros_->getRobotFootprint()) once (minor improvement)
- Add OpenMP support for the collision checks
	- With 8 threads, reduces time by x4

Optimizer:
- Clamp exponential arguments: caps all exp() arguments at -80, where the value is already ~1e-35, slightly above float32's smallest fraction of ~1.2e-38. This eliminates potential underflows & slow paths in the exp implementation.
	- reduces computation by ~6x, from 2000-3000us to ~400us
- Add noalias call
	- very slight reduction in computation, but no harm to add

## Description of documentation updates required from your changes

- added a parameter `CostCritic.num_threads`
- explain building with OpenMP ?
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- Tested extensively on our robot, especially near walls
- Added timing prints to average times of different MPPI components over time

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
