### PR TITLE
Fix Zenoh test failures caused by late cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,7 +528,7 @@ _jobs:
         type: boolean
         default: false
       rmw:
-        default: "rmw_cyclonedds_cpp"
+        default: "rmw_zenoh_cpp"
         type: string
     parallelism: 1
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,7 +528,7 @@ _jobs:
         type: boolean
         default: false
       rmw:
-        default: "rmw_zenoh_cpp"
+        default: "rmw_cyclonedds_cpp"
         type: string
     parallelism: 1
     environment:

--- a/nav2_behavior_tree/test/plugins/action/test_check_pose_occupancy_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_check_pose_occupancy_action.cpp
@@ -197,24 +197,30 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   // initialize service and spin on new thread
-  CheckPoseOccupancyTestFixture::success_server_ =
-    std::make_shared<CheckPoseOccupancySuccessService>();
-  std::thread success_server_thread([]() {
-      rclcpp::spin(CheckPoseOccupancyTestFixture::success_server_);
-    });
+  auto success_server = std::make_shared<CheckPoseOccupancySuccessService>();
+  CheckPoseOccupancyTestFixture::success_server_ = success_server;
 
-  CheckPoseOccupancyTestFixture::failure_server_ =
-    std::make_shared<CheckPoseOccupancyFailureService>();
-  std::thread failure_server_thread([]() {
-      rclcpp::spin(CheckPoseOccupancyTestFixture::failure_server_);
+  auto failure_server = std::make_shared<CheckPoseOccupancyFailureService>();
+  CheckPoseOccupancyTestFixture::failure_server_ = failure_server;
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(success_server);
+  executor.add_node(failure_server);
+  std::thread server_thread([&executor]() {
+      executor.spin();
     });
 
   int all_successful = RUN_ALL_TESTS();
 
+  executor.cancel();
+  server_thread.join();
+  executor.remove_node(success_server);
+  executor.remove_node(failure_server);
+  success_server.reset();
+  failure_server.reset();
+
   // shutdown ROS
   rclcpp::shutdown();
-  success_server_thread.join();
-  failure_server_thread.join();
 
   return all_successful;
 }

--- a/nav2_behavior_tree/test/plugins/control/test_pause_resume_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_pause_resume_controller.cpp
@@ -42,6 +42,7 @@ public:
     tree_.reset();
     pause_client_.reset();
     resume_client_.reset();
+    nav2_behavior_tree::BehaviorTreeTestFixture::TearDownTestCase();
   }
 
   static void CheckServiceResult(

--- a/nav2_costmap_2d/test/unit/obstacle_layer_test.cpp
+++ b/nav2_costmap_2d/test/unit/obstacle_layer_test.cpp
@@ -25,14 +25,6 @@
 #include "tf2_ros/buffer.hpp"
 
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestLifecycleNode : public nav2::LifecycleNode
 {
 public:
@@ -392,4 +384,13 @@ TEST_F(ObstacleLayerTest, testClearDiagonalDistance) {
   ASSERT_EQ(countValues(*obstacle_layer_, nav2_costmap_2d::FREE_SPACE), 8);
   ASSERT_EQ(countValues(*obstacle_layer_, nav2_costmap_2d::LETHAL_OBSTACLE),
             20 * 20 - 8);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_following/opennav_following/test/test_following_server_unit.cpp
+++ b/nav2_following/opennav_following/test/test_following_server_unit.cpp
@@ -28,14 +28,6 @@
 
 using namespace std::chrono_literals;  // NOLINT
 
-class RosLockGuard
-{
-public:
-  RosLockGuard() {rclcpp::init(0, nullptr);}
-  ~RosLockGuard() {rclcpp::shutdown();}
-};
-RosLockGuard g_rclcpp;
-
 namespace opennav_following
 {
 
@@ -390,3 +382,12 @@ TEST(FollowingServerTests, DynamicParams)
 }
 
 }  // namespace opennav_following
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/nav2_loopback_sim/test/test_clock_publisher.cpp
+++ b/nav2_loopback_sim/test/test_clock_publisher.cpp
@@ -24,14 +24,6 @@
 
 using namespace std::chrono_literals;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class ClockPublisherTest : public ::testing::Test
 {
 protected:
@@ -191,4 +183,13 @@ TEST_F(ClockPublisherTest, SpeedFactorAffectsRate)
   // With 0.5x, sim time should be roughly half of wall time
   EXPECT_GT(ratio, 0.45);
   EXPECT_LT(ratio, 0.55);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_loopback_sim/test/test_loopback_simulator.cpp
+++ b/nav2_loopback_sim/test/test_loopback_simulator.cpp
@@ -29,14 +29,6 @@
 
 using namespace std::chrono_literals;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class LoopbackSimulatorTest : public ::testing::Test
 {
 protected:
@@ -330,4 +322,13 @@ TEST_F(LoopbackSimulatorTest, SpeedFactorDynamicReconfigure)
 
   // Should still be last valid value
   EXPECT_DOUBLE_EQ(sim_node_->get_parameter("speed_factor").as_double(), 5.0);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_ros_common/test/test_lifecycle_node.cpp
+++ b/nav2_ros_common/test/test_lifecycle_node.cpp
@@ -125,5 +125,7 @@ int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_ros_common/test/test_lifecycle_node.cpp
+++ b/nav2_ros_common/test/test_lifecycle_node.cpp
@@ -18,14 +18,6 @@
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class LifecycleTransitionTestNode : public nav2::LifecycleNode
 {
 public:
@@ -127,4 +119,11 @@ protected:
   node.reset();
 
   SUCCEED();
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/nav2_ros_common/test/test_service_client.cpp
+++ b/nav2_ros_common/test/test_service_client.cpp
@@ -23,14 +23,6 @@
 using nav2::ServiceClient;
 using std::string;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestServiceClient : public ServiceClient<std_srvs::srv::Empty>
 {
 public:
@@ -140,4 +132,11 @@ TEST(ServiceClient, can_ServiceClient_async_call) {
   srv_thread.join();
   ASSERT_EQ(a, 1);
   ASSERT_TRUE(callback_called);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/nav2_ros_common/test/test_service_client.cpp
+++ b/nav2_ros_common/test/test_service_client.cpp
@@ -138,5 +138,7 @@ int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_ros_common/test/test_service_server.cpp
+++ b/nav2_ros_common/test/test_service_server.cpp
@@ -23,14 +23,6 @@
 using nav2::ServiceServer;
 using std::string;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
-
 class TestServiceServer : public ServiceServer<std_srvs::srv::Empty>
 {
 public:
@@ -81,5 +73,8 @@ TEST(ServiceServer, can_handle_all_introspection_modes)
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_collision_operation.cpp
+++ b/nav2_route/test/test_collision_operation.cpp
@@ -30,13 +30,6 @@
 #include "nav2_route/plugins/route_operations/collision_monitor.hpp"
 #include "nav2_costmap_2d/costmap_2d_publisher.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -330,4 +323,13 @@ TEST(TestCollisionMonitor, test_costmap_apis)
     &node1 /*unused*/, curr_edge, curr_edge /*unused*/, route, pose, nullptr);
   EXPECT_FALSE(result.reroute);
   EXPECT_EQ(result.blocked_ids.size(), 0u);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_corner_smoothing.cpp
+++ b/nav2_route/test/test_corner_smoothing.cpp
@@ -23,13 +23,6 @@
 #include "nav2_route/corner_smoothing.hpp"
 // #include "nav2_route/types.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -120,4 +113,13 @@ TEST(DegeneratePointsTest, test_degenerate_points_smoothing)
     angle_threshold);
 
   EXPECT_FALSE(corner_arc.isCornerValid());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_edge_scorers.cpp
+++ b/nav2_route/test/test_edge_scorers.cpp
@@ -30,13 +30,6 @@
 #include "tf2_ros/static_transform_broadcaster.hpp"
 #include "tf2_ros/transform_listener.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -956,4 +949,13 @@ TEST(EdgeScorersTest, test_start_pose_orientation_scoring)
     scorer.score(
       &edge, route_request, edge_type,
       traversal_cost), nav2_core::InvalidEdgeScorerUse);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_geojson_graph_file_loader.cpp
+++ b/nav2_route/test/test_geojson_graph_file_loader.cpp
@@ -21,13 +21,6 @@
 #include "nav2_ros_common/node_utils.hpp"
 #include "nav2_route/plugins/graph_file_loaders/geojson_graph_file_loader.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route; // NOLINT
 using Json = nlohmann::json;
@@ -385,4 +378,13 @@ TEST(GeoJsonGraphFileLoader, invalid_file)
   Graph graph;
   GraphToIDMap graph_to_id_map;
   EXPECT_FALSE(graph_file_loader.loadGraphFromFile(graph, graph_to_id_map, file_path));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_geojson_graph_file_saver.cpp
+++ b/nav2_route/test/test_geojson_graph_file_saver.cpp
@@ -22,13 +22,6 @@
 #include "nav2_route/plugins/graph_file_loaders/geojson_graph_file_loader.hpp"
 #include "nav2_route/plugins/graph_file_savers/geojson_graph_file_saver.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route; // NOLINT
 using Json = nlohmann::json;
@@ -351,4 +344,13 @@ TEST(GeoJsonGraphFileSaver, sample_graph)
   std::string type;
   type = operations[1].metadata.getValue("type", type);
   EXPECT_EQ(type, "jpg");
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_goal_intent_extractor.cpp
+++ b/nav2_route/test/test_goal_intent_extractor.cpp
@@ -27,13 +27,6 @@
 #include "nav2_ros_common/node_thread.hpp"
 #include "nav2_route/goal_intent_extractor.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -378,4 +371,13 @@ TEST(GoalIntentExtractorTest, test_pruning)
   extractor2.setStartAndGoal(start, goal);
   rtn = extractor2.pruneStartandGoal(route, poses_goal, rerouting_info);
   EXPECT_EQ(rtn.edges.size(), 2u);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_goal_intent_search.cpp
+++ b/nav2_route/test/test_goal_intent_search.cpp
@@ -27,13 +27,6 @@
 #include "nav2_ros_common/node_thread.hpp"
 #include "nav2_route/goal_intent_extractor.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -167,4 +160,13 @@ TEST(GoalIntentSearchTest, test_breadth_first_search)
   // Test empty candidates
   candidate_nodes.clear();
   EXPECT_FALSE(bfs.search(target_node, candidate_nodes));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_graph_loader.cpp
+++ b/nav2_route/test/test_graph_loader.cpp
@@ -23,13 +23,6 @@
 #include "nav2_route/graph_loader.hpp"
 #include "tf2_ros/static_transform_broadcaster.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route; //NOLINT
 
@@ -150,4 +143,13 @@ TEST(GraphLoader, test_transformation_api2)
   std::string filepath = nav2::get_package_share_directory("nav2_route") +
     "/test/test_graphs/no_frame.json";
   EXPECT_FALSE(graph_loader.loadGraphFromFile(graph, graph_to_id_map, filepath));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_graph_saver.cpp
+++ b/nav2_route/test/test_graph_saver.cpp
@@ -25,13 +25,6 @@
 #include "nav2_route/graph_saver.hpp"
 #include "tf2_ros/static_transform_broadcaster.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route; //NOLINT
 
@@ -165,4 +158,13 @@ TEST(GraphSaver, test_transformation_api)
   EXPECT_FALSE(graph_saver.saveGraphToFile(graph, file_path));
   EXPECT_EQ(graph[0].coords.frame_id, "map_test2");
   EXPECT_EQ(graph[0].coords.x, or_coord);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_operations.cpp
+++ b/nav2_route/test/test_operations.cpp
@@ -28,13 +28,6 @@
 #include "nav2_route/types.hpp"
 #include "nav2_core/route_exceptions.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -567,4 +560,13 @@ TEST(OperationsTest, test_interface)
 {
   TestRouteOperations op;
   EXPECT_EQ(op.processType(), nav2_route::RouteOperationType::ON_GRAPH);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_path_converter.cpp
+++ b/nav2_route/test/test_path_converter.cpp
@@ -22,13 +22,6 @@
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_route/path_converter.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -174,4 +167,13 @@ TEST(PathConverterTest, test_path_converter_zero_length_edge)
   std::vector<geometry_msgs::msg::PoseStamped> poses;
   converter.interpolateEdge(x0, y0, x1, y1, poses);
   ASSERT_TRUE(poses.empty());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_route_planner.cpp
+++ b/nav2_route/test/test_route_planner.cpp
@@ -23,13 +23,6 @@
 #include "nav2_route/route_planner.hpp"
 #include "nav2_msgs/action/compute_route.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -223,4 +216,13 @@ TEST(RoutePlannerTest, test_route_planner_negative)
     planner.findRoute(
       graph, start, goal, blocked_ids,
       route_request), nav2_core::NoValidGraph);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_route_server.cpp
+++ b/nav2_route/test/test_route_server.cpp
@@ -30,13 +30,6 @@
 #include "nav2_route/route_server.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -399,4 +392,13 @@ TEST(RouteServerTest, test_error_codes)
   server->shutdown();
   node_thread.reset();
   server.reset();
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_route_tracker.cpp
+++ b/nav2_route/test/test_route_tracker.cpp
@@ -27,13 +27,6 @@
 #include "nav2_route/route_tracker.hpp"
 #include "nav2_route/route_server.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -353,4 +346,13 @@ TEST(RouteTrackerTest, test_node_achievement)
   pose.pose.position.x = -9.5;
   pose.pose.position.y = 10.5;
   EXPECT_TRUE(tracker.nodeAchieved(pose, state, route));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/nav2_route/test/test_utils_and_types.cpp
+++ b/nav2_route/test/test_utils_and_types.cpp
@@ -23,13 +23,6 @@
 #include "nav2_route/utils.hpp"
 #include "nav2_route/types.hpp"
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcppfixture;
 
 using namespace nav2_route;  // NOLINT
 
@@ -351,4 +344,13 @@ TEST(UtilsTest, test_routing_state)
   EXPECT_EQ(state.closest_pt_on_edge.x, 0.0);
   EXPECT_EQ(state.rerouting_start_id, std::numeric_limits<unsigned int>::max());
   EXPECT_EQ(state.rerouting_start_pose.pose.position.x, 0.0);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | #6163 |
| Primary OS tested on | Ubuntu (WSL) |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixes the Zenoh nightly failures caused by ROS resources being cleaned up too late during process exit.
* Moves `rclcpp::init()` and `rclcpp::shutdown()` out of global fixtures and into `main()`, following the approach used in #4948.
* Fixes the remaining `nav2_behavior_tree` failure by calling the base fixture teardown before shutting down ROS.
* Updates 23 test files across `opennav_following`, `nav2_behavior_tree`, `nav2_costmap_2d`, `nav2_loopback_sim`, `nav2_ros_common`, and `nav2_route`.

## Description of documentation updates required from your changes

Not required

## Description of how this change was tested

* Local tests with RMW_IMPLEMENTATION=rmw_zenoh_cpp pass without TLS panic
* I cannot run the Zenoh CircleCI job from my fork because of free tier limit. As discussed, the final Zenoh specific check can be done by the nightly CI after merge.
* The global fixture changes follow the same approach as #4948.

---

## Future work that may be required in bullet points

* This PR covers the Zenoh failures from #6163. The FastDDS and CycloneDDS failures still need to be investigated separately.

#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.