### PR TITLE
Improve BT navigation failure robustness and diagnostics

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -406,7 +406,15 @@ void BtActionServer<ActionT, NodeT>::executeCallback()
 
   auto on_loop = [&]() {
       if (action_server_->is_preempt_requested() && on_preempt_callback_) {
-        on_preempt_callback_(action_server_->get_pending_goal());
+        auto pending_goal = action_server_->get_pending_goal();
+        if (!pending_goal) {
+          RCLCPP_WARN_THROTTLE(
+            logger_, *clock_, 2000,
+            "Preempt requested for %s, but no pending goal is available. Ignoring preempt.",
+            action_name_.c_str());
+        } else {
+          on_preempt_callback_(pending_goal);
+        }
       }
       topic_logger_->flush();
       on_loop_callback_();
@@ -414,6 +422,11 @@ void BtActionServer<ActionT, NodeT>::executeCallback()
 
   // Execute the BT that was previously created in the configure step
   nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling, bt_loop_duration_);
+
+  // Flush final status transitions after tree completion to avoid dropping terminal events.
+  if (topic_logger_) {
+    topic_logger_->flush();
+  }
 
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include "behaviortree_cpp/control_node.h"
+#include "rclcpp/rclcpp.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -64,6 +65,7 @@ private:
   unsigned int current_child_idx_;
   unsigned int number_of_retries_;
   unsigned int retry_count_;
+  rclcpp::Logger logger_{rclcpp::get_logger("RecoveryNode")};
 
   /**
    * @brief The main override required by a BT action

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -31,6 +31,9 @@ NavigateThroughPosesAction::NavigateThroughPosesAction(
 void NavigateThroughPosesAction::on_tick()
 {
   if (!getInput("goals", goal_.poses)) {
+    should_send_goal_ = false;
+    setOutput("error_code_id", ActionResult::UNKNOWN);
+    setOutput("error_msg", "NavigateThroughPosesAction missing required input port: goals");
     RCLCPP_ERROR(
       node_->get_logger(),
       "NavigateThroughPosesAction: goal not provided");

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -30,6 +30,9 @@ NavigateToPoseAction::NavigateToPoseAction(
 void NavigateToPoseAction::on_tick()
 {
   if (!getInput("goal", goal_.pose)) {
+    should_send_goal_ = false;
+    setOutput("error_code_id", ActionResult::UNKNOWN);
+    setOutput("error_msg", "NavigateToPoseAction missing required input port: goal");
     RCLCPP_ERROR(
       node_->get_logger(),
       "NavigateToPoseAction: goal not provided");

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include "nav2_behavior_tree/plugins/control/recovery_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -63,11 +64,26 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             if (retry_count_ < number_of_retries_) {
+              RCLCPP_DEBUG(
+                logger_,
+                "RecoveryNode '%s': primary child '%s' failed. "
+                "Running recovery child '%s' (%u/%u).",
+                name().c_str(),
+                children_nodes_[0]->name().c_str(),
+                children_nodes_[1]->name().c_str(),
+                retry_count_ + 1,
+                number_of_retries_);
               // halt first child and tick second child in next iteration
               ControlNode::haltChild(0);
               current_child_idx_++;
               break;
             } else {
+              RCLCPP_ERROR(
+                logger_,
+                "RecoveryNode '%s': primary child '%s' failed and max retries (%u) reached.",
+                name().c_str(),
+                children_nodes_[0]->name().c_str(),
+                number_of_retries_);
               // reset node and return failure when max retries has been exceeded
               halt();
               return BT::NodeStatus::FAILURE;
@@ -95,6 +111,12 @@ BT::NodeStatus RecoveryNode::tick()
 
         case BT::NodeStatus::SUCCESS:
           {
+            RCLCPP_DEBUG(
+              logger_,
+              "RecoveryNode '%s': recovery child '%s' succeeded. Retrying primary child '%s'.",
+              name().c_str(),
+              children_nodes_[1]->name().c_str(),
+              children_nodes_[0]->name().c_str());
             // halt second child, increment recovery count, and tick first child in next iteration
             ControlNode::haltChild(1);
             retry_count_++;
@@ -103,6 +125,12 @@ BT::NodeStatus RecoveryNode::tick()
           break;
 
         case BT::NodeStatus::FAILURE:
+          RCLCPP_ERROR(
+            logger_,
+            "RecoveryNode '%s': recovery child '%s' failed after primary child '%s' failure.",
+            name().c_str(),
+            children_nodes_[1]->name().c_str(),
+            children_nodes_[0]->name().c_str());
           // reset node and return failure if second child fails
           halt();
           return BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -86,7 +86,23 @@ BehaviorTreeEngine::run(
     return BtStatus::FAILED;
   }
 
-  return (result == BT::NodeStatus::SUCCESS) ? BtStatus::SUCCEEDED : BtStatus::FAILED;
+  if (result == BT::NodeStatus::SUCCESS) {
+    return BtStatus::SUCCEEDED;
+  }
+
+  if (result == BT::NodeStatus::FAILURE) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("BehaviorTreeEngine"),
+      "Behavior Tree completed with FAILURE status at root node '%s'.",
+      tree->rootNode() ? tree->rootNode()->name().c_str() : "<unknown>");
+  } else if (result == BT::NodeStatus::IDLE) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("BehaviorTreeEngine"),
+      "Behavior Tree returned unexpected IDLE status at root node '%s'. Treating as failure.",
+      tree->rootNode() ? tree->rootNode()->name().c_str() : "<unknown>");
+  }
+
+  return BtStatus::FAILED;
 }
 
 BT::Tree

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -14,9 +14,13 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>
+#include <thread>
 
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -31,9 +35,25 @@ using namespace std::chrono_literals;
 class FollowPathActionServer : public TestActionServer<nav2_msgs::action::FollowPath>
 {
 public:
+  enum class ResultMode : uint8_t
+  {
+    SUCCEED,
+    ABORT
+  };
+
   FollowPathActionServer()
   : TestActionServer("follow_path")
   {}
+
+  void setResultMode(const ResultMode mode)
+  {
+    result_mode_ = mode;
+  }
+
+  void setExecutionDelay(const std::chrono::milliseconds delay)
+  {
+    execution_delay_ms_ = delay.count();
+  }
 
 protected:
   void execute(
@@ -41,10 +61,37 @@ protected:
       rclcpp_action::ServerGoalHandle<nav2_msgs::action::FollowPath>> goal_handle)
   override
   {
-    const auto goal = goal_handle->get_goal();
     auto result = std::make_shared<nav2_msgs::action::FollowPath::Result>();
+
+    const auto execution_delay = std::chrono::milliseconds(execution_delay_ms_.load());
+    if (execution_delay > 0ms) {
+      const auto end_time = std::chrono::steady_clock::now() + execution_delay;
+      while (rclcpp::ok() && std::chrono::steady_clock::now() < end_time) {
+        if (goal_handle->is_canceling()) {
+          goal_handle->canceled(result);
+          return;
+        }
+        std::this_thread::sleep_for(5ms);
+      }
+    }
+
+    if (goal_handle->is_canceling()) {
+      goal_handle->canceled(result);
+      return;
+    }
+
+    if (result_mode_.load() == ResultMode::ABORT) {
+      result->error_code = nav2_msgs::action::FollowPath::Result::NO_VALID_CONTROL;
+      result->error_msg = "Controller failed to produce a valid control command";
+      goal_handle->abort(result);
+      return;
+    }
+
     goal_handle->succeed(result);
   }
+
+  std::atomic<ResultMode> result_mode_{ResultMode::SUCCEED};
+  std::atomic<int64_t> execution_delay_ms_{0};
 };
 
 class FollowPathActionTestFixture : public ::testing::Test
@@ -97,6 +144,8 @@ public:
   void TearDown() override
   {
     tree_.reset();
+    action_server_->setResultMode(FollowPathActionServer::ResultMode::SUCCEED);
+    action_server_->setExecutionDelay(0ms);
   }
 
   static std::shared_ptr<FollowPathActionServer> action_server_;
@@ -161,6 +210,80 @@ TEST_F(FollowPathActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses.size(), 1u);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses[0].pose.position.x, -2.5);
+}
+
+TEST_F(FollowPathActionTestFixture, test_controller_failure_propagates_error)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <FollowPath path="{path}" controller_id="FollowPath"
+                        error_code_id="{follow_path_error_code}"
+                        error_msg="{follow_path_error_msg}"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(
+    factory_->createTreeFromText(xml_txt, config_->blackboard));
+  action_server_->setResultMode(FollowPathActionServer::ResultMode::ABORT);
+
+  nav_msgs::msg::Path path;
+  path.poses.resize(1);
+  path.poses[0].pose.position.x = 2.0;
+  config_->blackboard->set("path", path);
+
+  BT::NodeStatus status = BT::NodeStatus::RUNNING;
+  while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
+    status = tree_->rootNode()->executeTick();
+  }
+
+  EXPECT_EQ(status, BT::NodeStatus::FAILURE);
+
+  uint16_t error_code = nav2_msgs::action::FollowPath::Result::NONE;
+  std::string error_msg;
+  EXPECT_TRUE(config_->blackboard->get("follow_path_error_code", error_code));
+  EXPECT_TRUE(config_->blackboard->get("follow_path_error_msg", error_msg));
+  EXPECT_EQ(error_code, nav2_msgs::action::FollowPath::Result::NO_VALID_CONTROL);
+  EXPECT_EQ(error_msg, "Controller failed to produce a valid control command");
+}
+
+TEST_F(FollowPathActionTestFixture, test_goal_replacement_while_active)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <FollowPath path="{path}" controller_id="FollowPath"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+  action_server_->setExecutionDelay(150ms);
+
+  nav_msgs::msg::Path path;
+  path.poses.resize(1);
+  path.poses[0].pose.position.x = 1.0;
+  config_->blackboard->set("path", path);
+
+  BT::NodeStatus status = tree_->rootNode()->executeTick();
+  ASSERT_EQ(status, BT::NodeStatus::RUNNING);
+
+  path.poses[0].pose.position.x = -3.0;
+  config_->blackboard->set("path", path);
+
+  rclcpp::WallRate loop_rate(10ms);
+  int iterations = 0;
+  while (rclcpp::ok() && status == BT::NodeStatus::RUNNING && iterations < 300) {
+    status = tree_->rootNode()->executeTick();
+    iterations++;
+    loop_rate.sleep();
+  }
+
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  ASSERT_NE(action_server_->getCurrentGoal(), nullptr);
+  ASSERT_EQ(action_server_->getCurrentGoal()->path.poses.size(), 1u);
+  EXPECT_EQ(action_server_->getCurrentGoal()->path.poses[0].pose.position.x, -3.0);
 }
 
 TEST(FollowPathAction, testProgressCheckerIdUpdate)

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -152,6 +152,31 @@ TEST_F(NavigateThroughPosesActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::IDLE);
 }
 
+TEST_F(NavigateThroughPosesActionTestFixture, test_missing_goals_input_fails_fast)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <NavigateThroughPoses goals="{goals}" error_code_id="{error_code}"
+                                  error_msg="{error_msg}" />
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  const auto status = tree_->rootNode()->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::FAILURE);
+  EXPECT_EQ(action_server_->getCurrentGoal(), nullptr);
+
+  uint16_t error_code = nav2_msgs::action::NavigateThroughPoses::Result::NONE;
+  std::string error_msg;
+  EXPECT_TRUE(config_->blackboard->get("error_code", error_code));
+  EXPECT_TRUE(config_->blackboard->get("error_msg", error_msg));
+  EXPECT_EQ(error_code, nav2_msgs::action::NavigateThroughPoses::Result::UNKNOWN);
+  EXPECT_EQ(error_msg, "NavigateThroughPosesAction missing required input port: goals");
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -155,6 +155,30 @@ TEST_F(NavigateToPoseActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
 }
 
+TEST_F(NavigateToPoseActionTestFixture, test_missing_goal_input_fails_fast)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <NavigateToPose goal="{goal}" error_code_id="{error_code}" error_msg="{error_msg}"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  const auto status = tree_->rootNode()->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::FAILURE);
+  EXPECT_EQ(action_server_->getCurrentGoal(), nullptr);
+
+  uint16_t error_code = nav2_msgs::action::NavigateToPose::Result::NONE;
+  std::string error_msg;
+  EXPECT_TRUE(config_->blackboard->get("error_code", error_code));
+  EXPECT_TRUE(config_->blackboard->get("error_msg", error_msg));
+  EXPECT_EQ(error_code, nav2_msgs::action::NavigateToPose::Result::UNKNOWN);
+  EXPECT_EQ(error_msg, "NavigateToPoseAction missing required input port: goal");
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_bt_navigator/doc/bt_navigation_failure_audit.md
+++ b/nav2_bt_navigator/doc/bt_navigation_failure_audit.md
@@ -1,0 +1,97 @@
+# BT Navigation Failure Audit
+
+This note captures concrete failure modes that were found in BT navigation execution paths,
+how they previously propagated, and what was changed.
+
+## 1) Goal replacement during active `NavigateThroughPoses` with TF issues
+
+- Scenario: A preempting goal arrives while navigation is active, but one or more new poses cannot
+  be transformed due to delayed/missing TF.
+- Previous propagation:
+  - `NavigateThroughPosesNavigator::onPreempt()` called `initializeGoalPoses()`.
+  - On transform failure it threw a `std::runtime_error`.
+  - The exception escaped through the BT loop and was converted into a generic BT failure.
+  - Result: active navigation could fail due to a bad replacement goal instead of rejecting that
+    pending goal and continuing.
+- Fix:
+  - Preempt transform failure now rejects only the pending goal and keeps current navigation active.
+  - This is now consistent with `NavigateToPose` preempt behavior.
+
+## 2) Terminal BT status changes missing from introspection logs
+
+- Scenario: Tree reaches terminal `SUCCESS` or `FAILURE`.
+- Previous propagation:
+  - BT topic logs were flushed only during loop iterations while the tree was still running.
+  - Final status transitions could be buffered and never published.
+  - Result: debugging terminal failures/successes from BT event logs could be incomplete.
+- Fix:
+  - Added a post-run flush in `BtActionServer::executeCallback()` so final transitions are always
+    published.
+
+## 3) BT fails without a populated error code/message
+
+- Scenario: Tree returns `FAILED`, but no node-level error code was set on blackboard.
+- Previous propagation:
+  - Action result could terminate with failure but empty `error_msg` and `error_code == NONE`.
+  - Result: operationally confusing failure reports.
+- Fix:
+  - Added explicit terminal warnings in `BehaviorTreeEngine` for `FAILURE` and unexpected `IDLE`.
+
+## 4) Navigation action BT node missing required goal input
+
+- Scenario: `NavigateToPoseAction` or `NavigateThroughPosesAction` ticks without required goal input.
+- Previous propagation:
+  - Node logged an error but still sent a default-constructed action goal.
+  - Result: empty/invalid goals could be sent, obscuring root cause.
+- Fix:
+  - Nodes now fail fast (`should_send_goal_ = false`) and set explicit `UNKNOWN` error outputs.
+
+## 5) Recovery loops were difficult to interpret during failures
+
+- Scenario: primary child fails and recovery child is attempted repeatedly.
+- Previous propagation:
+  - Retry transitions had limited runtime logging context.
+- Fix:
+  - Added concise logs in `RecoveryNode` for primary failure, recovery attempt, recovery success,
+    recovery failure, and retry exhaustion.
+
+## 6) Preempt-without-pending-goal warning could spam the log at tick rate
+
+- Scenario: A preempt is requested but `get_pending_goal()` returns null on a given loop iteration,
+  and the condition persists across several BT loop iterations (ticking at up to `bt_loop_duration_`
+  frequency) before resolving.
+- Previous propagation:
+  - `BtActionServer::executeCallback()`'s `on_loop` logged this case with `RCLCPP_WARN` unconditionally
+    on every iteration where the condition held, unbounded by time.
+  - Result: log flooding and unnecessary overhead on the BT tick hot path.
+- Fix:
+  - Switched to `RCLCPP_WARN_THROTTLE` (2s), matching the throttle convention already used in
+    `NavigateToPose`/`NavigateThroughPoses` `onLoop()` for TF-unavailable warnings.
+
+## 7) `RecoveryNode::tick()` constructed a logger on every tick regardless of outcome
+
+- Scenario: `RecoveryNode` is ticked at full BT rate during normal, non-failing navigation (the
+  common case), not just on retries/failures.
+- Previous propagation:
+  - `tick()` called `rclcpp::get_logger("RecoveryNode")` unconditionally at the top of every tick,
+    even though the actual `RCLCPP_DEBUG`/`RCLCPP_ERROR` calls were already correctly gated to
+    failure/success transitions only.
+  - Result: avoidable per-tick overhead independent of whether any diagnostic message fired,
+    violating the requirement that new diagnostics add no steady-state tick-path cost.
+- Fix:
+  - Logger is now a `rclcpp::Logger logger_` member, constructed once in the header's default
+    member initializer and reused across ticks instead of being rebuilt each call.
+
+## Plugin API/ABI stability check
+
+- No public virtual method signatures, base-class interfaces (e.g. `BtActionNode`, `BtServiceNode`),
+  or constructor signatures used by pluginlib-loaded, out-of-tree BT plugins were changed. The
+  `RecoveryNode::logger_` addition is a private member on a concrete leaf control node (not a base
+  class third parties inherit from), so it does not affect any out-of-tree plugin's API surface.
+
+## Follow-up intentionally postponed
+
+- Add end-to-end system tests in `nav2_system_tests` that assert complete navigator action results
+  and BT event logs under real TF delay/intermittent localization conditions.
+- Add optional structured metadata in BT status log events for recovery retry counters to improve
+  offline traceability.

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -157,7 +157,10 @@ NavigateThroughPosesNavigator::onLoop()
       feedback_utils_.global_frame, feedback_utils_.robot_frame,
       feedback_utils_.transform_tolerance))
   {
-    RCLCPP_ERROR(logger_, "Robot pose is not available.");
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000,
+      "Robot pose is not available for NavigateThroughPoses feedback. "
+      "This is often caused by delayed TF or intermittent localization.");
     return;
   }
 
@@ -224,13 +227,18 @@ NavigateThroughPosesNavigator::onPreempt(ActionT::Goal::ConstSharedPtr goal)
     (goal->behavior_tree.empty() &&
     bt_action_server_->getCurrentBTFilenameOrID() == bt_action_server_->getDefaultBTFilenameOrID()))
   {
-    // if pending goal requests the same BT as the current goal, accept the pending goal
+    // if pending goal requests the same BT as the current goal, validate it first and then
+    // accept the pending goal
     // if pending goal has an empty behavior_tree field, it requests the default BT file
     // accept the pending goal if the current goal is running the default BT file
-    if (!initializeGoalPoses(bt_action_server_->acceptPendingGoal())) {
-      throw std::runtime_error(
+    if (!initializeGoalPoses(goal)) {
+      RCLCPP_WARN(
+        logger_,
         "Preemption request was rejected since the goal poses could not be "
-        "transformed.");
+        "transformed. Continuing to track the last valid goal set.");
+      bt_action_server_->terminatePendingGoal();
+    } else {
+      bt_action_server_->acceptPendingGoal();
     }
   } else {
     RCLCPP_WARN(

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -136,7 +136,10 @@ NavigateToPoseNavigator::onLoop()
       feedback_utils_.global_frame, feedback_utils_.robot_frame,
       feedback_utils_.transform_tolerance))
   {
-    RCLCPP_ERROR(logger_, "Robot pose is not available.");
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000,
+      "Robot pose is not available for NavigateToPose feedback. "
+      "This is often caused by delayed TF or intermittent localization.");
     return;
   }
 

--- a/nav2_system_tests/src/system/nav_through_poses_tester_node.py
+++ b/nav2_system_tests/src/system/nav_through_poses_tester_node.py
@@ -200,6 +200,84 @@ class NavTester(Node):
         self.info_msg('Goal succeeded!')
         return True
 
+    def runBadTFReplacementPreemptionAction(self) -> bool:
+        # Sends a valid NavigateThroughPoses goal then preempts it with a bad-TF goal.
+        # The replacement goal should be terminated while the original goal is not aborted.
+        self.info_msg("Waiting for 'NavigateThroughPoses' action server")
+        while not self.action_client.wait_for_server(timeout_sec=1.0):
+            self.info_msg(
+                "'NavigateThroughPoses' action server not available, waiting..."
+            )
+
+        first_goal_msg = NavigateThroughPoses.Goal()
+        first_goal_msg.poses.header.frame_id = 'map'
+        first_goal_msg.poses.header.stamp = self.get_clock().now().to_msg()
+        first_goal_msg.poses.goals = [
+            self.getStampedPoseMsg(self.goal_pose),
+            self.getStampedPoseMsg(self.goal_pose),
+        ]
+
+        self.info_msg('Sending initial valid goal request...')
+        send_first_goal_future = self.action_client.send_goal_async(first_goal_msg)
+        rclpy.spin_until_future_complete(self, send_first_goal_future)
+        first_goal_handle = send_first_goal_future.result()
+
+        if not first_goal_handle or not first_goal_handle.accepted:
+            self.error_msg('Initial goal rejected')
+            return False
+
+        replacement_goal_msg = NavigateThroughPoses.Goal()
+        replacement_goal_msg.poses.header.frame_id = 'map'
+        replacement_goal_msg.poses.header.stamp = self.get_clock().now().to_msg()
+        bad_pose = self.getStampedPoseMsg(self.initial_pose)
+        bad_pose.header.frame_id = 'bad_tf_frame'
+        replacement_goal_msg.poses.goals = [bad_pose]
+
+        self.info_msg('Sending replacement goal request with bad TF frame...')
+        send_replacement_goal_future = self.action_client.send_goal_async(
+            replacement_goal_msg
+        )
+        rclpy.spin_until_future_complete(self, send_replacement_goal_future)
+        replacement_goal_handle = send_replacement_goal_future.result()
+
+        if not replacement_goal_handle or not replacement_goal_handle.accepted:
+            self.error_msg('Replacement goal rejected unexpectedly')
+            return False
+
+        replacement_result_future = replacement_goal_handle.get_result_async()
+        rclpy.spin_until_future_complete(self, replacement_result_future, timeout_sec=30.0)
+        if not replacement_result_future.done():
+            self.error_msg('Timed out waiting for replacement goal result')
+            return False
+
+        replacement_status = replacement_result_future.result().status  # type: ignore[union-attr]
+        if replacement_status == GoalStatus.STATUS_SUCCEEDED:
+            self.error_msg('Replacement bad-TF goal unexpectedly succeeded')
+            return False
+
+        cancel_first_goal_future = first_goal_handle.cancel_goal_async()
+        rclpy.spin_until_future_complete(self, cancel_first_goal_future, timeout_sec=15.0)
+
+        first_result_future = first_goal_handle.get_result_async()
+        rclpy.spin_until_future_complete(self, first_result_future, timeout_sec=45.0)
+        if not first_result_future.done():
+            self.error_msg('Timed out waiting for initial goal result')
+            return False
+
+        first_status = first_result_future.result().status  # type: ignore[union-attr]
+        if first_status == GoalStatus.STATUS_ABORTED:
+            first_result = first_result_future.result().result  # type: ignore[union-attr]
+            self.error_msg(
+                f'Initial goal was aborted after bad preempt. '
+                f'status:{first_status} '
+                f'error_code:{first_result.error_code} '
+                f'error_msg:{first_result.error_msg}'
+            )
+            return False
+
+        self.info_msg('Bad-TF replacement preempt was rejected and original goal was not aborted')
+        return True
+
     def poseCallback(self, msg: PoseWithCovarianceStamped) -> None:
         self.info_msg('Received amcl_pose')
         self.current_pose = msg.pose.pose
@@ -286,6 +364,8 @@ def run_all_tests(robot_tester: NavTester) -> bool:
         # Test preempting NHP with the same goal
         result = result and robot_tester.runNavigatePreemptionAction(False)
         result = result and robot_tester.runNavigatePreemptionAction(True)
+        # Test preempting NHP with replacement goal that cannot be transformed
+        result = result and robot_tester.runBadTFReplacementPreemptionAction()
 
     # Add more tests here if desired
 


### PR DESCRIPTION
## Summary
- reject invalid NavigateThroughPoses replacement goals without aborting the active goal
- flush terminal Behavior Tree status transitions after tree execution completes
- fail fast on missing navigation BT action inputs and populate error outputs
- add recovery retry diagnostics and targeted regression coverage

## Validation
- Added BT action unit coverage for missing navigation inputs, FollowPath failure propagation, and active goal replacement.
- Added NavigateThroughPoses system coverage for bad-TF replacement preemption.