### PR TITLE
Handle non-mapping YAML in HasNodeParams

### DIFF
--- a/nav2_common/CMakeLists.txt
+++ b/nav2_common/CMakeLists.txt
@@ -28,6 +28,8 @@ if(BUILD_TESTING)
 
   nav2_add_pytest_test(test_rewritten_yaml test/test_rewritten_yaml.py
   )
+  nav2_add_pytest_test(test_has_node_params test/test_has_node_params.py
+  )
   nav2_add_pytest_test(test_launch_config_as_bool test/test_launch_config_as_bool.py
   )
 endif()

--- a/nav2_common/nav2_common/launch/has_node_params.py
+++ b/nav2_common/nav2_common/launch/has_node_params.py
@@ -52,8 +52,9 @@ class HasNodeParams(launch.Substitution):
 
     def perform(self, context: launch.LaunchContext) -> str:
         yaml_filename = launch.utilities.perform_substitutions(context, self.name)
-        data = yaml.safe_load(open(yaml_filename))
+        with open(yaml_filename, 'r') as yaml_file:
+            data = yaml.safe_load(yaml_file)
 
-        if self.__node_name in data.keys():
+        if isinstance(data, dict) and self.__node_name in data.keys():
             return 'True'
         return 'False'

--- a/nav2_common/test/test_has_node_params.py
+++ b/nav2_common/test/test_has_node_params.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 aineoae86-sys
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import launch
+from nav2_common.launch import HasNodeParams
+
+
+def perform_has_node_params(yaml_text):
+    test_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    try:
+        test_yaml.write(yaml_text)
+        test_yaml.close()
+
+        substitution = HasNodeParams(
+            source_file=test_yaml.name,
+            node_name='slam_toolbox',
+        )
+        return substitution.perform(launch.LaunchContext())
+    finally:
+        if not test_yaml.closed:
+            test_yaml.close()
+        os.unlink(test_yaml.name)
+
+
+def test_has_node_params_returns_true_for_present_node():
+    assert perform_has_node_params(
+        'slam_toolbox:\n  ros__parameters:\n    use_sim_time: true\n'
+    ) == 'True'
+
+
+def test_has_node_params_returns_false_for_missing_node():
+    assert perform_has_node_params(
+        'map_server:\n  ros__parameters:\n    use_sim_time: true\n'
+    ) == 'False'
+
+
+def test_has_node_params_returns_false_for_empty_yaml():
+    assert perform_has_node_params('') == 'False'
+
+
+def test_has_node_params_returns_false_for_non_mapping_yaml():
+    assert perform_has_node_params('- slam_toolbox\n') == 'False'


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Windows 11 |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

* Makes `HasNodeParams` return `False` when the YAML file is empty or has a non-mapping top-level value.
* Uses a context manager when reading the YAML file.
* Adds focused pytest coverage for present, missing, empty, and non-mapping YAML inputs.

## Description of documentation updates required from your changes

* None.

---

## Future work that may be required in bullet points

* None.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists

Validation:
- `python -m py_compile nav2_common\nav2_common\launch\has_node_params.py nav2_common\test\test_has_node_params.py`
- `git diff --check`
- Focused `HasNodeParams` cases were run with a minimal launch-module shim because this Windows environment does not have ROS 2 `launch` / `colcon` installed.