### PR TITLE
Fix various compilation issues with clang

### DIFF
--- a/nav2_behavior_tree/test/test_loop_rate.cpp
+++ b/nav2_behavior_tree/test/test_loop_rate.cpp
@@ -171,7 +171,7 @@ TEST_F(LoopRateTest, test_ros_time_with_sim_time)
   nav2_behavior_tree::LoopRate rate(period, tree_.get(), clock);
 
   // Advance sim time past the period from a separate thread
-  std::thread advancer([rcl_clock, t0]() {
+  std::thread advancer([rcl_clock]() {
       std::this_thread::sleep_for(10ms);
       auto ret = rcl_set_ros_time_override(rcl_clock, t0 + RCL_MS_TO_NS(60));
       EXPECT_EQ(RCL_RET_OK, ret);
@@ -202,7 +202,7 @@ TEST_F(LoopRateTest, test_ros_time_sim_time_does_not_overshoot)
   nav2_behavior_tree::LoopRate rate(period, tree_.get(), clock);
 
   // Advance sim time by exactly the period after a short wall delay
-  std::thread advancer([rcl_clock, t0]() {
+  std::thread advancer([rcl_clock]() {
       std::this_thread::sleep_for(5ms);
       auto ret = rcl_set_ros_time_override(rcl_clock, t0 + RCL_MS_TO_NS(100));
       EXPECT_EQ(RCL_RET_OK, ret);
@@ -269,7 +269,7 @@ TEST_F(LoopRateTest, test_consecutive_sleeps_maintain_cadence_sim_time)
 
   // Advance sim time in a background thread at 10x real time:
   // each iteration advances 50ms sim time every 5ms wall time
-  std::thread advancer([rcl_clock, t0, iterations]() {
+  std::thread advancer([rcl_clock]() {
       for (int i = 1; i <= iterations; ++i) {
         std::this_thread::sleep_for(5ms);
         auto ret = rcl_set_ros_time_override(

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -66,14 +66,14 @@ public:
     std::string error_msg;
     if (command->target.y != 0.0 || command->target.z != 0.0) {
       error_msg = "DrivingOnHeading in Y and Z not supported, will only move in X.";
-      RCLCPP_INFO(this->logger_, error_msg.c_str());
+      RCLCPP_INFO(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::INVALID_INPUT, error_msg};
     }
 
     // Ensure that both the speed and direction have the same sign
     if (!((command->target.x > 0.0) == (command->speed > 0.0)) ) {
       error_msg = "Speed and command sign did not match";
-      RCLCPP_ERROR(this->logger_, error_msg.c_str());
+      RCLCPP_ERROR(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::INVALID_INPUT, error_msg};
     }
 
@@ -89,7 +89,7 @@ public:
         this->transform_tolerance_))
     {
       error_msg = "Initial robot pose is not available.";
-      RCLCPP_ERROR(this->logger_, error_msg.c_str());
+      RCLCPP_ERROR(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::TF_ERROR, error_msg};
     }
 
@@ -107,7 +107,7 @@ public:
       this->stopRobot();
       std::string error_msg =
         "Exceeded time allowance before reaching the DriveOnHeading goal - Exiting DriveOnHeading";
-      RCLCPP_WARN(this->logger_, error_msg.c_str());
+      RCLCPP_WARN(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::TIMEOUT, error_msg};
     }
 
@@ -117,7 +117,7 @@ public:
         this->transform_tolerance_))
     {
       std::string error_msg = "Current robot pose is not available.";
-      RCLCPP_ERROR(this->logger_, error_msg.c_str());
+      RCLCPP_ERROR(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::TF_ERROR, error_msg};
     }
 
@@ -168,7 +168,7 @@ public:
     if (!isCollisionFree(distance, cmd_vel->twist, pose2d)) {
       this->stopRobot();
       std::string error_msg = "Collision Ahead - Exiting DriveOnHeading";
-      RCLCPP_WARN(this->logger_, error_msg.c_str());
+      RCLCPP_WARN(this->logger_, "%s", error_msg.c_str());
       return ResultStatus{Status::FAILED, ActionT::Result::COLLISION_AHEAD, error_msg};
     }
 

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -279,7 +279,7 @@ protected:
         case Status::FAILED:
           result->error_code = on_cycle_update_result.error_code;
           result->error_msg = behavior_name_ + " failed:" + on_cycle_update_result.error_msg;
-          RCLCPP_WARN(logger_, result->error_msg.c_str());
+          RCLCPP_WARN(logger_, "%s", result->error_msg.c_str());
           result->total_elapsed_time = clock_->now() - start_time;
           onActionCompletion(result);
           action_server_->terminate_current(result);

--- a/nav2_behaviors/plugins/back_up.cpp
+++ b/nav2_behaviors/plugins/back_up.cpp
@@ -21,7 +21,7 @@ ResultStatus BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> comma
 {
   if (command->target.y != 0.0 || command->target.z != 0.0) {
     std::string error_msg = "Backing up in Y and Z not supported, will only move in X.";
-    RCLCPP_INFO(logger_, error_msg.c_str());
+    RCLCPP_INFO(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, BackUpActionResult::INVALID_INPUT, error_msg};
   }
 
@@ -38,7 +38,7 @@ ResultStatus BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> comma
       transform_tolerance_))
   {
     std::string error_msg = "Initial robot pose is not available.";
-    RCLCPP_ERROR(logger_, error_msg.c_str());
+    RCLCPP_ERROR(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, BackUpActionResult::TF_ERROR, error_msg};
   }
 

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -63,7 +63,7 @@ ResultStatus Spin::onRun(const std::shared_ptr<const SpinActionGoal> command)
       transform_tolerance_))
   {
     std::string error_msg = "Current robot pose is not available.";
-    RCLCPP_ERROR(logger_, error_msg.c_str());
+    RCLCPP_ERROR(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, SpinActionResult::TF_ERROR, error_msg};
   }
 
@@ -88,7 +88,7 @@ ResultStatus Spin::onCycleUpdate()
   if (time_remaining.seconds() < 0.0 && command_time_allowance_.seconds() > 0.0) {
     stopRobot();
     std::string error_msg = "Exceeded time allowance before reaching the Spin goal - Exiting Spin";
-    RCLCPP_WARN(logger_, error_msg.c_str());
+    RCLCPP_WARN(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, SpinActionResult::TIMEOUT, error_msg};
   }
 
@@ -98,7 +98,7 @@ ResultStatus Spin::onCycleUpdate()
       transform_tolerance_))
   {
     std::string error_msg = "Current robot pose is not available.";
-    RCLCPP_ERROR(logger_, error_msg.c_str());
+    RCLCPP_ERROR(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, SpinActionResult::TF_ERROR, error_msg};
   }
 
@@ -134,7 +134,7 @@ ResultStatus Spin::onCycleUpdate()
   if (!isCollisionFree(relative_yaw_, cmd_vel->twist, pose)) {
     stopRobot();
     std::string error_msg = "Collision Ahead - Exiting Spin";
-    RCLCPP_WARN(logger_, error_msg.c_str());
+    RCLCPP_WARN(logger_, "%s", error_msg.c_str());
     return ResultStatus{Status::FAILED, SpinActionResult::COLLISION_AHEAD, error_msg};
   }
 

--- a/nav2_controller/plugins/test/progress_checker.cpp
+++ b/nav2_controller/plugins/test/progress_checker.cpp
@@ -202,16 +202,16 @@ TEST(SimpleProgressChecker, required_movement_radius) {
   // translation at required_movement_radius one axis
   EXPECT_FALSE(checkMacro(progress_checker, 0, 0, 0, radius, 0, 0, twice_time_allowance_ms));
   EXPECT_FALSE(checkMacro(progress_checker, 0, 0, 0, 0, radius, 0, twice_time_allowance_ms));
-  constexpr auto axis = radius / std::sqrt(2);
+  auto axis = radius / std::sqrt(2);
   EXPECT_FALSE(checkMacro(progress_checker, 0, 0, 0, axis, axis, 0, twice_time_allowance_ms));
   // translation at required_movement_radius both axes
 
   // translation above required_movement_radius one axis
-  constexpr auto above = radius + std::numeric_limits<double>::epsilon();
+  auto above = radius + std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(checkMacro(progress_checker, 0, 0, 0, above, 0, 0, twice_time_allowance_ms));
   EXPECT_TRUE(checkMacro(progress_checker, 0, 0, 0, 0, above, 0, twice_time_allowance_ms));
   // translation at required_movement_radius both axes
-  constexpr auto above_axis = axis + std::numeric_limits<double>::epsilon();
+  auto above_axis = axis + std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(
     checkMacro(progress_checker, 0, 0, 0, above_axis, above_axis, 0, twice_time_allowance_ms));
 }

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -249,7 +249,7 @@ bool ClearCostmapService::clearEntirely(const std::vector<std::string> & plugins
 
     bool result = validateAndClearPlugins(
       plugins, layers,
-      [this](std::shared_ptr<CostmapLayer> & layer) {
+      [](const std::shared_ptr<CostmapLayer> & layer) {
         layer->resetMap(0, 0, layer->getSizeInCellsX(), layer->getSizeInCellsY());
       },
       "clear costmap entirely");

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -85,12 +85,12 @@ public:
   /**
   * @brief Registers callbacks for dynamic parameter handling.
   */
-  void activate();
+  void activate() override;
 
   /**
   * @brief Resets callbacks for dynamic parameter handling.
   */
-  void deactivate();
+  void deactivate() override;
 
 protected:
   /**

--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -102,7 +102,7 @@ add_library(mppi_critics SHARED
   src/critics/twirling_critic.cpp
   src/critics/velocity_deadband_critic.cpp
 )
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND APPLE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # Apple Clang: use C++20 and optimization, omit -fconcepts
     target_compile_features(mppi_critics PUBLIC cxx_std_20)
     target_compile_options(mppi_critics PUBLIC -O3)

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/parameters_handler.hpp
@@ -266,7 +266,7 @@ void ParametersHandler::setParamCallback(
     };
 
   auto static_callback =
-    [this, &setting, name](
+    [name](
     const rclcpp::Parameter & param, rcl_interfaces::msg::SetParametersResult & result) {
       std::string reason = "Rejected change to static parameter: " + std::to_string(param);
       result.successful = false;

--- a/nav2_mppi_controller/src/parameters_handler.cpp
+++ b/nav2_mppi_controller/src/parameters_handler.cpp
@@ -85,7 +85,7 @@ ParametersHandler::validateParameterUpdatesCallback(
   }
 
   if (!result.successful) {
-    RCLCPP_ERROR(logger_, result.reason.c_str());
+    RCLCPP_ERROR(logger_, "%s", result.reason.c_str());
   }
   return result;
 }

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -310,8 +310,8 @@ TEST(UtilsTests, findPathCosts)
     }
   }
 
-  path.x(1) = 999999999;  // OFF COSTMAP
-  path.y(1) = 999999999;
+  path.x(1) = 9999999;  // OFF COSTMAP
+  path.y(1) = 9999999;
   path.x(10) = 1.5;  // IN LETHAL
   path.y(10) = 1.5;
   path.x(20) = 4.2;  // IN INFLATED

--- a/nav2_route/test/test_operations.cpp
+++ b/nav2_route/test/test_operations.cpp
@@ -136,7 +136,7 @@ TEST(OperationsManagerTest, test_processing_speed_on_status)
   nav2_msgs::msg::SpeedLimit my_msg;
   auto sub = node->create_subscription<nav2_msgs::msg::SpeedLimit>(
     "speed_limit",
-    [&, this](nav2_msgs::msg::SpeedLimit msg) {got_msg = true; my_msg = msg;});
+    [&](nav2_msgs::msg::SpeedLimit msg) {got_msg = true; my_msg = msg;});
 
   Node node2;
   DirectionalEdge enter;

--- a/nav2_route/test/test_path_converter.cpp
+++ b/nav2_route/test/test_path_converter.cpp
@@ -39,7 +39,7 @@ TEST(PathConverterTest, test_path_converter_api)
 
   nav_msgs::msg::Path path_msg;
   auto sub = node->create_subscription<nav_msgs::msg::Path>(
-    "plan", [&, this](nav_msgs::msg::Path msg) {path_msg = msg;});
+    "plan", [&](nav_msgs::msg::Path msg) {path_msg = msg;});
 
   PathConverter converter;
   converter.configure(node);

--- a/nav2_smoother/src/nav2_smoother.cpp
+++ b/nav2_smoother/src/nav2_smoother.cpp
@@ -311,43 +311,43 @@ void SmootherServer::smoothPlan()
     action_server_->succeeded_current(result);
   } catch (nav2_core::InvalidSmoother & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::INVALID_SMOOTHER;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmootherTimedOut & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::TIMEOUT;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmoothedPathInCollision & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::SMOOTHED_PATH_IN_COLLISION;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::FailedToSmoothPath & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::FAILED_TO_SMOOTH_PATH;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::InvalidPath & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::INVALID_PATH;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmootherException & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::UNKNOWN;
     action_server_->terminate_current(result);
     return;
   } catch (std::exception & ex) {
     result->error_msg = ex.what();
-    RCLCPP_ERROR(this->get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(this->get_logger(), "%s", result->error_msg.c_str());
     result->error_code = ActionResult::UNKNOWN;
     action_server_->terminate_current(result);
     return;

--- a/nav2_util/test/regression/map_bresenham_2d.cpp
+++ b/nav2_util/test/regression/map_bresenham_2d.cpp
@@ -148,7 +148,7 @@ TEST(map_2d, bresenham2DSamePoint)
   const unsigned int sz_y = 60;
   const unsigned int max_length = 60;
   const unsigned int min_length = 0;
-  MapTest mt(sz_x, sz_y, 0.1);
+  MapTest mt(sz_x, sz_y, 0);
   MapAction ma(mt.getMap(), mt.getSize());
 
   // Initial point

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -195,7 +195,7 @@ void WaypointFollower::followWaypointsHandler(
     result->error_msg =
       "Empty vector of waypoints passed to waypoint following "
       "action potentially due to conversation failure or empty request.";
-    RCLCPP_ERROR(get_logger(), result->error_msg.c_str());
+    RCLCPP_ERROR(get_logger(), "%s", result->error_msg.c_str());
     action_server->terminate_current(result);
     return;
   }
@@ -228,7 +228,7 @@ void WaypointFollower::followWaypointsHandler(
         result->error_msg =
           "Empty vector of Waypoints passed to waypoint following logic. "
           "Nothing to execute, returning with failure!";
-        RCLCPP_ERROR(get_logger(), result->error_msg.c_str());
+        RCLCPP_ERROR(get_logger(), "%s", result->error_msg.c_str());
         action_server->terminate_current(result);
         return;
       }
@@ -278,7 +278,7 @@ void WaypointFollower::followWaypointsHandler(
           "Failed to process waypoint " + std::to_string(goal_index) +
           " in waypoint list and stop on failure is enabled."
           " Terminating action.";
-        RCLCPP_WARN(get_logger(), result->error_msg.c_str());
+        RCLCPP_WARN(get_logger(), "%s", result->error_msg.c_str());
         action_server->terminate_current(result);
         current_goal_status_.error_code = 0;
         current_goal_status_.error_msg = "";
@@ -315,7 +315,7 @@ void WaypointFollower::followWaypointsHandler(
         result->error_msg =
           "Failed to execute task at waypoint " + std::to_string(goal_index) +
           " stop on failure is enabled. Terminating action.";
-        RCLCPP_WARN(get_logger(), result->error_msg.c_str());
+        RCLCPP_WARN(get_logger(), "%s", result->error_msg.c_str());
         action_server->terminate_current(result);
         current_goal_status_.error_code = 0;
         current_goal_status_.error_msg = "";
@@ -406,7 +406,7 @@ WaypointFollower::resultCallback(
       current_goal_status_.status = ActionStatus::UNKNOWN;
       current_goal_status_.error_code = nav2_msgs::action::FollowWaypoints::Result::UNKNOWN;
       current_goal_status_.error_msg = "Received an UNKNOWN result code from navigation action!";
-      RCLCPP_ERROR(get_logger(), current_goal_status_.error_msg.c_str());
+      RCLCPP_ERROR(get_logger(), "%s", current_goal_status_.error_msg.c_str());
       return;
   }
 }
@@ -420,7 +420,7 @@ WaypointFollower::goalResponseCallback(
     current_goal_status_.error_code = nav2_msgs::action::FollowWaypoints::Result::UNKNOWN;
     current_goal_status_.error_msg =
       "navigate_to_pose action client failed to send goal to server.";
-    RCLCPP_ERROR(get_logger(), current_goal_status_.error_msg.c_str());
+    RCLCPP_ERROR(get_logger(), "%s", current_goal_status_.error_msg.c_str());
   }
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | CI |
| Does this PR contain AI generated software? | No|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

This PR fixes various small compilation errors with clang
- The last argument to MapTest is the default cost value, not the resolution
- Many logging statements were incorrect
- I've removed some unused lambda captures
- std::sqrt is not constexpr until C++26 in clang
- some float constants were bigger than what could be represented without conversion loss

## Description of how this change was tested

I've compiled the code with clang & gcc on my PC

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
