### PR TITLE
Fix TruncatePathLocal to use robot_base_frame from parameter file

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
@@ -38,7 +38,7 @@ namespace nav2_behavior_tree
  * Usage in XML:
  * @code
  * <TruncatePathLocal input_path="{path}" output_path="{path_local}"
- *                    distance_forward="3.5" distance_backward="2.0" robot_frame="base_link"/>
+ *                    distance_forward="3.5" distance_backward="2.0"/>
  * @endcode
  */
 class TruncatePathLocal : public BT::ActionNodeBase
@@ -74,7 +74,7 @@ public:
         "distance_backward", 4.0,
         "Distance in backward direction"),
       BT::InputPort<std::string>(
-        "robot_frame", "base_link",
+        "robot_base_frame",
         "Robot base frame id"),
       BT::InputPort<double>(
         "transform_tolerance", 0.2,

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -250,7 +250,7 @@
       <input_port name="input_path" type="nav_msgs::msg::Path">The original path to be truncated.</input_port>
       <input_port name="distance_forward" type="double" default="8.0">The trimming distance in forward direction. Set to -1 to search full path forward.</input_port>
       <input_port name="distance_backward" type="double" default="4.0">The trimming distance in backward direction.</input_port>
-      <input_port name="robot_frame" type="string" default="&quot;base_link&quot;">Robot base frame id.</input_port>
+      <input_port name="robot_base_frame" type="string">Robot base frame id.</input_port>
       <input_port name="transform_tolerance" type="double" default="0.2">Robot pose lookup tolerance.</input_port>
       <input_port name="pose" type="geometry_msgs::msg::PoseStamped">Manually specified pose to be used alternatively to current robot pose.</input_port>
       <input_port name="angular_distance_weight" type="double" default="0.0">Weight of angular distance relative to positional distance when finding which path pose is closest to robot. Not applicable on paths without orientations assigned.</input_port>

--- a/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
@@ -116,11 +116,13 @@ inline bool TruncatePathLocal::getRobotPose(
   std::string path_frame_id, geometry_msgs::msg::PoseStamped & pose)
 {
   if (!getInput("pose", pose)) {
-    std::string robot_frame;
-    if (!getInput("robot_frame", robot_frame)) {
+    auto node = config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node");
+    std::string robot_frame = BT::deconflictPortAndParamFrame<std::string>(
+      node, "robot_base_frame", this);
+    if (robot_frame.empty()) {
       RCLCPP_ERROR(
-        config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node")->get_logger(),
-        "Neither pose nor robot_frame specified for %s", name().c_str());
+        node->get_logger(),
+        "Neither pose nor robot_base_frame specified for %s", name().c_str());
       return false;
     }
     double transform_tolerance;
@@ -129,7 +131,7 @@ inline bool TruncatePathLocal::getRobotPose(
         pose, *tf_buffer_, path_frame_id, robot_frame, transform_tolerance))
     {
       RCLCPP_WARN(
-        config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node")->get_logger(),
+        node->get_logger(),
         "Failed to lookup current robot pose for %s", name().c_str());
       return false;
     }

--- a/nav2_behavior_tree/test/plugins/action/test_truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_truncate_path_local_action.cpp
@@ -112,7 +112,7 @@ TEST_F(TruncatePathLocalTestFixture, test_tick)
           <TruncatePathLocal
             distance_forward="2.0"
             distance_backward="1.0"
-            robot_frame="base_link"
+            robot_base_frame="base_link"
             transform_tolerance="0.2"
             angular_distance_weight="0.2"
             pose="{pose}"
@@ -206,7 +206,7 @@ TEST_F(TruncatePathLocalTestFixture, test_success_on_empty_path)
           <TruncatePathLocal
             distance_forward="2.0"
             distance_backward="1.0"
-            robot_frame="base_link"
+            robot_base_frame="base_link"
             transform_tolerance="0.2"
             angular_distance_weight="0.2"
             pose="{pose}"
@@ -252,7 +252,7 @@ TEST_F(TruncatePathLocalTestFixture, test_failure_on_no_pose)
             distance_backward="1.0"
             transform_tolerance="0.2"
             angular_distance_weight="0.2"
-            robot_frame="{robot_frame}"
+            robot_base_frame="{robot_base_frame}"
             input_path="{path}"
             output_path="{truncated_path}"
             max_robot_pose_search_dist="infinity"
@@ -282,7 +282,7 @@ TEST_F(TruncatePathLocalTestFixture, test_failure_on_no_pose)
   SUCCEED();
 }
 
-TEST_F(TruncatePathLocalTestFixture, test_failure_on_invalid_robot_frame)
+TEST_F(TruncatePathLocalTestFixture, test_failure_on_invalid_robot_base_frame)
 {
   // create tree
   std::string xml_txt =
@@ -293,7 +293,7 @@ TEST_F(TruncatePathLocalTestFixture, test_failure_on_invalid_robot_frame)
             distance_forward="2.0"
             distance_backward="1.0"
             transform_tolerance="0.2"
-            robot_frame="invalid_frame"
+            robot_base_frame="invalid_frame"
             angular_distance_weight="0.2"
             input_path="{path}"
             output_path="{truncated_path}"
@@ -333,7 +333,7 @@ TEST_F(TruncatePathLocalTestFixture, test_path_pruning)
           <TruncatePathLocal
             distance_forward="2.0"
             distance_backward="1.0"
-            robot_frame="base_link"
+            robot_base_frame="base_link"
             transform_tolerance="0.2"
             angular_distance_weight="0.0"
             pose="{pose}"
@@ -439,6 +439,42 @@ TEST_F(TruncatePathLocalTestFixture, test_path_pruning)
   EXPECT_EQ(truncated_path.poses.back().pose.position.x, 0.3);
   EXPECT_EQ(truncated_path.poses.back().pose.position.y, -1.0);
 
+  SUCCEED();
+}
+
+TEST_F(TruncatePathLocalTestFixture, test_param_fallback_without_port)
+{
+  // create tree without robot_base_frame port
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+          <TruncatePathLocal
+            distance_forward="2.0"
+            distance_backward="1.0"
+            transform_tolerance="0.2"
+            angular_distance_weight="0.2"
+            input_path="{path}"
+            output_path="{truncated_path}"
+          />
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  // create path and set it on blackboard
+  nav_msgs::msg::Path path = createLoopCrossingTestPath();
+  config_->blackboard->set("path", path);
+
+  // tick until node succeeds or fails
+  while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS &&
+    tree_->rootNode()->status() != BT::NodeStatus::FAILURE)
+  {
+    tree_->rootNode()->executeTick();
+  }
+
+  // should fail since no robot_base_frame port or parameter is set
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);
   SUCCEED();
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | #6226 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A (unit tests only) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed `TruncatePathLocal` ignoring the `robot_base_frame` parameter when the BT input port is omitted
* Replaced manual frame lookup with `deconflictPortAndParamFrame()`, matching other BT nodes like `GetCurrentPose` and `GoalReached`
* Renamed port from `robot_frame` to `robot_base_frame` to follow Nav2 naming conventions
* Updated `nav2_tree_nodes.xml` and unit tests accordingly

## Description of documentation updates required from your changes

* Update BT node docs to reflect the renamed port (`robot_frame` to `robot_base_frame`) https://docs.nav2.org/configuration/packages/bt-plugins/actions/TruncatePathLocal.html
* Existing behavior trees with `robot_frame` need to change to `robot_base_frame`

## Description of how this change was tested

* Added `test_param_fallback_without_port` to verify the node fails when neither port nor parameter is set (on main it incorrectly succeeds due to hardcoded default)
* Updated unit tests in `test_truncate_path_local_action.cpp` to use the renamed port
* All 6 unit tests pass

---

## Future work that may be required in bullet points

* None

#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
