### PR TITLE
[nav2_controller] First check if goal reached then calculate velocity

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -521,12 +521,12 @@ void ControllerServer::computeControl()
 
       updateGlobalPath();
 
-      computeAndPublishVelocity();
-
       if (isGoalReached()) {
         RCLCPP_INFO(get_logger(), "Reached the goal!");
         break;
       }
+
+      computeAndPublishVelocity();
 
       auto cycle_duration = this->now() - start_time;
       if (!loop_rate.sleep()) {

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -731,16 +731,6 @@ void ControllerServer::computeAndPublishVelocity()
 
   nav2_msgs::msg::TrackingFeedback current_tracking_feedback;
 
-  // Use the current robot pose's timestamp for the transformation
-  end_pose_.header.stamp = pose.header.stamp;
-
-  if (!nav2_util::transformPoseInTargetFrame(
-      end_pose_, transformed_end_pose_, *costmap_ros_->getTfBuffer(),
-      costmap_ros_->getGlobalFrameID(), transform_tolerance_))
-  {
-    throw nav2_core::ControllerTFError("Failed to transform end pose to global frame");
-  }
-
   if (current_path_.poses.size() >= 2) {
     double current_distance_to_goal = nav2_util::geometry_utils::euclidean_distance(
       pose, transformed_end_pose_);
@@ -911,6 +901,14 @@ bool ControllerServer::isGoalReached()
 
   if (!getRobotPose(pose)) {
     return false;
+  }
+
+  end_pose_.header.stamp = pose.header.stamp;
+  if (!nav2_util::transformPoseInTargetFrame(
+      end_pose_, transformed_end_pose_, *costmap_ros_->getTfBuffer(),
+      costmap_ros_->getGlobalFrameID(), transform_tolerance_))
+  {
+    throw nav2_core::ControllerTFError("Failed to transform end pose to global frame");
   }
 
   geometry_msgs::msg::Twist velocity = getThresholdedTwist(odom_sub_->getRawTwist());

--- a/nav2_controller/test/test_controller_server.cpp
+++ b/nav2_controller/test/test_controller_server.cpp
@@ -19,9 +19,52 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "nav2_core/controller_exceptions.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_controller/controller_server.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+class ControllerServerShim : public nav2_controller::ControllerServer
+{
+public:
+  using nav2_controller::ControllerServer::ControllerServer;
+
+  void setEndPoseFrame(const std::string & frame) {end_pose_.header.frame_id = frame;}
+  bool callIsGoalReached() {return isGoalReached();}
+  tf2_ros::Buffer & getTfBuffer() {return *costmap_ros_->getTfBuffer();}
+};
+
+TEST(ControllerServerTest, IsGoalReachedThrowsOnTfFailure)
+{
+  // aa
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("goal_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("controller_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("path_handler_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("filters", std::vector<std::string>{}),
+  });
+
+  auto server = std::make_shared<ControllerServerShim>(options);
+  ASSERT_EQ(
+    server->configure().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  geometry_msgs::msg::TransformStamped tf_msg;
+  tf_msg.header.stamp = server->now();
+  tf_msg.header.frame_id = "map";
+  tf_msg.child_frame_id = "base_link";
+  tf_msg.transform.rotation.w = 1.0;
+  server->getTfBuffer().setTransform(tf_msg, "test", true);
+
+  server->setEndPoseFrame("nonexistent_frame_xyz");
+  EXPECT_THROW(server->callIsGoalReached(), nav2_core::ControllerTFError);
+  server->cleanup();
+}
 
 TEST(ControllerServerTest, GoalCheckerPluginTypeException)
 {


### PR DESCRIPTION
Simply put, why are we calculating velocity if we have already reached the goal tolerances?

Let's consider this scenario:

- Robot moves along the path
- Goal checker is stateful
- Robot reaches the end of the path but still has an orientation offset to the goal pose
- There's a lethal cell that the robot would hit if it tries to rotate towards the goal pose
- However, the orientation offset is within the goal checker's yaw tolerance so the robot doesn't really need to rotate at all, goal should be considered as successfully achieved.

Now the problem is, currently controller server first calculates the velocity, and afterwards it checks if goal is reached. In the scenario above, this would result in a collision detection and controller would fail whereas in theory, it shouldn't really have mattered since we were already within the yaw tolerance.

If we instead first check whether we have reached the goal and only then calculate the velocity, then we will not have this unnecessary failure.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
