### PR TITLE
Declare nav2_controller costmap dependency

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -3,6 +3,7 @@ project(nav2_controller)
 
 find_package(ament_cmake REQUIRED)
 find_package(nav2_core REQUIRED)
+find_package(nav2_costmap_2d REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(angles REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -44,6 +45,7 @@ set(dependencies
   nav_2d_msgs
   nav2_util
   nav2_core
+  nav2_costmap_2d
   pluginlib
 )
 

--- a/nav2_controller/package.xml
+++ b/nav2_controller/package.xml
@@ -18,6 +18,7 @@
   <depend>nav_2d_utils</depend>
   <depend>nav_2d_msgs</depend>
   <depend>nav2_core</depend>
+  <depend>nav2_costmap_2d</depend>
   <depend>pluginlib</depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- add `nav2_costmap_2d` to `nav2_controller`'s CMake dependencies on `humble`
- add the matching `package.xml` dependency declaration
- avoid relying on `nav2_core` to provide a direct dependency transitively

Fixes #6239

## Testing
- `git diff --check`
- parsed `nav2_controller/package.xml` with PowerShell XML support and confirmed exactly one `nav2_costmap_2d` dependency
- confirmed the new CMake and package declarations with `rg`
- Not run: ROS 2 workspace build, because this Windows host does not have `colcon` or `rosdep` available.