### PR TITLE
fix: added validation for OccupancyGrid msgs for the map_saver_node

### DIFF
--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "nav2_map_server/map_io.hpp"
+#include "nav2_ros_common/validate_messages.hpp"
 
 #ifndef _WIN32
 #include <libgen.h>
@@ -636,6 +637,13 @@ bool saveMapToFile(
   const nav_msgs::msg::OccupancyGrid & map,
   const SaveParameters & save_parameters)
 {
+  if (!nav2::validateMsg(map)) {
+    RCLCPP_ERROR_STREAM(
+      rclcpp::get_logger("map_io"),
+      "Failed to write map for reason: invalid OccupancyGrid message");
+    return false;
+  }
+
   // Local copy of SaveParameters that might be modified by checkSaveParameters()
   SaveParameters save_parameters_loc = save_parameters;
 

--- a/nav2_map_server/test/component/test_map_saver_node.cpp
+++ b/nav2_map_server/test/component/test_map_saver_node.cpp
@@ -212,6 +212,34 @@ TEST_F(MapSaverTestFixture, SaveMapInvalidParameters)
   ASSERT_EQ(resp->result, false);
 }
 
+// Send map saving service request with malformed OccupancyGrid.
+// Verify the request fails and the map_saver node remains available.
+TEST_F(MapSaverTestFixture, SaveMalformedMap)
+{
+  RCLCPP_INFO(node_->get_logger(), "Testing SaveMap service with malformed map");
+  auto req = std::make_shared<nav2_msgs::srv::SaveMap::Request>();
+  auto client = node_->create_client<nav2_msgs::srv::SaveMap>(
+    "/map_saver/save_map");
+
+  RCLCPP_INFO(node_->get_logger(), "Waiting for save_map service");
+  ASSERT_TRUE(client->wait_for_service());
+
+  req->map_topic = "malformed_map";
+  req->map_url = path(g_tmp_dir) / path(g_valid_map_name);
+  req->image_format = "png";
+  req->map_mode = "trinary";
+  req->free_thresh = g_default_free_thresh;
+  req->occupied_thresh = g_default_occupied_thresh;
+  auto resp = send_request<nav2_msgs::srv::SaveMap>(node_, client, req);
+  ASSERT_NE(resp, nullptr);
+  ASSERT_EQ(resp->result, false);
+
+  req->map_topic = "map";
+  resp = send_request<nav2_msgs::srv::SaveMap>(node_, client, req);
+  ASSERT_NE(resp, nullptr);
+  ASSERT_EQ(resp->result, true);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_map_server/test/component/test_map_saver_publisher.cpp
+++ b/nav2_map_server/test/component/test_map_saver_publisher.cpp
@@ -44,10 +44,21 @@ public:
       "map",
       nav2::qos::LatchedPublisherQoS());
     map_pub_->publish(msg);
+
+    nav_msgs::msg::OccupancyGrid malformed_msg = msg;
+    malformed_msg.info.width = 2;
+    malformed_msg.info.height = 2;
+    malformed_msg.data.clear();
+
+    malformed_map_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
+      "malformed_map",
+      nav2::qos::LatchedPublisherQoS());
+    malformed_map_pub_->publish(malformed_msg);
   }
 
 protected:
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr malformed_map_pub_;
 };
 
 int main(int argc, char ** argv)

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -180,11 +180,6 @@ bool validateMsg(const nav_msgs::msg::OccupancyGrid & msg)
   // msg.data :  @todo any check for it ?
   if (!validateMsg(msg.info)) {return false;}
 
-  // check logic
-  if (msg.data.size() != msg.info.width * msg.info.height) {
-    return false;                                                          // check map-size
-  }
-
   if (msg.info.width > INT16_MAX || msg.info.height > INT16_MAX) {
     // avoid overflow in nav2_amcl::convertMap()
     // because map_t size_x and size_y are int
@@ -197,6 +192,10 @@ bool validateMsg(const nav_msgs::msg::OccupancyGrid & msg)
     return false;
   }
 
+  // check logic
+  if (msg.data.size() != static_cast<size_t>(num_cells)) {
+    return false;                                                          // check map-size
+  }
 
   return true;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6232 |
| Primary OS tested on | Ubuntu (ROS Rolling Docker) |
| Robotic platform tested on | Gazebo Simulation of Turtlebot and Colcon Tests |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* I added validation in map_io->saveMapToFile() to check for Malformed OccupancyGrids with missing data or incorrect map metadata (wrong width, and height) to prevent map_saver_node from crashing.
* Added Test case for the same. 

## Description of documentation updates required from your changes

None

## Description of how this change was tested

* I wrote unit tests for malformed map publishing
* I tested it in simulation and manual map publishing with empty data but valid width and height. Additionally also tested for large width and height (1e8x1e8) to ensure Overflow Handling.

---

## Future work that may be required in bullet points

None

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
