### PR TITLE
[nav2_common] Fix missing cmake include

### DIFF
--- a/nav2_common/CMakeLists.txt
+++ b/nav2_common/CMakeLists.txt
@@ -22,6 +22,8 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+include(cmake/nav2_package.cmake)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_test REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)


### PR DESCRIPTION
If I try to do a clean build for `nav2_common` with testing enabled:

`colcon build --packages-up-to nav2_common --cmake-args -DBUILD_TESTING=ON`

then it throws the following error:

```
CMake Error at CMakeLists.txt:31 (nav2_add_pytest_test):
  Unknown CMake command "nav2_add_pytest_test".
```
I see that it is included in `nav2_common-extras.cmake` which is being added via CONFIG_EXTRAS so other packages receive it automatically via `find_package(nav2_common)` but I don't think it gets included in `nav2_common` itself.

I wonder why your CI is passing but I am guessing it gets masked by other packages that get built first?