### PR TITLE
add param to clamp raw controls

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
@@ -34,6 +34,7 @@ struct OptimizerSettings
   float model_delay_vx{0.0f};
   float model_delay_vy{0.0f};
   float model_delay_wz{0.0f};
+  bool clamp_raw_controls{false};
   float controller_period{0.0f};
   float temperature{0.0f};
   float gamma{0.0f};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -66,13 +66,14 @@ public:
     */
   void setConstraints(
     const models::ControlConstraints & control_constraints, float model_dt,
-    float model_delay_vx, float model_delay_vy, float model_delay_wz)
+    float model_delay_vx, float model_delay_vy, float model_delay_wz, bool clamp_raw_controls)
   {
     control_constraints_ = control_constraints;
     model_dt_ = model_dt;
     model_delay_vx_ = model_delay_vx;
     model_delay_vy_ = model_delay_vy;
     model_delay_wz_ = model_delay_wz;
+    clamp_raw_controls_ = clamp_raw_controls;
 
     cmd_history_vx_.resize(offsetSteps(model_delay_vx_), 0.0f);
     cmd_history_vy_.resize(offsetSteps(model_delay_vy_), 0.0f);
@@ -127,10 +128,16 @@ public:
       state.vx.col(i) = state.cvx.col(i - 1)
         .cwiseMax(lower_bound_vx)
         .cwiseMin(upper_bound_vx);
+      if (clamp_raw_controls_) {
+        state.cvx.col(i - 1) = state.vx.col(i);
+      }
 
       state.wz.col(i) = state.cwz.col(i - 1)
         .cwiseMax(state.wz.col(i - 1) - max_delta_wz)
         .cwiseMin(state.wz.col(i - 1) + max_delta_wz);
+      if (clamp_raw_controls_) {
+        state.cwz.col(i - 1) = state.wz.col(i);
+      }
 
       if (is_holo) {
         auto lower_bound_vy = (state.vy.col(i - 1) >
@@ -144,6 +151,9 @@ public:
         state.vy.col(i) = state.cvy.col(i - 1)
           .cwiseMax(lower_bound_vy)
           .cwiseMin(upper_bound_vy);
+        if (clamp_raw_controls_) {
+          state.cvy.col(i - 1) = state.vy.col(i);
+        }
       }
     }
 
@@ -230,6 +240,7 @@ protected:
   float model_delay_vx_{0.0};
   float model_delay_vy_{0.0};
   float model_delay_wz_{0.0};
+  bool clamp_raw_controls_{false};
 
   // Per-axis ring buffer of recently published commands
   std::vector<float> cmd_history_vx_;

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -105,6 +105,7 @@ void Optimizer::getParams()
   getParam(s.model_delay_vx, "model_delay_vx", 0.0f);
   getParam(s.model_delay_vy, "model_delay_vy", 0.0f);
   getParam(s.model_delay_wz, "model_delay_wz", 0.0f);
+  getParam(s.clamp_raw_controls, "clamp_raw_controls", false);
   getParam(s.time_steps, "time_steps", 56);
   getParam(s.batch_size, "batch_size", 1000);
   getParam(s.iteration_count, "iteration_count", 1);
@@ -198,7 +199,8 @@ void Optimizer::reset(bool reset_dynamic_speed_limits)
 
   noise_generator_.reset(settings_, isHolonomic());
   motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
-    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
+    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz,
+    settings_.clamp_raw_controls);
   motion_model_->clearCommandHistory();
   trajectory_validator_->initialize(
     parent_, name_ + ".TrajectoryValidator",
@@ -674,7 +676,8 @@ void Optimizer::setMotionModel(const std::string & motion_model_name)
     motion_model_ = motion_model_loader_->createSharedInstance(plugin_type);
     motion_model_->initialize(parameters_handler_, plugin_ns);
     motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
-      settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
+      settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz,
+      settings_.clamp_raw_controls);
   } catch (const pluginlib::PluginlibException & ex) {
     throw nav2_core::ControllerException(
             std::string("Failed to load motion model plugin '") + motion_model_name +
@@ -710,7 +713,8 @@ void Optimizer::setSpeedLimit(double speed_limit, bool percentage)
     }
   }
   motion_model_->setConstraints(settings_.constraints, settings_.model_dt,
-    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz);
+    settings_.model_delay_vx, settings_.model_delay_vy, settings_.model_delay_wz,
+    settings_.clamp_raw_controls);
 }
 
 models::Trajectories & Optimizer::getGeneratedTrajectories()

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -270,7 +270,7 @@ TEST(MotionModelTests, DelayReplayAllAxes)
   OmniMotionModel model;
 
   // Set model_dt, model_delay_vx, model_delay_vy, model_delay_wz = 0.05f, 0.10f, 0.10f, 0.15f;
-  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.10f, 0.15f);
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.10f, 0.15f, false);
 
   // Ring-buffer size of vx/vy/wz = 2/2/3 steps
   // After 3 pushes per axis the rings hold the most-recent 2/2/3 values.
@@ -307,7 +307,7 @@ TEST(MotionModelTests, DelayVyIgnoredOnDiffDrive)
   state.reset(8, 20);
 
   DiffDriveMotionModel model;
-  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.10f, 0.0f);
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.10f, 0.0f, false);
   model.pushCommandHistory(0.0f, 99.0f, 0.0f);
   model.pushCommandHistory(0.0f, 99.0f, 0.0f);
 
@@ -321,7 +321,7 @@ TEST(MotionModelTests, DelayClearCommandHistory)
   state.reset(8, 20);
 
   DiffDriveMotionModel model;
-  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.0f, 0.15f);
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.10f, 0.0f, 0.15f, false);
   model.pushCommandHistory(7.0f, 0.0f, 7.0f);
   model.clearCommandHistory();
   model.predict(state);
@@ -341,7 +341,7 @@ TEST(MotionModelTests, DelayZeroSkipsShift)
   state.cvx.setConstant(2.0f);
 
   DiffDriveMotionModel model;
-  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.0f, 0.0f);
+  model.setConstraints(unboundedConstraints(), 0.05f, 0.0f, 0.0f, 0.0f, false);
   EXPECT_NO_THROW(model.pushCommandHistory(123.0f, 0.0f, 0.0f));
   model.predict(state);
 

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -348,6 +348,38 @@ TEST(MotionModelTests, DelayZeroSkipsShift)
   EXPECT_TRUE(state.vx.isApproxToConstant(2.0f));
 }
 
+TEST(MotionModelTests, ClampRawControlsRewritesRawCommand)
+{
+  models::State state;
+  state.reset(1, 3);
+
+  // ax_max/ax_min/az_max = 1.0, so each step can only change velocity by
+  // model_dt * 1.0 = 1.0, well below the 5.0 raw commands set below
+  models::ControlConstraints tight_constraints{
+    100.0f, -100.0f, 100.0f, 100.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f};
+
+  OmniMotionModel model;
+  model.setConstraints(tight_constraints, 1.0f, 0.0f, 0.0f, 0.0f, true);
+
+  state.cvx.col(0).setConstant(5.0f);
+  state.cvx.col(1).setConstant(5.0f);
+  state.cwz.col(0).setConstant(5.0f);
+  state.cwz.col(1).setConstant(5.0f);
+
+  model.predict(state);
+
+  EXPECT_TRUE(state.vx.col(1).isApproxToConstant(1.0f));
+  EXPECT_TRUE(state.vx.col(2).isApproxToConstant(2.0f));
+  EXPECT_TRUE(state.wz.col(1).isApproxToConstant(1.0f));
+  EXPECT_TRUE(state.wz.col(2).isApproxToConstant(2.0f));
+
+  // clamp_raw_controls=true applies acceleration limits on the raw commands as well
+  EXPECT_TRUE(state.cvx.col(0).isApproxToConstant(1.0f));
+  EXPECT_TRUE(state.cvx.col(1).isApproxToConstant(2.0f));
+  EXPECT_TRUE(state.cwz.col(0).isApproxToConstant(1.0f));
+  EXPECT_TRUE(state.cwz.col(1).isApproxToConstant(2.0f));
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#6171 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Add a parameter to clamp the raw controls.

This solves an issue where clamping the raw controls with high `time_steps` leads to very noisy control signal.

Note: This is not the ideal solution, since it is probably missing the improvements made by #6072

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

Describe new parameter
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

See #6171 for replication

Without #6072 :
<img width="937" height="996" alt="tb_steps100_nolow_accel" src="https://github.com/user-attachments/assets/31b73150-dbc9-4e19-a362-dbf5be55b934" />

With #6072 and `clamp_raw_controls: true`:
<img width="937" height="996" alt="tb_steps100_clamp_true_2" src="https://github.com/user-attachments/assets/c058acd9-7daf-491b-8132-34309c173c2e" />

With #6072 and `clamp_raw_controls: false`:
<img width="937" height="996" alt="tb_steps100_clamp_false" src="https://github.com/user-attachments/assets/8cc9cdca-a91e-4ae1-9ec7-8f9d03dafed9" />

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
