### PR TITLE
Fix Smac2D final pose to match reached goal

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
@@ -271,12 +271,12 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
 
   // Corner case of start and goal being on the same cell
   if (std::floor(mx_start) == std::floor(mx_goal) && std::floor(my_start) == std::floor(my_goal)) {
-    pose.pose = start.pose;
+    pose.pose = goal.pose;
     // if we have a different start and goal orientation, set the unique path pose to the goal
     // orientation, unless use_final_approach_orientation=true where we need it to be the start
     // orientation to avoid movement from the local planner
-    if (start.pose.orientation != goal.pose.orientation && !_use_final_approach_orientation) {
-      pose.pose.orientation = goal.pose.orientation;
+    if (start.pose.orientation != goal.pose.orientation && _use_final_approach_orientation) {
+      pose.pose.orientation = start.pose.orientation;
     }
     plan.poses.push_back(pose);
 
@@ -308,6 +308,9 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
       throw nav2_core::PlannerTimedOut("exceeded maximum iterations");
     }
   }
+
+  const bool reached_goal_cell = std::floor(path.front().x) == std::floor(mx_goal) &&
+                                  std::floor(path.front().y) == std::floor(my_goal);
 
   // Convert to world coordinates
   plan.poses.reserve(path.size());
@@ -346,6 +349,10 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
   // And deal with corner case of plan of length 1
   // If use_final_approach_orientation=false (default), override last pose orientation to match goal
   size_t plan_size = plan.poses.size();
+  if (reached_goal_cell && plan_size > 0) {
+    plan.poses.back().pose.position = goal.pose.position;
+  }
+  
   if (_use_final_approach_orientation) {
     if (plan_size == 1) {
       plan.poses.back().pose.orientation = start.pose.orientation;

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d_impl.hpp
@@ -309,8 +309,9 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
     }
   }
 
-  const bool reached_goal_cell = std::floor(path.front().x) == std::floor(mx_goal) &&
-                                  std::floor(path.front().y) == std::floor(my_goal);
+  const bool reached_goal_cell =
+    std::floor(path.front().x) == std::floor(mx_goal) &&
+    std::floor(path.front().y) == std::floor(my_goal);
 
   // Convert to world coordinates
   plan.poses.reserve(path.size());
@@ -352,7 +353,7 @@ nav_msgs::msg::Path SmacPlanner2DT<NodeT>::createPlan(
   if (reached_goal_cell && plan_size > 0) {
     plan.poses.back().pose.position = goal.pose.position;
   }
-  
+
   if (_use_final_approach_orientation) {
     if (plan_size == 1) {
       plan.poses.back().pose.orientation = start.pose.orientation;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #6265) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Our robot) |
| Does this PR contain AI generated software? | (No) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

- Updated `SmacPlanner2D` to return the requested goal position as the final path pose when the search reaches the goal cell.
- Preserved tolerance fallback behavior by only snapping the final pose when the returned path actually ends in the requested goal cell.
- Made the same-cell start/goal shortcut return the requested goal pose while preserving `use_final_approach_orientation` behavior.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

- Tested manually with the `ComputePathToPose` action using `SmacPlanner2D` with this configuration:

```
planner_server:
  ros__parameters:
    planner_plugins: ["GridBased"]

    GridBased:
      plugin: "nav2_smac_planner::SmacPlanner2D" # In Iron and older versions, "/" was used instead of "::"
      tolerance: 0.25                        # tolerance for planning if unable to reach exact pose, in meters
      downsample_costmap: false             # whether or not to downsample the map
      downsampling_factor: 1                # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
      allow_unknown: true                   # allow traveling in unknown space
      max_iterations: -1               # maximum total iterations to search for before failing (in case unreachable), set to -1 to disable
      max_on_approach_iterations: 10000      # maximum number of iterations to attempt to reach goal once in tolerance
      max_planning_time: 2.0                # max time in s for planner to plan, smooth
      cost_travel_multiplier: 2.0           # Cost multiplier to apply to search to steer away from high cost areas. Larger values will place in the center of aisles more exactly (if non-`FREE` cost potential field exists) but take slightly longer to compute. To optimize for speed, a value of 1.0 is reasonable. A reasonable tradeoff value is 2.0. A value of 0.0 effective disables steering away from obstacles and acts like a naive binary search A*.
      use_final_approach_orientation: false # Whether to set the final path pose at the goal's orientation to the requested orientation (false) or in line with the approach angle so the robot doesn't rotate to heading (true)
      smoother:
        max_iterations: 1000
        w_smooth: 0.3
        w_data: 0.2
        tolerance: 1.0e-10
```

- Verified the existing behavior **before the change**: when the planner reached the goal cell, the returned path succeeded but the final path pose position could differ from the requested goal pose due to grid-cell coordinate conversion:

<img width="462" height="340" alt="Screenshot from 2026-07-15 16-58-14" src="https://github.com/user-attachments/assets/99e24ce7-b83c-4ba1-9dbf-245b2d16b9b2" />


- Verified the updated behavior **after the change**: when the planner reaches the requested goal cell, the final path pose position matches the requested goal position exactly:

<img width="675" height="629" alt="image" src="https://github.com/user-attachments/assets/d775d72d-d2bf-4dcd-ad07-a32f6b052e2d" />

- Verified tolerance behavior is preserved **after the change**: when the exact goal cell cannot be reached and the planner falls back to a valid endpoint within the configured tolerance, the final path pose remains at the tolerance endpoint and is not overwritten with the unreachable requested goal pose:

<img width="675" height="629" alt="image" src="https://github.com/user-attachments/assets/1bf8350b-cf0d-4f19-85f8-645951213af3" />

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
