### PR TITLE
Fix SMAC smoother footprint check 

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -30,7 +30,6 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/point.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_ros_common/node_utils.hpp"
 #include "tf2/utils.hpp"
@@ -122,7 +121,7 @@ protected:
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
   nav2_costmap_2d::Costmap2D * _costmap;
-  std::vector<geometry_msgs::msg::Point> _smoother_footprint;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> _costmap_ros;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   rclcpp::Clock::SharedPtr _clock;
   rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner2D")};

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -30,6 +30,7 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/point.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_ros_common/node_utils.hpp"
 #include "tf2/utils.hpp"
@@ -121,6 +122,7 @@ protected:
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
   nav2_costmap_2d::Costmap2D * _costmap;
+  std::vector<geometry_msgs::msg::Point> _smoother_footprint;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   rclcpp::Clock::SharedPtr _clock;
   rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner2D")};

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
@@ -62,6 +62,9 @@ void SmacPlanner2DT<NodeT>::configure(
   _logger = node->get_logger();
   _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
+  _smoother_footprint = costmap_ros->getUseRadius() ?
+    std::vector<geometry_msgs::msg::Point>() :
+    costmap_ros->getRobotFootprint();
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
 
@@ -331,7 +334,7 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
 #endif
 
   // Smooth plan
-  _smoother->smooth(plan, costmap, time_remaining);
+  _smoother->smooth(plan, costmap, time_remaining, _smoother_footprint);
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
@@ -62,9 +62,7 @@ void SmacPlanner2DT<NodeT>::configure(
   _logger = node->get_logger();
   _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
-  _smoother_footprint = costmap_ros->getUseRadius() ?
-    std::vector<geometry_msgs::msg::Point>() :
-    costmap_ros->getRobotFootprint();
+  _costmap_ros = costmap_ros;
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
 
@@ -334,7 +332,12 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
 #endif
 
   // Smooth plan
-  _smoother->smooth(plan, costmap, time_remaining, _smoother_footprint);
+  _smoother->smooth(
+  plan,
+  costmap,
+  time_remaining,
+  _costmap_ros->getUseRadius() ? std::vector<geometry_msgs::msg::Point>() :
+  _costmap_ros->getRobotFootprint());
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid_impl.hpp
@@ -557,7 +557,12 @@ nav_msgs::msg::Path SmacPlannerHybridT<NodeT>::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, costmap, time_remaining);
+    _smoother->smooth(
+      plan,
+      costmap,
+      time_remaining,
+      _costmap_ros->getUseRadius() ? std::vector<geometry_msgs::msg::Point>() :
+      _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_lattice_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_lattice_impl.hpp
@@ -508,7 +508,12 @@ nav_msgs::msg::Path SmacPlannerLatticeT<NodeT>::createPlan(
 
   // Smooth plan
   if (_smoother && num_iterations > 1) {
-    _smoother->smooth(plan, _costmap, time_remaining);
+    _smoother->smooth(
+      plan,
+      _costmap,
+      time_remaining,
+      _costmap_ros->getUseRadius() ? std::vector<geometry_msgs::msg::Point>() :
+      _costmap_ros->getRobotFootprint());
   }
 
 #ifdef BENCHMARK_TESTING

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -24,6 +24,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "ompl/base/StateSpace.h"
 #include "geometry_msgs/msg/point.hpp"
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
 
 namespace nav2_smac_planner
 {
@@ -205,6 +206,8 @@ protected:
   bool is_holonomic_, do_refinement_;
   MotionModel motion_model_;
   ompl::base::StateSpacePtr state_space_;
+  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+  footprint_checker_;
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -97,7 +97,9 @@ public:
   bool smooth(
     nav_msgs::msg::Path & path,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const double & max_time);
+    const double & max_time，
+    const nav2_costmap_2d::Footprint & footprint = nav2_costmap_2d::Footprint(),
+    const bool & use_radius = true);
 
 protected:
   /**
@@ -112,7 +114,9 @@ protected:
     nav_msgs::msg::Path & path,
     bool & reversing_segment,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const double & max_time);
+    const double & max_time,
+    const nav2_costmap_2d::Footprint & footprint,
+    const bool & use_radius);
 
   /**
    * @brief Get the field value for a given dimension

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -100,8 +100,7 @@ public:
     const nav2_costmap_2d::Costmap2D * costmap,
     const double & max_time,
     const std::vector<geometry_msgs::msg::Point> & footprint =
-    std::vector<geometry_msgs::msg::Point>(),
-    const bool & use_radius = true);
+    std::vector<geometry_msgs::msg::Point>());
 
 protected:
   /**
@@ -117,8 +116,7 @@ protected:
     bool & reversing_segment,
     const nav2_costmap_2d::Costmap2D * costmap,
     const double & max_time,
-    const std::vector<geometry_msgs::msg::Point> & footprint,
-    const bool & use_radius);
+    const std::vector<geometry_msgs::msg::Point> & footprint);
 
   /**
    * @brief Get the field value for a given dimension

--- a/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smoother.hpp
@@ -23,6 +23,7 @@
 #include "nav2_util/geometry_utils.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "ompl/base/StateSpace.h"
+#include "geometry_msgs/msg/point.hpp"
 
 namespace nav2_smac_planner
 {
@@ -97,8 +98,9 @@ public:
   bool smooth(
     nav_msgs::msg::Path & path,
     const nav2_costmap_2d::Costmap2D * costmap,
-    const double & max_time，
-    const nav2_costmap_2d::Footprint & footprint = nav2_costmap_2d::Footprint(),
+    const double & max_time,
+    const std::vector<geometry_msgs::msg::Point> & footprint =
+    std::vector<geometry_msgs::msg::Point>(),
     const bool & use_radius = true);
 
 protected:
@@ -115,7 +117,7 @@ protected:
     bool & reversing_segment,
     const nav2_costmap_2d::Costmap2D * costmap,
     const double & max_time,
-    const nav2_costmap_2d::Footprint & footprint,
+    const std::vector<geometry_msgs::msg::Point> & footprint,
     const bool & use_radius);
 
   /**

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -54,9 +54,8 @@ bool Smoother::smooth(
   nav_msgs::msg::Path & path,
   const nav2_costmap_2d::Costmap2D * costmap,
   const double & max_time,
-  const double & max_time,
-  const nav2_costmap_2d::Footprint & footprint = nav2_costmap_2d::Footprint(),
-  const bool & use_radius = true)
+  const std::vector<geometry_msgs::msg::Point> & footprint,
+  const bool & use_radius)
 {
   // by-pass path orientations approximation when skipping smac smoother
   if (max_its_ == 0) {
@@ -90,7 +89,8 @@ bool Smoother::smooth(
       const geometry_msgs::msg::Pose start_pose = curr_path_segment.poses.front().pose;
       const geometry_msgs::msg::Pose goal_pose = curr_path_segment.poses.back().pose;
       bool local_success =
-        smoothImpl(curr_path_segment, reversing_segment, costmap, time_remaining, 
+        smoothImpl(
+        curr_path_segment, reversing_segment, costmap, time_remaining,
         footprint, use_radius);
       success = success && local_success;
 
@@ -115,9 +115,8 @@ bool Smoother::smoothImpl(
   nav_msgs::msg::Path & path,
   bool & reversing_segment,
   const nav2_costmap_2d::Costmap2D * costmap,
-  const double & max_time，
   const double & max_time,
-  const nav2_costmap_2d::Footprint & footprint,
+  const std::vector<geometry_msgs::msg::Point> & footprint,
   const bool & use_radius)
 {
   steady_clock::time_point a = steady_clock::now();
@@ -192,21 +191,21 @@ bool Smoother::smoothImpl(
         return false;
       }
     }
-    
+
     if (costmap && !use_radius) {
       nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
 
-      nav2_costmap_2d::FootprintCollisionChecker<const nav2_costmap_2d::Costmap2D *>
-      footprint_checker(costmap);
+      nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+      footprint_checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
 
       for (const auto & pose : new_path.poses) {
         const double footprint_cost = footprint_checker.footprintCostAtPose(
-          pose.pose.position.x, 
-          pose.pose.position.y, 
-          f2f::getYaw(pose.pose.orientation), 
+          pose.pose.position.x,
+          pose.pose.position.y,
+          tf2::getYaw(pose.pose.orientation),
           footprint);
-        
-        if (footprint_cost >= nav2_costmap_2d::LETHAL_OBSTACLE) {
+
+        if (footprint_cost > MAX_NON_OBSTACLE_COST && footprint_cost != UNKNOWN_COST) {
           RCLCPP_DEBUG(
             rclcpp::get_logger("SmacPlannerSmoother"),
             "Smoothing process resulted in an infeasible footprint collision. "

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -25,7 +25,6 @@
 
 #include "nav2_smac_planner/smoother.hpp"
 #include "nav2_util/smoother_utils.hpp"
-#include "nav2_costmap_2d/footprint_collision_checker.hpp"
 
 namespace nav2_smac_planner
 {
@@ -168,45 +167,39 @@ bool Smoother::smoothImpl(
         setFieldByDim(new_path.poses[i], j, y_i);
         change += abs(y_i - y_i_org);
       }
-
-      // validate update is admissible, only checks cost if a valid costmap pointer is provided
-      float cost = 0.0;
-      if (costmap && footprint.empty()) {
-        costmap->worldToMap(
-          getFieldByDim(new_path.poses[i], 0),
-          getFieldByDim(new_path.poses[i], 1),
-          mx, my);
-        cost = static_cast<float>(costmap->getCost(mx, my));
-      }
-
-      if (cost > MAX_NON_OBSTACLE_COST && cost != UNKNOWN_COST) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("SmacPlannerSmoother"),
-          "Smoothing process resulted in an infeasible collision. "
-          "Returning the last path before the infeasibility was introduced.");
-        path = last_path;
-        nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
-        return false;
-      }
     }
 
-    if (costmap && !footprint.empty()) {
-      nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
+    // validate update is admissible, only checks cost if a valid costmap pointer is provided
+    if (costmap) {
+      nav2_util::updateApproximatePathOrientations(
+        new_path, reversing_segment, is_holonomic_);
 
-      nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
-      footprint_checker(const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
+      if (!footprint.empty()) {
+        footprint_checker_.setCostmap(
+          const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
+      }
 
-      for (const auto & pose : new_path.poses) {
-        const double footprint_cost = footprint_checker.footprintCostAtPose(
-          pose.pose.position.x,
-          pose.pose.position.y,
-          tf2::getYaw(pose.pose.orientation),
-          footprint);
+      for (unsigned int i = 1; i != path_size - 1; i++) {
+        float cost = 0.0;
 
-        if (footprint_cost > MAX_NON_OBSTACLE_COST && footprint_cost != UNKNOWN_COST) {
+        if (footprint.empty()) {
+          costmap->worldToMap(
+            getFieldByDim(new_path.poses[i], 0),
+            getFieldByDim(new_path.poses[i], 1),
+            mx, my);
+          cost = static_cast<float>(costmap->getCost(mx, my));
+        } else {
+          cost = static_cast<float>(footprint_checker_.footprintCostAtPose(
+            new_path.poses[i].pose.position.x,
+            new_path.poses[i].pose.position.y,
+            tf2::getYaw(new_path.poses[i].pose.orientation),
+            footprint));
+        }
+
+        if (cost > MAX_NON_OBSTACLE_COST && cost != UNKNOWN_COST) {
           RCLCPP_DEBUG(
             rclcpp::get_logger("SmacPlannerSmoother"),
-            "Smoothing process resulted in an infeasible footprint collision. "
+            "Smoothing process resulted in an infeasible collision. "
             "Returning the last path before the infeasibility was introduced.");
           path = last_path;
           nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -169,11 +169,11 @@ bool Smoother::smoothImpl(
       }
     }
 
+    nav2_util::updateApproximatePathOrientations(
+      new_path, reversing_segment, is_holonomic_);
+
     // validate update is admissible, only checks cost if a valid costmap pointer is provided
     if (costmap) {
-      nav2_util::updateApproximatePathOrientations(
-        new_path, reversing_segment, is_holonomic_);
-
       if (!footprint.empty()) {
         footprint_checker_.setCostmap(
           const_cast<nav2_costmap_2d::Costmap2D *>(costmap));
@@ -202,7 +202,6 @@ bool Smoother::smoothImpl(
             "Smoothing process resulted in an infeasible collision. "
             "Returning the last path before the infeasibility was introduced.");
           path = last_path;
-          nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
           return false;
         }
       }
@@ -218,7 +217,6 @@ bool Smoother::smoothImpl(
     smoothImpl(new_path, reversing_segment, costmap, max_time, footprint);
   }
 
-  nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
   path = new_path;
   return true;
 }

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -25,6 +25,7 @@
 
 #include "nav2_smac_planner/smoother.hpp"
 #include "nav2_util/smoother_utils.hpp"
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
 
 namespace nav2_smac_planner
 {
@@ -52,7 +53,10 @@ void Smoother::initialize(const double & min_turning_radius)
 bool Smoother::smooth(
   nav_msgs::msg::Path & path,
   const nav2_costmap_2d::Costmap2D * costmap,
-  const double & max_time)
+  const double & max_time,
+  const double & max_time,
+  const nav2_costmap_2d::Footprint & footprint = nav2_costmap_2d::Footprint(),
+  const bool & use_radius = true)
 {
   // by-pass path orientations approximation when skipping smac smoother
   if (max_its_ == 0) {
@@ -86,7 +90,8 @@ bool Smoother::smooth(
       const geometry_msgs::msg::Pose start_pose = curr_path_segment.poses.front().pose;
       const geometry_msgs::msg::Pose goal_pose = curr_path_segment.poses.back().pose;
       bool local_success =
-        smoothImpl(curr_path_segment, reversing_segment, costmap, time_remaining);
+        smoothImpl(curr_path_segment, reversing_segment, costmap, time_remaining, 
+        footprint, use_radius);
       success = success && local_success;
 
       // Enforce boundary conditions
@@ -110,7 +115,10 @@ bool Smoother::smoothImpl(
   nav_msgs::msg::Path & path,
   bool & reversing_segment,
   const nav2_costmap_2d::Costmap2D * costmap,
-  const double & max_time)
+  const double & max_time，
+  const double & max_time,
+  const nav2_costmap_2d::Footprint & footprint,
+  const bool & use_radius)
 {
   steady_clock::time_point a = steady_clock::now();
   rclcpp::Duration max_dur = rclcpp::Duration::from_seconds(max_time);
@@ -166,7 +174,7 @@ bool Smoother::smoothImpl(
 
       // validate update is admissible, only checks cost if a valid costmap pointer is provided
       float cost = 0.0;
-      if (costmap) {
+      if (costmap && use_radius) {
         costmap->worldToMap(
           getFieldByDim(new_path.poses[i], 0),
           getFieldByDim(new_path.poses[i], 1),
@@ -184,6 +192,31 @@ bool Smoother::smoothImpl(
         return false;
       }
     }
+    
+    if (costmap && !use_radius) {
+      nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
+
+      nav2_costmap_2d::FootprintCollisionChecker<const nav2_costmap_2d::Costmap2D *>
+      footprint_checker(costmap);
+
+      for (const auto & pose : new_path.poses) {
+        const double footprint_cost = footprint_checker.footprintCostAtPose(
+          pose.pose.position.x, 
+          pose.pose.position.y, 
+          f2f::getYaw(pose.pose.orientation), 
+          footprint);
+        
+        if (footprint_cost >= nav2_costmap_2d::LETHAL_OBSTACLE) {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("SmacPlannerSmoother"),
+            "Smoothing process resulted in an infeasible footprint collision. "
+            "Returning the last path before the infeasibility was introduced.");
+          path = last_path;
+          nav2_util::updateApproximatePathOrientations(path, reversing_segment, is_holonomic_);
+          return false;
+        }
+      }
+    }
 
     last_path = new_path;
   }
@@ -192,7 +225,7 @@ bool Smoother::smoothImpl(
   // but really puts the path quality over the top.
   if (do_refinement_ && refinement_ctr_ < refinement_num_) {
     refinement_ctr_++;
-    smoothImpl(new_path, reversing_segment, costmap, max_time);
+    smoothImpl(new_path, reversing_segment, costmap, max_time, footprint, use_radius);
   }
 
   nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -54,8 +54,7 @@ bool Smoother::smooth(
   nav_msgs::msg::Path & path,
   const nav2_costmap_2d::Costmap2D * costmap,
   const double & max_time,
-  const std::vector<geometry_msgs::msg::Point> & footprint,
-  const bool & use_radius)
+  const std::vector<geometry_msgs::msg::Point> & footprint)
 {
   // by-pass path orientations approximation when skipping smac smoother
   if (max_its_ == 0) {
@@ -91,7 +90,7 @@ bool Smoother::smooth(
       bool local_success =
         smoothImpl(
         curr_path_segment, reversing_segment, costmap, time_remaining,
-        footprint, use_radius);
+        footprint);
       success = success && local_success;
 
       // Enforce boundary conditions
@@ -116,8 +115,7 @@ bool Smoother::smoothImpl(
   bool & reversing_segment,
   const nav2_costmap_2d::Costmap2D * costmap,
   const double & max_time,
-  const std::vector<geometry_msgs::msg::Point> & footprint,
-  const bool & use_radius)
+  const std::vector<geometry_msgs::msg::Point> & footprint)
 {
   steady_clock::time_point a = steady_clock::now();
   rclcpp::Duration max_dur = rclcpp::Duration::from_seconds(max_time);
@@ -173,7 +171,7 @@ bool Smoother::smoothImpl(
 
       // validate update is admissible, only checks cost if a valid costmap pointer is provided
       float cost = 0.0;
-      if (costmap && use_radius) {
+      if (costmap && footprint.empty()) {
         costmap->worldToMap(
           getFieldByDim(new_path.poses[i], 0),
           getFieldByDim(new_path.poses[i], 1),
@@ -192,7 +190,7 @@ bool Smoother::smoothImpl(
       }
     }
 
-    if (costmap && !use_radius) {
+    if (costmap && !footprint.empty()) {
       nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);
 
       nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
@@ -224,7 +222,7 @@ bool Smoother::smoothImpl(
   // but really puts the path quality over the top.
   if (do_refinement_ && refinement_ctr_ < refinement_num_) {
     refinement_ctr_++;
-    smoothImpl(new_path, reversing_segment, costmap, max_time, footprint, use_radius);
+    smoothImpl(new_path, reversing_segment, costmap, max_time, footprint);
   }
 
   nav2_util::updateApproximatePathOrientations(new_path, reversing_segment, is_holonomic_);

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -248,7 +248,7 @@ TEST(SmootherTest, rejects_non_circular_footprint_collision)
     ASSERT_LT(footprint_cost, nav2_costmap_2d::LETHAL_OBSTACLE);
   }
 
-  const bool success = smoother.smooth(path, &costmap, 1.0);
+  const bool success = smoother.smooth(path, &costmap, 1.0, footprint, false);
 
   bool footprint_collision = false;
   for (const auto & path_pose : path.poses) {

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -248,7 +248,7 @@ TEST(SmootherTest, rejects_non_circular_footprint_collision)
     ASSERT_LT(footprint_cost, nav2_costmap_2d::LETHAL_OBSTACLE);
   }
 
-  const bool success = smoother.smooth(path, &costmap, 1.0, footprint, false);
+  const bool success = smoother.smooth(path, &costmap, 1.0, footprint);
 
   bool footprint_collision = false;
   for (const auto & path_pose : path.poses) {

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -17,7 +17,11 @@
 #include <string>
 #include <vector>
 #include <limits>
+#include <utility>
 
+#include "tf2/utils.hpp"
+#include "nav2_costmap_2d/footprint_collision_checker.hpp"
+#include "nav2_util/geometry_utils.hpp"
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
@@ -178,6 +182,89 @@ TEST(SmootherTest, test_full_smoother)
   EXPECT_NEAR(plan.poses.end()[-2].pose.orientation.w, 0.0, 1e-3);
 
   delete costmap;
+}
+
+TEST(SmootherTest, rejects_non_circular_footprint_collision)
+{
+  nav2_smac_planner::SmootherParams params;
+  params.tolerance_ = 2.0;
+  params.max_its_ = 1000;
+  params.w_data_ = 0.2;
+  params.w_smooth_ = 0.3;
+  params.do_refinement_ = false;
+  params.refinement_num_ = 0;
+  params.holonomic_ = false;
+
+  SmootherWrapper smoother(params);
+  smoother.initialize(0.4);
+
+  nav2_costmap_2d::Costmap2D costmap(
+    200, 200, 0.1, 0.0, 0.0, nav2_costmap_2d::FREE_SPACE);
+
+  nav2_costmap_2d::Footprint footprint;
+  for (const auto & coordinates : std::vector<std::pair<double, double>>{
+      {-0.6, -0.2}, {0.6, -0.2}, {0.6, 0.2}, {-0.6, 0.2}})
+  {
+    geometry_msgs::msg::Point point;
+    point.x = coordinates.first;
+    point.y = coordinates.second;
+    footprint.push_back(point);
+  }
+
+  // This obstacle is outside the original footprint, but intersects the
+  // rotated footprint after the corner is pulled inward by smoothing.
+  costmap.setCost(31, 117, nav2_costmap_2d::LETHAL_OBSTACLE);
+
+  nav_msgs::msg::Path path;
+  geometry_msgs::msg::PoseStamped pose;
+
+  for (unsigned int i = 0; i <= 5; ++i) {
+    pose.pose.position.x = 2.0;
+    pose.pose.position.y = 2.0 + 2.0 * i;
+    pose.pose.orientation =
+      nav2_util::geometry_utils::orientationAroundZAxis(
+      i == 5 ? 0.0 : M_PI_2);
+    path.poses.push_back(pose);
+  }
+
+  for (unsigned int i = 1; i <= 6; ++i) {
+    pose.pose.position.x = 2.0 + 2.0 * i;
+    pose.pose.position.y = 12.0;
+    pose.pose.orientation =
+      nav2_util::geometry_utils::orientationAroundZAxis(0.0);
+    path.poses.push_back(pose);
+  }
+
+  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+  footprint_checker(&costmap);
+
+  // Prove the test starts from a collision-free path.
+  for (const auto & path_pose : path.poses) {
+    const double footprint_cost = footprint_checker.footprintCostAtPose(
+      path_pose.pose.position.x,
+      path_pose.pose.position.y,
+      tf2::getYaw(path_pose.pose.orientation),
+      footprint);
+    ASSERT_LT(footprint_cost, nav2_costmap_2d::LETHAL_OBSTACLE);
+  }
+
+  const bool success = smoother.smooth(path, &costmap, 1.0);
+
+  bool footprint_collision = false;
+  for (const auto & path_pose : path.poses) {
+    const double footprint_cost = footprint_checker.footprintCostAtPose(
+      path_pose.pose.position.x,
+      path_pose.pose.position.y,
+      tf2::getYaw(path_pose.pose.orientation),
+      footprint);
+    footprint_collision =
+      footprint_collision ||
+      footprint_cost >= nav2_costmap_2d::LETHAL_OBSTACLE;
+  }
+
+  // A smoother must reject and roll back an update that creates a collision.
+  EXPECT_FALSE(success);
+  EXPECT_FALSE(footprint_collision);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -95,7 +95,7 @@ TEST(SmootherTest, test_full_smoother)
 
   std::unique_ptr<nav2_smac_planner::GridCollisionChecker> checker =
     std::make_unique<nav2_smac_planner::GridCollisionChecker>(costmap_ros, size_theta, node);
-  checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
+  checker->setFootprint(std::vector<geometry_msgs::msg::Point>(), true, 0.0);
 
   auto dummy_cancel_checker = []() {
       return false;
@@ -201,9 +201,9 @@ TEST(SmootherTest, rejects_non_circular_footprint_collision)
   nav2_costmap_2d::Costmap2D costmap(
     200, 200, 0.1, 0.0, 0.0, nav2_costmap_2d::FREE_SPACE);
 
-  nav2_costmap_2d::Footprint footprint;
+  std::vector<geometry_msgs::msg::Point> footprint;
   for (const auto & coordinates : std::vector<std::pair<double, double>>{
-      {-0.6, -0.2}, {0.6, -0.2}, {0.6, 0.2}, {-0.6, 0.2}})
+    {-0.6, -0.2}, {0.6, -0.2}, {0.6, 0.2}, {-0.6, 0.2}})
   {
     geometry_msgs::msg::Point point;
     point.x = coordinates.first;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5330  |
| Primary OS tested on | Ubuntu24.04 |
| Robotic platform tested on | Unit test |
| Does this PR contain AI generated software? | Only for code to reproduce the regression test, also for debugging missing `#include` |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
- Fixes #5330 : SMAC smoothing needs to account for non circular footprints
(Note on scope proposed in the original issue:  this pr does not try to redesign the smoother to retain "true" orientation information or enforce min-turning-radius feasibility during smoothing. The goal here is fixing the immediate false-negative collision case for non-circular footprints, preserving existing smoother structure.)
- Adds regression test: given safe footprint, SMAC Smoothing will not cause false collision and report unsafe

Code change: 
- Extended (in `nav2_smac_planner/include/nav2_smac_planner/smoother.hpp`) `Smoother::smooth()` and `Smoother::smoothImpl()` to optionally accept `footprint` and `use_radius` (whether bot is radius based or not)
- Extended logic (in `nav2_smac_planner/src/smoother.cpp`): kept original centre-cell cost check for circular footprint; added a non circular footprint validation path if `costmap` is a valid pointer  && `!use_radius`
 
## Description of documentation updates required from your changes
No updates required. This is only bug fix. 

## Description of how this change was tested

The test isolates the smoother's own collision-validation behavior:

- Start with a footprint-valid path validated by `footprint_checker.footprintCostAtPose()` to be safe
- Checks whether smoothing itself can introduce a footprint collision and whether that update is rejected
- Scenario: a rectangular non-circular footprint, an obstacle placed so that the original path is valid (see **Test Details** at the end). After smoothing, the corner is pulled inward, the bot centre remains in a free cell, but the rectangular footprint overlaps the obstacle
- Expected: SMAC smoother detects the footprint collision, roll back to the previous valid path, returns `false`.
- Previously: smoother only checked the centre cell cost, so it returned success and accepted the colliding smoothed path

---

## Future work that may be required in bullet points
no know follow up work 
#### Test Details & Results
To visualize the footprint geometry a bit, r denotes the robot centre, `
```text 
1.2m * 0.4m
        [===========]
        [     r     ]
        [===========]
              ^
            center
X is our obstacle in the following landscape

y
^
| 12m    r----r----r----r----r----r
|        |
|        |     X  obstacle around (3.1, 11.7), not to scale
|        |
| 10m    r
|        |
|  8m    r
|        |
|  6m    r
|        |
|  4m    r
|        |
|  2m    r
|
+--------+----+----+----+----+----+----> x
        2m   4m   6m   8m  10m  12m  14m
```
To reproduce the regression test:

```bash
cd <nav2_ws>

git -C src/navigation2 fetch https://github.com/MobiusRoamer/navigation2.git fix/smac-smoother-footprint-5330
git -C src/navigation2 switch -C test-smac-smoother-footprint FETCH_HEAD

```
then (replace --packages-select with --packages-up-to nav2_smac_planner if dependencies not installed yet)
```text
colcon build \
  --symlink-install \
  --packages-select nav2_smac_planner \
  --cmake-args -DBUILD_TESTING=ON

source install/setup.bash

./build/nav2_smac_planner/test/test_smoother \
  --gtest_filter='SmootherTest.rejects_non_circular_footprint_collision'
```

Does this fit with the original scope? Let me know if more changes are needed or if you would like to see additional testing  / screenshot from the local run
#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
