### PR TITLE
Fixed future prediction of speed and pose

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -167,6 +167,31 @@ public:
   }
 
   /**
+   * @brief With input pose, speed find the vehicle's output pose at pred_dt in future
+   * @param pose pose of the robot
+   * @param speed speed 
+   * @param pred_dt time in future to predict the pose
+  */
+  virtual void predictFuture(geometry_msgs::msg::PoseStamped& pose, geometry_msgs::msg::Twist& speed, float pred_dt)
+  {
+    const bool is_holo = isHolonomic();
+    auto initial_yaw = static_cast<float>(tf2::getYaw(pose.pose.orientation));
+    auto yaw_cos = cosf(initial_yaw);
+    auto yaw_sin = sinf(initial_yaw);
+    auto dx = speed.linear.x * yaw_cos;
+    auto dy = speed.linear.x * yaw_sin;
+    if (is_holo) {
+      dx -= speed.linear.y * yaw_sin;
+      dy += speed.linear.y * yaw_cos;
+    }
+    pose.pose.position.x += dx*dt;
+    pose.pose.position.y += dy*dt;
+    initial_yaw += speed.angular.z * pred_dt;
+    tf2::Quaternion quat;
+    quat.setRPY(0.0, 0.0, initial_yaw);
+    pose.pose.orientation = quat;
+  }
+  /**
    * @brief Whether the motion model is holonomic, using Y axis
    * @return Bool If holonomic
    */

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -28,6 +28,8 @@
 #include "nav2_mppi_controller/models/constraints.hpp"
 
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/utils.hpp"
 
 namespace mppi
 {
@@ -169,27 +171,29 @@ public:
   /**
    * @brief With input pose, speed find the vehicle's output pose at pred_dt in future
    * @param pose pose of the robot
-   * @param speed speed 
+   * @param speed speed
    * @param pred_dt time in future to predict the pose
   */
-  virtual void predictFuture(geometry_msgs::msg::PoseStamped& pose, geometry_msgs::msg::Twist& speed, float pred_dt)
+  virtual void predictFuture(
+    geometry_msgs::msg::PoseStamped & pose,
+    geometry_msgs::msg::Twist & speed, float pred_dt)
   {
     const bool is_holo = isHolonomic();
     auto initial_yaw = static_cast<float>(tf2::getYaw(pose.pose.orientation));
     auto yaw_cos = cosf(initial_yaw);
     auto yaw_sin = sinf(initial_yaw);
-    auto dx = speed.linear.x * yaw_cos;
-    auto dy = speed.linear.x * yaw_sin;
+    auto dx = static_cast<float>(speed.linear.x) * yaw_cos;
+    auto dy = static_cast<float>(speed.linear.x) * yaw_sin;
     if (is_holo) {
       dx -= speed.linear.y * yaw_sin;
       dy += speed.linear.y * yaw_cos;
     }
-    pose.pose.position.x += dx*dt;
-    pose.pose.position.y += dy*dt;
+    pose.pose.position.x += dx * pred_dt;
+    pose.pose.position.y += dy * pred_dt;
     initial_yaw += speed.angular.z * pred_dt;
     tf2::Quaternion quat;
     quat.setRPY(0.0, 0.0, initial_yaw);
-    pose.pose.orientation = quat;
+    pose.pose.orientation = tf2::toMsg(quat);
   }
   /**
    * @brief Whether the motion model is holonomic, using Y axis

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -28,9 +28,8 @@
 #include "nav2_mppi_controller/models/constraints.hpp"
 
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "nav2_util/geometry_utils.hpp"
 #include "tf2/utils.hpp"
-
 namespace mppi
 {
 
@@ -191,9 +190,7 @@ public:
     pose.pose.position.x += dx * pred_dt;
     pose.pose.position.y += dy * pred_dt;
     initial_yaw += speed.angular.z * pred_dt;
-    tf2::Quaternion quat;
-    quat.setRPY(0.0, 0.0, initial_yaw);
-    pose.pose.orientation = tf2::toMsg(quat);
+    pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(initial_yaw);
   }
   /**
    * @brief Whether the motion model is holonomic, using Y axis

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -173,7 +173,7 @@ public:
    * @param speed speed
    * @param pred_dt time in future to predict the pose
   */
-  virtual void predictFuture(
+  virtual void predictPose(
     geometry_msgs::msg::PoseStamped & pose,
     const geometry_msgs::msg::Twist & speed, float pred_dt)
   {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -174,11 +174,11 @@ public:
    * @param pred_dt time in future to predict the pose
   */
   virtual void predictPose(
-    geometry_msgs::msg::PoseStamped & pose,
+    geometry_msgs::msg::Pose & pose,
     const geometry_msgs::msg::Twist & speed, float pred_dt)
   {
     const bool is_holo = isHolonomic();
-    auto initial_yaw = static_cast<float>(tf2::getYaw(pose.pose.orientation));
+    auto initial_yaw = static_cast<float>(tf2::getYaw(pose.orientation));
     auto yaw_cos = cosf(initial_yaw);
     auto yaw_sin = sinf(initial_yaw);
     auto dx = static_cast<float>(speed.linear.x) * yaw_cos;
@@ -187,10 +187,10 @@ public:
       dx -= speed.linear.y * yaw_sin;
       dy += speed.linear.y * yaw_cos;
     }
-    pose.pose.position.x += dx * pred_dt;
-    pose.pose.position.y += dy * pred_dt;
+    pose.position.x += dx * pred_dt;
+    pose.position.y += dy * pred_dt;
     initial_yaw += speed.angular.z * pred_dt;
-    pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(initial_yaw);
+    pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(initial_yaw);
   }
   /**
    * @brief Whether the motion model is holonomic, using Y axis

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -175,7 +175,7 @@ public:
   */
   virtual void predictFuture(
     geometry_msgs::msg::PoseStamped & pose,
-    geometry_msgs::msg::Twist & speed, float pred_dt)
+    const geometry_msgs::msg::Twist & speed, float pred_dt)
   {
     const bool is_holo = isHolonomic();
     auto initial_yaw = static_cast<float>(tf2::getYaw(pose.pose.orientation));

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -330,13 +330,10 @@ void Optimizer::prepare(
     // Predict the robot pose at 1*dt in future
     motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
-
-
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);
   costs_.setZero(settings_.batch_size);
   goal_ = goal;
-
   critics_data_.fail_flag = false;
   critics_data_.goal_checker = goal_checker;
   critics_data_.motion_model = motion_model_;

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -311,24 +311,28 @@ void Optimizer::prepare(
     // Clamp to physically achievable range so prediction never exceeds dynamics.
     const auto & c = settings_.constraints;
     const double dt = settings_.controller_period;
+    float max_delta_vx = dt * c.ax_max;
+    float min_delta_vx = dt * c.ax_min;
+    float max_delta_vy = dt * c.ay_max;
+    float min_delta_vy = dt * c.ay_min;
+    float max_delta_wz = dt * c.az_max;
     state_.speed = robot_speed;
-    state_.speed.linear.x = std::clamp(
-      last_command_vel_.linear.x,
-      robot_speed.linear.x + dt * c.ax_min,
-      robot_speed.linear.x + dt * c.ax_max);
-    state_.speed.angular.z = std::clamp(
-      last_command_vel_.angular.z,
-      robot_speed.angular.z - dt * c.az_max,
-      robot_speed.angular.z + dt * c.az_max);
+    auto robot_last_speed = state_.speed;
+    state_.speed.linear.x = utils::clampVelocityByAccel(
+      robot_speed.linear.x, last_command_vel_.linear.x,  min_delta_vx, max_delta_vx);
+    state_.speed.angular.z = utils::clampVelocityByAccel(
+      robot_speed.angular.z, last_command_vel_.angular.z,  -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
-      state_.speed.linear.y = std::clamp(
-        last_command_vel_.linear.y,
-        robot_speed.linear.y + dt * c.ay_min,
-        robot_speed.linear.y + dt * c.ay_max);
+      state_.speed.linear.y = utils::clampVelocityByAccel(
+      robot_speed.linear.y, last_command_vel_.linear.y,  min_delta_vy, max_delta_vy);
     }
   }
 
   state_.pose = robot_pose;
+  // Predict the robot pose at 1*dt in future
+  // assuming robot is executing current observed speed until dt in future,
+  motion_model_->predictFuture(state_.pose,robot_last_speed,dt);
+
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);
   costs_.setZero(settings_.batch_size);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -303,9 +303,9 @@ void Optimizer::prepare(
   const geometry_msgs::msg::Pose & goal,
   nav2_core::GoalChecker * goal_checker)
 {
+  state_.pose = robot_pose;
   if (settings_.open_loop) {
     state_.speed = last_command_vel_;
-    state_.pose = robot_pose;
   } else {
     // Predict state one controller_period forward toward the last command to compensate
     // for the latency between measurement and when this command will take effect.
@@ -314,8 +314,6 @@ void Optimizer::prepare(
     const double dt = settings_.controller_period;
     float max_delta_vx = dt * c.ax_max;
     float min_delta_vx = dt * c.ax_min;
-    float max_delta_vy = dt * c.ay_max;
-    float min_delta_vy = dt * c.ay_min;
     float max_delta_wz = dt * c.az_max;
     state_.speed = robot_speed;
     auto robot_last_speed = state_.speed;
@@ -324,12 +322,12 @@ void Optimizer::prepare(
     state_.speed.angular.z = utils::clampVelocityByAccel(
       robot_speed.angular.z, last_command_vel_.angular.z, -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
+      float max_delta_vy = dt * c.ay_max;
+      float min_delta_vy = dt * c.ay_min;
       state_.speed.linear.y = utils::clampVelocityByAccel(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
-    state_.pose = robot_pose;
     // Predict the robot pose at 1*dt in future
-    // assuming robot is executing current observed speed until dt in future,
     motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
 

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -305,6 +305,7 @@ void Optimizer::prepare(
 {
   if (settings_.open_loop) {
     state_.speed = last_command_vel_;
+    state_.pose = robot_pose;
   } else {
     // Predict state one controller_period forward toward the last command to compensate
     // for the latency between measurement and when this command will take effect.
@@ -319,19 +320,19 @@ void Optimizer::prepare(
     state_.speed = robot_speed;
     auto robot_last_speed = state_.speed;
     state_.speed.linear.x = utils::clampVelocityByAccel(
-      robot_speed.linear.x, last_command_vel_.linear.x,  min_delta_vx, max_delta_vx);
+      robot_speed.linear.x, last_command_vel_.linear.x, min_delta_vx, max_delta_vx);
     state_.speed.angular.z = utils::clampVelocityByAccel(
-      robot_speed.angular.z, last_command_vel_.angular.z,  -max_delta_wz, max_delta_wz);
+      robot_speed.angular.z, last_command_vel_.angular.z, -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
       state_.speed.linear.y = utils::clampVelocityByAccel(
-      robot_speed.linear.y, last_command_vel_.linear.y,  min_delta_vy, max_delta_vy);
+      robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
+    state_.pose = robot_pose;
+    // Predict the robot pose at 1*dt in future
+    // assuming robot is executing current observed speed until dt in future,
+    motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
 
-  state_.pose = robot_pose;
-  // Predict the robot pose at 1*dt in future
-  // assuming robot is executing current observed speed until dt in future,
-  motion_model_->predictFuture(state_.pose,robot_last_speed,dt);
 
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -328,7 +328,7 @@ void Optimizer::prepare(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
     // Predict the robot pose at dt in future
-    motion_model_->predictFuture(state_.pose, robot_speed, dt);
+    motion_model_->predictPose(state_.pose, robot_speed, dt);
   }
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -331,13 +331,10 @@ void Optimizer::prepare(
     // Predict the robot pose at 1*dt in future
     motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
-
-
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);
   costs_.setZero(settings_.batch_size);
   goal_ = goal;
-
   critics_data_.fail_flag = false;
   critics_data_.goal_checker = goal_checker;
   critics_data_.motion_model = motion_model_;

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -306,6 +306,7 @@ void Optimizer::prepare(
 {
   if (settings_.open_loop) {
     state_.speed = last_command_vel_;
+    state_.pose = robot_pose;
   } else {
     // Predict state one controller_period forward toward the last command to compensate
     // for the latency between measurement and when this command will take effect.
@@ -320,19 +321,19 @@ void Optimizer::prepare(
     state_.speed = robot_speed;
     auto robot_last_speed = state_.speed;
     state_.speed.linear.x = utils::clampVelocityByAccel(
-      robot_speed.linear.x, last_command_vel_.linear.x,  min_delta_vx, max_delta_vx);
+      robot_speed.linear.x, last_command_vel_.linear.x, min_delta_vx, max_delta_vx);
     state_.speed.angular.z = utils::clampVelocityByAccel(
-      robot_speed.angular.z, last_command_vel_.angular.z,  -max_delta_wz, max_delta_wz);
+      robot_speed.angular.z, last_command_vel_.angular.z, -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
       state_.speed.linear.y = utils::clampVelocityByAccel(
-      robot_speed.linear.y, last_command_vel_.linear.y,  min_delta_vy, max_delta_vy);
+      robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
+    state_.pose = robot_pose;
+    // Predict the robot pose at 1*dt in future
+    // assuming robot is executing current observed speed until dt in future,
+    motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
 
-  state_.pose = robot_pose;
-  // Predict the robot pose at 1*dt in future
-  // assuming robot is executing current observed speed until dt in future,
-  motion_model_->predictFuture(state_.pose,robot_last_speed,dt);
 
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -317,7 +317,6 @@ void Optimizer::prepare(
     float min_delta_vx = dt * c.ax_min;
     float max_delta_wz = dt * c.az_max;
     state_.speed = robot_speed;
-    auto robot_last_speed = state_.speed;
     state_.speed.linear.x = utils::clampVelocityByAccel(
       robot_speed.linear.x, last_command_vel_.linear.x, min_delta_vx, max_delta_vx);
     state_.speed.angular.z = utils::clampVelocityByAccel(
@@ -329,7 +328,7 @@ void Optimizer::prepare(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
     // Predict the robot pose at 1*dt in future
-    motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
+    motion_model_->predictFuture(state_.pose, robot_speed, dt);
   }
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -328,7 +328,7 @@ void Optimizer::prepare(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
     // Predict the robot pose at dt in future
-    motion_model_->predictPose(state_.pose, robot_speed, dt);
+    motion_model_->predictPose(state_.pose.pose, robot_speed, dt);
   }
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -327,7 +327,7 @@ void Optimizer::prepare(
       state_.speed.linear.y = utils::clampVelocityByAccel(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
-    // Predict the robot pose at 1*dt in future
+    // Predict the robot pose at dt in future
     motion_model_->predictFuture(state_.pose, robot_speed, dt);
   }
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -312,24 +312,28 @@ void Optimizer::prepare(
     // Clamp to physically achievable range so prediction never exceeds dynamics.
     const auto & c = settings_.constraints;
     const double dt = settings_.controller_period;
+    float max_delta_vx = dt * c.ax_max;
+    float min_delta_vx = dt * c.ax_min;
+    float max_delta_vy = dt * c.ay_max;
+    float min_delta_vy = dt * c.ay_min;
+    float max_delta_wz = dt * c.az_max;
     state_.speed = robot_speed;
-    state_.speed.linear.x = std::clamp(
-      last_command_vel_.linear.x,
-      robot_speed.linear.x + dt * c.ax_min,
-      robot_speed.linear.x + dt * c.ax_max);
-    state_.speed.angular.z = std::clamp(
-      last_command_vel_.angular.z,
-      robot_speed.angular.z - dt * c.az_max,
-      robot_speed.angular.z + dt * c.az_max);
+    auto robot_last_speed = state_.speed;
+    state_.speed.linear.x = utils::clampVelocityByAccel(
+      robot_speed.linear.x, last_command_vel_.linear.x,  min_delta_vx, max_delta_vx);
+    state_.speed.angular.z = utils::clampVelocityByAccel(
+      robot_speed.angular.z, last_command_vel_.angular.z,  -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
-      state_.speed.linear.y = std::clamp(
-        last_command_vel_.linear.y,
-        robot_speed.linear.y + dt * c.ay_min,
-        robot_speed.linear.y + dt * c.ay_max);
+      state_.speed.linear.y = utils::clampVelocityByAccel(
+      robot_speed.linear.y, last_command_vel_.linear.y,  min_delta_vy, max_delta_vy);
     }
   }
 
   state_.pose = robot_pose;
+  // Predict the robot pose at 1*dt in future
+  // assuming robot is executing current observed speed until dt in future,
+  motion_model_->predictFuture(state_.pose,robot_last_speed,dt);
+
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);
   costs_.setZero(settings_.batch_size);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -304,9 +304,9 @@ void Optimizer::prepare(
   const geometry_msgs::msg::Pose & goal,
   nav2_core::GoalChecker * goal_checker)
 {
+  state_.pose = robot_pose;
   if (settings_.open_loop) {
     state_.speed = last_command_vel_;
-    state_.pose = robot_pose;
   } else {
     // Predict state one controller_period forward toward the last command to compensate
     // for the latency between measurement and when this command will take effect.
@@ -315,8 +315,6 @@ void Optimizer::prepare(
     const double dt = settings_.controller_period;
     float max_delta_vx = dt * c.ax_max;
     float min_delta_vx = dt * c.ax_min;
-    float max_delta_vy = dt * c.ay_max;
-    float min_delta_vy = dt * c.ay_min;
     float max_delta_wz = dt * c.az_max;
     state_.speed = robot_speed;
     auto robot_last_speed = state_.speed;
@@ -325,12 +323,12 @@ void Optimizer::prepare(
     state_.speed.angular.z = utils::clampVelocityByAccel(
       robot_speed.angular.z, last_command_vel_.angular.z, -max_delta_wz, max_delta_wz);
     if (isHolonomic()) {
+      float max_delta_vy = dt * c.ay_max;
+      float min_delta_vy = dt * c.ay_min;
       state_.speed.linear.y = utils::clampVelocityByAccel(
       robot_speed.linear.y, last_command_vel_.linear.y, min_delta_vy, max_delta_vy);
     }
-    state_.pose = robot_pose;
     // Predict the robot pose at 1*dt in future
-    // assuming robot is executing current observed speed until dt in future,
     motion_model_->predictFuture(state_.pose, robot_last_speed, dt);
   }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6249  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No 

---

## Description of contribution in a few bullet points


* Used clampVelocityByAccel in optimizer::prepare function to predict the future speed constraints with dynamic limits.
* Added predictFuture in motion_models.hpp to predict the future pose, given the speed, and time duration.
* Used predictFuture function in optimizer::prepare to predict the future state of the robot, and set it to the state_.pose.


## Description of documentation updates required from your changes
    Not Needed


## Description of how this change was tested
 Todo
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points
NA

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
