### PR TITLE
docs: update robot_base_frame port description for TruncatePathLocal BT node

### DIFF
--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -250,7 +250,7 @@
       <input_port name="input_path" type="nav_msgs::msg::Path">The original path to be truncated.</input_port>
       <input_port name="distance_forward" type="double" default="8.0">The trimming distance in forward direction. Set to -1 to search full path forward.</input_port>
       <input_port name="distance_backward" type="double" default="4.0">The trimming distance in backward direction.</input_port>
-      <input_port name="robot_base_frame" type="string">Robot base frame id.</input_port>
+      <input_port name="robot_base_frame" type="string">Robot base frame id. If not provided, uses the BT Navigator's `robot_base_frame` parameter value (`base_link` by default).</input_port>
       <input_port name="transform_tolerance" type="double" default="0.2">Robot pose lookup tolerance.</input_port>
       <input_port name="pose" type="geometry_msgs::msg::PoseStamped">Manually specified pose to be used alternatively to current robot pose.</input_port>
       <input_port name="angular_distance_weight" type="double" default="0.0">Weight of angular distance relative to positional distance when finding which path pose is closest to robot. Not applicable on paths without orientations assigned.</input_port>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | N/A |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

The recent docs commit https://github.com/ros-navigation/docs.nav2.org/pull/927 updates port description for TruncatePathLocal node that is not reflected in the current Groot XML file. So I'm updating this file to have the same data after the docs generation.
Description from the mentioned commit: `Robot base frame id. If not provided, uses the BT Navigator's ``robot_base_frame`` setting automatically.`

I'm using a slightly modified description to match the existing port descriptions in the XML for DistanceTraveled and RemovePassedGoals nodes:

https://github.com/ros-navigation/navigation2/blob/1129cb43086719d0e44f577be7a7ff70be3cd274/nav2_behavior_tree/nav2_tree_nodes.xml#L451-L454

They are almost identical, except for a small note about the default value.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
