### PR TITLE
Harden dock database file parsing

### DIFF
--- a/nav2_docking/opennav_docking/include/opennav_docking/utils.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/utils.hpp
@@ -61,48 +61,55 @@ inline bool parseDockFile(
     return false;
   }
 
-  auto yaml_docks = yaml_file["docks"];
-  Dock curr_dock;
-  for (const auto & yaml_dock : yaml_docks) {
-    std::string dock_name = yaml_dock.first.as<std::string>();
-    const YAML::Node & dock_attribs = yaml_dock.second;
+  try {
+    auto yaml_docks = yaml_file["docks"];
+    for (const auto & yaml_dock : yaml_docks) {
+      std::string dock_name = yaml_dock.first.as<std::string>();
+      const YAML::Node & dock_attribs = yaml_dock.second;
+      Dock curr_dock;
 
-    curr_dock.frame = "map";
-    if (dock_attribs["frame"]) {
-      curr_dock.frame = dock_attribs["frame"].as<std::string>();
-    }
+      curr_dock.frame = "map";
+      if (dock_attribs["frame"]) {
+        curr_dock.frame = dock_attribs["frame"].as<std::string>();
+      }
 
-    if (!dock_attribs["type"]) {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Dock database (%s) entries do not contain 'type'.", yaml_filepath.c_str());
-      return false;
-    }
-    curr_dock.type = dock_attribs["type"].as<std::string>();
+      if (!dock_attribs["type"]) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "Dock database (%s) entries do not contain 'type'.", yaml_filepath.c_str());
+        return false;
+      }
+      curr_dock.type = dock_attribs["type"].as<std::string>();
 
-    if (!dock_attribs["pose"]) {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Dock database (%s) entries do not contain 'pose'.", yaml_filepath.c_str());
-      return false;
-    }
-    std::vector<double> pose_arr = dock_attribs["pose"].as<std::vector<double>>();
-    if (pose_arr.size() != 3u) {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Dock database (%s) entries do not contain pose of size 3.", yaml_filepath.c_str());
-      return false;
-    }
-    curr_dock.pose.position.x = pose_arr[0];
-    curr_dock.pose.position.y = pose_arr[1];
-    curr_dock.pose.orientation = orientationAroundZAxis(pose_arr[2]);
+      if (!dock_attribs["pose"]) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "Dock database (%s) entries do not contain 'pose'.", yaml_filepath.c_str());
+        return false;
+      }
+      std::vector<double> pose_arr = dock_attribs["pose"].as<std::vector<double>>();
+      if (pose_arr.size() != 3u) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "Dock database (%s) entries do not contain pose of size 3.", yaml_filepath.c_str());
+        return false;
+      }
+      curr_dock.pose.position.x = pose_arr[0];
+      curr_dock.pose.position.y = pose_arr[1];
+      curr_dock.pose.orientation = orientationAroundZAxis(pose_arr[2]);
 
-    if (dock_attribs["id"]) {
-      curr_dock.id = dock_attribs["id"].as<std::string>();
-    }
+      if (dock_attribs["id"]) {
+        curr_dock.id = dock_attribs["id"].as<std::string>();
+      }
 
-    // Insert into dock instance database
-    dock_db.emplace(dock_name, curr_dock);
+      // Insert into dock instance database
+      dock_db.emplace(dock_name, curr_dock);
+    }
+  } catch (const YAML::Exception & e) {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Dock database (%s) is malformed: %s.", yaml_filepath.c_str(), e.what());
+    return false;
   }
 
   return true;

--- a/nav2_docking/opennav_docking/src/dock_database.cpp
+++ b/nav2_docking/opennav_docking/src/dock_database.cpp
@@ -189,21 +189,18 @@ bool DockDatabase::getDockInstances(const nav2::LifecycleNode::SharedPtr & node)
 {
   // Attempt to obtain docks from separate file
   std::string dock_filepath;
+  bool dock_filepath_given = false;
   try {
     dock_filepath = node->declare_or_get_parameter<std::string>("dock_database");
-    RCLCPP_INFO(
-      node->get_logger(), "Loading dock from database file  %s.", dock_filepath.c_str());
-    try {
-      return utils::parseDockFile(dock_filepath, node, dock_instances_);
-    } catch (YAML::BadConversion & e) {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Dock database (%s) is malformed: %s.", dock_filepath.c_str(), e.what());
-      return false;
-    }
-    return true;
+    dock_filepath_given = true;
   } catch (...) {
     // pass
+  }
+
+  if (dock_filepath_given) {
+    RCLCPP_INFO(
+      node->get_logger(), "Loading dock from database file  %s.", dock_filepath.c_str());
+    return utils::parseDockFile(dock_filepath, node, dock_instances_);
   }
 
   // Attempt to obtain docks from parameter file

--- a/nav2_docking/opennav_docking/test/dock_files/test_dock_file.yaml
+++ b/nav2_docking/opennav_docking/test/dock_files/test_dock_file.yaml
@@ -3,7 +3,7 @@ docks:
     type: "dockv3"
     frame: "mapA"
     pose: [0.3, 0.3, 0.0]
+    id: "1"
   dock2:
     type: "dockv1"
     pose: [0.0, 0.0, 0.4]
-    id: "2"

--- a/nav2_docking/opennav_docking/test/test_dock_database.cpp
+++ b/nav2_docking/opennav_docking/test/test_dock_database.cpp
@@ -174,6 +174,16 @@ TEST(DatabaseTests, reloadDbService)
     rclcpp::spin_until_future_complete(node, result2, 2s),
     rclcpp::FutureReturnCode::SUCCESS);
   EXPECT_FALSE(result2.get()->success);
+
+  auto request3 = std::make_shared<nav2_msgs::srv::ReloadDockDatabase::Request>();
+  request3->filepath = nav2::get_package_share_directory("opennav_docking") +
+    "/dock_files/test_dock_bad_conversion_file.yaml";
+  EXPECT_TRUE(client->wait_for_service(1s));
+  auto result3 = client->async_call(request3);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(node, result3, 2s),
+    rclcpp::FutureReturnCode::SUCCESS);
+  EXPECT_FALSE(result3.get()->success);
 }
 
 TEST(DatabaseTests, reloadDbMutexLocked)

--- a/nav2_docking/opennav_docking/test/test_utils.cpp
+++ b/nav2_docking/opennav_docking/test/test_utils.cpp
@@ -106,8 +106,8 @@ TEST(UtilsTests, parseDockFile)
   EXPECT_EQ(db["dock2"].pose.position.x, 0.0);
   EXPECT_EQ(db["dock2"].pose.position.y, 0.0);
   EXPECT_NE(db["dock2"].pose.orientation.w, 1.0);
-  EXPECT_EQ(db["dock1"].id, std::string(""));
-  EXPECT_EQ(db["dock2"].id, std::string("2"));
+  EXPECT_EQ(db["dock1"].id, std::string("1"));
+  EXPECT_EQ(db["dock2"].id, std::string(""));
 }
 
 TEST(UtilsTests, parseDockFile2)
@@ -133,6 +133,10 @@ TEST(UtilsTests, parseDockFile2)
   // Test with a file that has wring pose array size
   filepath = nav2::get_package_share_directory("opennav_docking") +
     "/dock_files/test_dock_bad_pose_file.yaml";
+  EXPECT_FALSE(utils::parseDockFile(filepath, node, db));
+
+  filepath = nav2::get_package_share_directory("opennav_docking") +
+    "/dock_files/test_dock_bad_conversion_file.yaml";
   EXPECT_FALSE(utils::parseDockFile(filepath, node, db));
 }
 


### PR DESCRIPTION
## Summary
- Reset each dock object while parsing dock database files so optional fields such as `id` do not carry over from a previous entry.
- Convert YAML conversion failures inside `parseDockFile()` into a `false` result so malformed files fail cleanly during startup and `reload_database` calls.

## Testing
- `git diff --check`
- GitHub Actions: lint, pre-commit, semgrep, XML BT validation, `build-docker (jazzy)`, and `build-docker (kilted)` passed.
- CircleCI: `core_build`, `algorithm_build`, `system_build`, and `release_test` passed.

Not run locally: `opennav_docking` tests. This Windows workspace does not have `colcon` or `cmake` installed.

## CI notes
- Current visible checks are passing or neutral as of 2026-07-10 14:40 CST. The earlier `raw.githubusercontent.com` HTTP 429 and CircleCI `release_test` failures passed on rerun.