### PR TITLE
only reload BTs if any file changed, full clear BTs

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -132,6 +132,13 @@ public:
   void registerTreeFromFile(const std::string & file_path);
 
   /**
+   * @brief Clear all previously registered behavior trees from the factory's
+   * internal XML parser state.  This prevents the parser's opened_documents
+   * list from growing unboundedly when trees are re-registered (memory leak).
+   */
+  void clearRegisteredBehaviorTrees();
+
+  /**
    * @brief Function to explicitly reset all BT nodes to initial state
    * @param tree Tree to halt
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -132,9 +132,8 @@ public:
   void registerTreeFromFile(const std::string & file_path);
 
   /**
-   * @brief Clear all previously registered behavior trees from the factory's
-   * internal XML parser state.  This prevents the parser's opened_documents
-   * list from growing unboundedly when trees are re-registered (memory leak).
+   * @brief Clear all registered behavior trees
+   * This prevents the parser's list from growing unboundedly when trees are re-registered
    */
   void clearRegisteredBehaviorTrees();
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -16,9 +16,11 @@
 #define NAV2_BEHAVIOR_TREE__BT_ACTION_SERVER_HPP_
 
 #include <chrono>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -311,6 +313,9 @@ protected:
   std::string internal_error_msg_;
 
   std::atomic_bool muxer_preemption_requested_{false};
+  // File-modification cache: used by always_reload_bt_xml mode to skip
+  // a full tree rebuild when no XML file has been touched on disk.
+  std::unordered_map<std::string, std::filesystem::file_time_type> bt_xml_mtimes_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -313,8 +313,7 @@ protected:
   std::string internal_error_msg_;
 
   std::atomic_bool muxer_preemption_requested_{false};
-  // File-modification cache: used by always_reload_bt_xml mode to skip
-  // a full tree rebuild when no XML file has been touched on disk.
+  // File-modification times cache
   std::unordered_map<std::string, std::filesystem::file_time_type> bt_xml_mtimes_;
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -258,7 +258,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
   // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
-    bool any_changed = bt_xml_mtimes_.empty(); // no snapshot: force reload
+    bool any_changed = bt_xml_mtimes_.empty();  // no snapshot: force reload
     try {
       for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
         if (fs::last_write_time(path) != old_mtime) {
@@ -267,7 +267,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
         }
       }
     } catch (const std::filesystem::filesystem_error &) {
-      any_changed = true; // file vanished or became inaccessible: force reload
+      any_changed = true;  // file vanished or became inaccessible: force reload
     }
     if (!any_changed) {
       RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -431,16 +431,21 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // always_reload_bt_ can tell whether any XML actually changed.
   if (always_reload_bt_) {
     bt_xml_mtimes_.clear();
-    // Track the main file when it is specified as a path (not an ID)
-    if (!is_bt_id) {
-      bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
-    }
-    for (const auto & directory : search_directories_) {
-      for (const auto & entry : fs::directory_iterator(directory)) {
-        if (entry.path().extension() == ".xml") {
-          bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+    try {
+      if (!is_bt_id && fs::exists(file_or_id)) {
+        bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
+      }
+      for (const auto & directory : search_directories_) {
+        if (fs::exists(directory) && fs::is_directory(directory)) {
+          for (const auto & entry : fs::directory_iterator(directory)) {
+            if (entry.path().extension() == ".xml") {
+              bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+            }
+          }
         }
       }
+    } catch (const std::filesystem::filesystem_error & e) {
+      RCLCPP_WARN(logger_, "Failed to snapshot BT XML mtimes: %s", e.what());
     }
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -253,11 +253,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     return true;
   }
 
-  // When always_reload_bt_ is true and the same BT is requested, only perform
-  // the expensive full reload if at least one XML file on disk actually changed.
-  // Recreating the behaviour-tree (and its ROS action-client / pub-sub
-  // resources) on every goal otherwise causes unbounded memory growth in both
-  // the BT factory's internal XML parser and the ROS / DDS middleware layer.
+  // When always_reload_bt_ is true and the same BT is requested, only perform the full reload if at
+  // least one XML file on disk actually changed. Recreating the behaviour-tree (and its ROS
+  // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
+  // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
     bool any_changed = false;
     try {
@@ -277,10 +276,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     RCLCPP_INFO(logger_, "BT XML file(s) modified on disk, reloading tree");
   }
 
-  // When reloading an already-loaded BT, clean up all resources before
-  // re-registering.  The BT factory's internal XML parser appends a new
-  // XMLDocument on each registerBehaviorTreeFromFile() call; clearing the
-  // parser state here keeps that list bounded and prevents a secondary leak.
+  // When reloading an already-loaded BT, clean up all resources before re-registering.
+  // The BT factory's internal XML parser appends a new XMLDocument on each
+  // registerBehaviorTreeFromFile() call, clearing the parser state here keeps that list bounded
+  // and prevents a secondary leak.
   if (!current_bt_file_or_id_.empty()) {
     topic_logger_.reset();
     bt_->haltAllActions(tree_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -254,9 +254,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   }
 
   // When always_reload_bt_ is true and the same BT is requested, only perform the full reload if at
-  // least one XML file on disk actually changed. Recreating the behaviour-tree (and its ROS
-  // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
-  // internal XML parser and the ROS / DDS middleware layer.
+  // least one XML file on disk actually changed
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
     bool any_changed = bt_xml_mtimes_.empty();  // no snapshot: force reload
     try {
@@ -277,9 +275,6 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   }
 
   // When reloading an already-loaded BT, clean up all resources before re-registering.
-  // The BT factory's internal XML parser appends a new XMLDocument on each
-  // registerBehaviorTreeFromFile() call, clearing the parser state here keeps that list bounded
-  // and prevents a secondary leak.
   if (!current_bt_file_or_id_.empty()) {
     topic_logger_.reset();
     bt_->haltAllActions(tree_);
@@ -427,8 +422,6 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
       action_name_.c_str(), groot_server_port_);
   }
 
-  // Snapshot file modification times so that the next call with
-  // always_reload_bt_ can tell whether any XML actually changed.
   if (always_reload_bt_) {
     bt_xml_mtimes_.clear();
     try {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -253,6 +253,41 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     return true;
   }
 
+  // When always_reload_bt_ is true and the same BT is requested, only perform
+  // the expensive full reload if at least one XML file on disk actually changed.
+  // Recreating the behaviour-tree (and its ROS action-client / pub-sub
+  // resources) on every goal otherwise causes unbounded memory growth in both
+  // the BT factory's internal XML parser and the ROS / DDS middleware layer.
+  if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
+    bool any_changed = false;
+    try {
+      for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
+        if (fs::last_write_time(path) != old_mtime) {
+          any_changed = true;
+          break;
+        }
+      }
+    } catch (const std::filesystem::filesystem_error &) {
+      any_changed = true;  // file vanished or became inaccessible; force reload
+    }
+    if (!any_changed) {
+      RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");
+      return true;
+    }
+    RCLCPP_INFO(logger_, "BT XML file(s) modified on disk, reloading tree");
+  }
+
+  // When reloading an already-loaded BT, clean up all resources before
+  // re-registering.  The BT factory's internal XML parser appends a new
+  // XMLDocument on each registerBehaviorTreeFromFile() call; clearing the
+  // parser state here keeps that list bounded and prevents a secondary leak.
+  if (!current_bt_file_or_id_.empty()) {
+    topic_logger_.reset();
+    bt_->haltAllActions(tree_);
+    tree_ = BT::Tree{};
+    bt_->clearRegisteredBehaviorTrees();
+  }
+
   // Reset any existing Groot2 monitoring
   bt_->resetGrootMonitor();
 
@@ -391,6 +426,23 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     RCLCPP_DEBUG(
       logger_, "Enabling Groot2 monitoring for %s: %d",
       action_name_.c_str(), groot_server_port_);
+  }
+
+  // Snapshot file modification times so that the next call with
+  // always_reload_bt_ can tell whether any XML actually changed.
+  if (always_reload_bt_) {
+    bt_xml_mtimes_.clear();
+    // Track the main file when it is specified as a path (not an ID)
+    if (!is_bt_id) {
+      bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
+    }
+    for (const auto & directory : search_directories_) {
+      for (const auto & entry : fs::directory_iterator(directory)) {
+        if (entry.path().extension() == ".xml") {
+          bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+        }
+      }
+    }
   }
 
   return true;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -258,7 +258,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
   // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
-    bool any_changed = false;
+    bool any_changed = bt_xml_mtimes_.empty(); // no snapshot: force reload
     try {
       for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
         if (fs::last_write_time(path) != old_mtime) {
@@ -267,7 +267,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
         }
       }
     } catch (const std::filesystem::filesystem_error &) {
-      any_changed = true;  // file vanished or became inaccessible; force reload
+      any_changed = true; // file vanished or became inaccessible: force reload
     }
     if (!any_changed) {
       RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -186,6 +186,11 @@ void BehaviorTreeEngine::registerTreeFromFile(
   factory_.registerBehaviorTreeFromFile(file_path);
 }
 
+void BehaviorTreeEngine::clearRegisteredBehaviorTrees()
+{
+  factory_.clearRegisteredBehaviorTrees();
+}
+
 void
 BehaviorTreeEngine::addGrootMonitoring(
   BT::Tree * tree,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo sim & robot |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Fix a memory leak when `always_reload_bt_xml` is `true`

1. When `always_reload_bt_` is true and the same BT is requested, only perform the full reload if at least one XML file on disk actually changed.
2. When reloading an already-loaded BT, clean up all resources before re-registering. 
These changes do not fully fix the memory increase, but they greatly reduce it. Reloading is only done now if a file was changed during a run, which should only happen by developers and (theoretically) not hundreds of times.
It is still recommended to keep always_reload_bt_xml set to false unless otherwise needed.

These changes do not fully fix the memory increase, but they greatly reduce it. Reloading is only done now if a file was changed during a run, which should only happen by developers and  not on every goal request

Full disclosure: This PR includes AI code. However, I fully reviewed, tested and deployed it to our robot.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes
None

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

- I wrote a script that keeps sending and canceling goals every few seconds.
- Without the fix: memory usage increases quickly and nav2 either crashes or freezes.
- With the fix: memory usage increases but slowly, no issue or slowdown after 1000 goals.

Note: Just to be clear, this issue happened on our robot naturally when running for a few hours. The script is just a way to force it. After the fix was deployed in April, we never had the issue anymore.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
