### PR TITLE
[nav2_util] Fix jumping yaw of the lookahead point

### DIFF
--- a/nav2_util/src/controller_utils.cpp
+++ b/nav2_util/src/controller_utils.cpp
@@ -147,9 +147,9 @@ geometry_msgs::msg::PoseStamped getLookAheadPoint(
 
     // Calculate orientation towards interpolated position
     // Convert yaw to quaternion
-    double yaw = atan2(
-      point.y - prev_pose_it->pose.position.y,
-      point.x - prev_pose_it->pose.position.x);
+    const auto yaw = atan2(
+      goal_pose_it->pose.position.y - prev_pose_it->pose.position.y,
+      goal_pose_it->pose.position.x - prev_pose_it->pose.position.x);
 
     geometry_msgs::msg::PoseStamped pose;
     pose.header.frame_id = prev_pose_it->header.frame_id;


### PR DESCRIPTION
Hi,

If the lookahead point is found within the plan, its orientation is calculated using the interpolated point and the previous pose along on the plan. But the problem is that this operation can cause floating point error when the interpolated point is too close to the previous pose; resulting in yaw value jumps. This problem becomes more highlighted when the robot deviates from the plan:

[jumping_yaw.webm](https://github.com/user-attachments/assets/95c1dd08-760d-41e5-be5c-832b19e9a984)

A more stable approach would be to use the two poses of the plan instead of the interpolated point and the previous pose:


[no_jumps.webm](https://github.com/user-attachments/assets/82d4a24c-ffba-45d9-8bfd-1d7fd8b67750)

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
