### PR TITLE
Fix collision monitor and costmap tests, Update tf2_ros API

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1384,12 +1384,10 @@ AmclNode::initTransforms()
   // Initialize transform listener and broadcaster
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(),
-    get_node_timers_interface(),
-    callback_group_);
+    *this, callback_group_);
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, true);
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this());
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*shared_from_this());
 
   sent_first_transform_ = false;
   latest_tf_valid_ = false;
@@ -1414,9 +1412,7 @@ AmclNode::initMessageFilters()
 
   laser_scan_filter_ = std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
     *laser_scan_sub_, *tf_buffer_, odom_frame_id_, 10,
-    get_node_logging_interface(),
-    get_node_clock_interface(),
-    transform_tolerance_);
+    *this, transform_tolerance_);
 
 
   laser_scan_connection_ = laser_scan_filter_->registerCallback(

--- a/nav2_behavior_tree/test/utils/test_transform_handler.hpp
+++ b/nav2_behavior_tree/test/utils/test_transform_handler.hpp
@@ -134,7 +134,7 @@ protected:
   virtual void startRobotTransform(std::chrono::milliseconds tf_broadcast_period)
   {
     // Provide the robot pose transform
-    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node_);
 
     if (!base_transform_) {
       base_transform_ = std::make_unique<geometry_msgs::msg::TransformStamped>();

--- a/nav2_behaviors/src/behavior_server.cpp
+++ b/nav2_behaviors/src/behavior_server.cpp
@@ -59,9 +59,7 @@ BehaviorServer::on_configure(const rclcpp_lifecycle::State & state)
   RCLCPP_INFO(get_logger(), "Configuring");
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(),
-    get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_->setCreateTimerInterface(timer_interface);
   transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, true);
 

--- a/nav2_behaviors/test/test_behaviors.cpp
+++ b/nav2_behaviors/test/test_behaviors.cpp
@@ -123,8 +123,7 @@ protected:
 
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_lifecycle_->get_clock());
     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      node_lifecycle_->get_node_base_interface(),
-      node_lifecycle_->get_node_timers_interface());
+      *node_lifecycle_);
     tf_buffer_->setCreateTimerInterface(timer_interface);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -50,8 +50,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & state)
   RCLCPP_INFO(get_logger(), "Configuring");
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(), get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_->setCreateTimerInterface(timer_interface);
   tf_->setUsingDedicatedThread(true);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, true);

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -46,9 +46,7 @@ CollisionDetector::on_configure(const rclcpp_lifecycle::State & state)
 
   // Transform buffer and listener initialization
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    this->get_node_base_interface(),
-    this->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, true);
 

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -52,9 +52,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
 
   // Transform buffer and listener initialization
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    this->get_node_base_interface(),
-    this->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, true);
 

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -226,7 +226,11 @@ std::vector<std::string> Polygon::getSourcesNames() const
 
 void Polygon::getPolygon(std::vector<Point> & poly) const
 {
-  poly.assign(poly_.begin(), poly_.end());
+  poly.clear();
+  if (poly_.empty()) {
+    return;
+  }
+  poly = poly_;
 }
 
 bool Polygon::isShapeSet()

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -226,10 +226,7 @@ std::vector<std::string> Polygon::getSourcesNames() const
 
 void Polygon::getPolygon(std::vector<Point> & poly) const
 {
-  if (poly.empty()) {
-    return;
-  }
-  poly = poly_;
+  poly.assign(poly_.begin(), poly_.end());
 }
 
 bool Polygon::isShapeSet()

--- a/nav2_collision_monitor/test/collision_detector_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_detector_node_test.cpp
@@ -413,7 +413,7 @@ void Tester::setVectors(
 void Tester::sendTransforms(const rclcpp::Time & stamp)
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(cd_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*cd_);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.transform.rotation.x = 0.0;

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -509,7 +509,7 @@ void Tester::setGlobalHeightParams(const std::string & source_name, const double
 void Tester::sendTransforms(const rclcpp::Time & stamp)
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(cm_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*cm_);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.transform.rotation.x = 0.0;

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -416,7 +416,7 @@ void Tester::createCircle(const std::string & action_type, const bool is_static)
 void Tester::sendTransforms(double shift)
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(test_node_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*test_node_);
 
   geometry_msgs::msg::TransformStamped transform;
 

--- a/nav2_collision_monitor/test/sources_test.cpp
+++ b/nav2_collision_monitor/test/sources_test.cpp
@@ -561,7 +561,7 @@ void Tester::createSources(const bool base_shift_correction)
 void Tester::sendTransforms(const rclcpp::Time & stamp)
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(test_node_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*test_node_);
 
   geometry_msgs::msg::TransformStamped transform;
 

--- a/nav2_constrained_smoother/test/test_constrained_smoother.cpp
+++ b/nav2_constrained_smoother/test/test_constrained_smoother.cpp
@@ -114,8 +114,7 @@ protected:
 
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_lifecycle_->get_clock());
     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      node_lifecycle_->get_node_base_interface(),
-      node_lifecycle_->get_node_timers_interface());
+      *node_lifecycle_);
     tf_buffer_->setCreateTimerInterface(timer_interface);
 
     costmap_sub_ =

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -121,7 +121,7 @@ TEST(PathHandlerTests, TestBounds)
 
   // Set tf between map odom and base_link
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ =
-    std::make_unique<tf2_ros::TransformBroadcaster>(node);
+    std::make_unique<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::TransformStamped t;
   t.header.frame_id = "map";
   t.child_frame_id = "base_link";
@@ -172,7 +172,7 @@ TEST(PathHandlerTests, TestBoundsWithConstraintCheck)
 
   // Set tf between map odom and base_link
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ =
-    std::make_unique<tf2_ros::TransformBroadcaster>(node);
+    std::make_unique<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::TransformStamped t;
   t.header.frame_id = "map";
   t.child_frame_id = "base_link";
@@ -223,7 +223,7 @@ TEST(PathHandlerTests, TestTransforms)
 
   // Set tf between map odom and base_link
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ =
-    std::make_unique<tf2_ros::TransformBroadcaster>(node);
+    std::make_unique<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::TransformStamped t;
   t.header.frame_id = "map";
   t.child_frame_id = "base_link";

--- a/nav2_costmap_2d/include/nav2_costmap_2d/asymmetric_inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/asymmetric_inflation_layer.hpp
@@ -125,7 +125,7 @@ protected:
   /**
    * @brief Callback for incoming global path messages
    */
-  void globalPathCallback(const nav_msgs::msg::Path::SharedPtr msg);
+  void globalPathCallback(const nav_msgs::msg::Path::ConstSharedPtr msg);
 
   /**
    * @brief Extract global path segments that overlap the local costmap window.
@@ -257,7 +257,7 @@ protected:
 
   // --- Path subscription ---
   nav2::Subscription<nav_msgs::msg::Path>::SharedPtr path_sub_;
-  nav_msgs::msg::Path::SharedPtr latest_global_path_;
+  nav_msgs::msg::Path::ConstSharedPtr latest_global_path_;
   std::mutex path_mutex_;
 };
 

--- a/nav2_costmap_2d/plugins/asymmetric_inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/asymmetric_inflation_layer.cpp
@@ -156,9 +156,11 @@ AsymmetricInflationLayer::deactivate()
 }
 
 void
-AsymmetricInflationLayer::globalPathCallback(const nav_msgs::msg::Path::SharedPtr msg)
+AsymmetricInflationLayer::globalPathCallback(const nav_msgs::msg::Path::ConstSharedPtr msg)
 {
-  if (*latest_global_path_ == *msg) {return;}
+  if (latest_global_path_ && *latest_global_path_ == *msg) {
+    return;
+  }
 
   // Cache the path
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -247,9 +247,7 @@ void ObstacleLayer::onInitialize()
 
       auto filter = std::make_shared<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
         *sub, *tf_, global_frame_, 50,
-        node->get_node_logging_interface(),
-        node->get_node_clock_interface(),
-        tf2::durationFromSec(transform_tolerance));
+        *node, tf2::durationFromSec(transform_tolerance));
 
       if (inf_is_valid) {
         filter->registerCallback(
@@ -318,9 +316,7 @@ void ObstacleLayer::onInitialize()
 
       auto filter = std::make_shared<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>>(
         *sub, *tf_, global_frame_, 50,
-        node->get_node_logging_interface(),
-        node->get_node_clock_interface(),
-        tf2::durationFromSec(transform_tolerance));
+        *node, tf2::durationFromSec(transform_tolerance));
 
       filter->registerCallback(
         std::bind(

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -153,9 +153,7 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Create the transform-related objects
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(),
-    get_node_timers_interface(),
-    callback_group_);
+    *this, callback_group_);
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 

--- a/nav2_costmap_2d/test/benchmark/asymmetric_layer_updatecosts_benchmark.cpp
+++ b/nav2_costmap_2d/test/benchmark/asymmetric_layer_updatecosts_benchmark.cpp
@@ -79,7 +79,7 @@ class BenchmarkAsymmetricInflationLayer : public nav2_costmap_2d::AsymmetricInfl
 {
 public:
   /** @brief Deliver @p msg as if it arrived on the plan topic. */
-  void injectPath(nav_msgs::msg::Path::SharedPtr msg) {globalPathCallback(msg);}
+  void injectPath(nav_msgs::msg::Path::ConstSharedPtr msg) {globalPathCallback(msg);}
 };
 
 /**

--- a/nav2_costmap_2d/test/integration/asymmetric_inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/asymmetric_inflation_tests.cpp
@@ -45,7 +45,7 @@ using geometry_msgs::msg::Point;
 class TestableAsymmetricInflationLayer : public nav2_costmap_2d::AsymmetricInflationLayer
 {
 public:
-  void injectPath(const nav_msgs::msg::Path::SharedPtr msg)
+  void injectPath(const nav_msgs::msg::Path::ConstSharedPtr msg)
   {
     globalPathCallback(msg);
   }

--- a/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
+++ b/nav2_costmap_2d/test/integration/dyn_params_tests.cpp
@@ -40,7 +40,7 @@ TEST(DynParamTestNode, testDynParamsSet)
 
   // Set tf between default global_frame and robot_base_frame in order not to block in on_activate
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ =
-    std::make_unique<tf2_ros::TransformBroadcaster>(node);
+    std::make_unique<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::TransformStamped t;
   t.header.stamp = node->get_clock()->now();
   t.header.frame_id = "map";

--- a/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
@@ -108,12 +108,10 @@ public:
       rclcpp::CallbackGroupType::MutuallyExclusive, false);
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      get_node_base_interface(),
-      get_node_timers_interface(),
-      callback_group_);
+      *shared_from_this(), callback_group_);
     tf_buffer_->setCreateTimerInterface(timer_interface);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this());
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*shared_from_this());
 
     std::string costmap_topic = "costmap_raw";
     std::string footprint_topic = "published_footprint";

--- a/nav2_costmap_2d/test/unit/binary_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/binary_filter_test.cpp
@@ -408,7 +408,7 @@ bool TestNode::createBinaryFilter(const std::string & global_frame, double flip_
 
 void TestNode::createTFBroadcaster(const std::string & mask_frame, const std::string & global_frame)
 {
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node_);
 
   transform_ = std::make_unique<geometry_msgs::msg::TransformStamped>();
   transform_->header.frame_id = mask_frame;

--- a/nav2_costmap_2d/test/unit/clear_costmap_service_test.cpp
+++ b/nav2_costmap_2d/test/unit/clear_costmap_service_test.cpp
@@ -48,7 +48,7 @@ protected:
     costmap_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("costmap");
 
     // Send identity transform to ensure costmap can transform robot poses during service calls
-    auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(costmap_);
+    auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*costmap_);
     geometry_msgs::msg::TransformStamped transform;
     transform.header.frame_id = "map";
     transform.child_frame_id = "base_link";

--- a/nav2_costmap_2d/test/unit/keepout_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/keepout_filter_test.cpp
@@ -241,7 +241,7 @@ void TestNode::createKeepoutFilter(const std::string & global_frame)
 
 void TestNode::createTFBroadcaster(const std::string & mask_frame, const std::string & global_frame)
 {
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node_);
 
   transform_ = std::make_unique<geometry_msgs::msg::TransformStamped>();
   transform_->header.frame_id = mask_frame;

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -506,7 +506,7 @@ bool TestNode::createSpeedFilter(
 
 void TestNode::createTFBroadcaster(const std::string & mask_frame, const std::string & global_frame)
 {
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node_);
 
   transform_ = std::make_unique<geometry_msgs::msg::TransformStamped>();
   transform_->header.frame_id = mask_frame;

--- a/nav2_following/opennav_following/test/test_following_server_unit.cpp
+++ b/nav2_following/opennav_following/test/test_following_server_unit.cpp
@@ -301,7 +301,7 @@ TEST(FollowingServerTests, GetFramePose)
   EXPECT_FALSE(node->getFramePose(pose, frame_test));
 
   // Set transform between my_frame and fixed_frame_test
-  auto tf_broadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::TransformStamped frame_to_fixed;
   frame_to_fixed.header.frame_id = "fixed_frame_test";
   frame_to_fixed.header.stamp = node->get_clock()->now();

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -49,9 +49,7 @@ VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   if (!enforce_global_frame_id_) {
     // Transform buffer and listener initialization
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      this->get_node_base_interface(),
-      this->get_node_timers_interface());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
     tf_buffer_->setCreateTimerInterface(timer_interface);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   } else {

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -337,7 +337,7 @@ void Tester::setCircleParams(const std::string & uuid)
 void Tester::sendTransform(const double frame_shift)
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(vo_server_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*vo_server_);
 
   geometry_msgs::msg::TransformStamped transform;
 

--- a/nav2_map_server/test/unit/test_vector_object_shapes.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_shapes.cpp
@@ -264,7 +264,7 @@ nav2_msgs::msg::CircleObject::SharedPtr Tester::makeCircleObject(
 void Tester::sendTransform()
 {
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*node_);
 
   geometry_msgs::msg::TransformStamped transform;
 

--- a/nav2_mppi_controller/benchmark/controller_benchmark.cpp
+++ b/nav2_mppi_controller/benchmark/controller_benchmark.cpp
@@ -88,7 +88,7 @@ void prepareAndRunBenchmark(
   tf_buffer->setUsingDedicatedThread(true);  // One-thread broadcasting-listening model
 
   auto broadcaster =
-    std::make_shared<tf2_ros::TransformBroadcaster>(node);
+    std::make_shared<tf2_ros::TransformBroadcaster>(*node);
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer);
 
   auto map_odom_broadcaster = std::async(

--- a/nav2_planner/test/test_plan_through_poses.cpp
+++ b/nav2_planner/test/test_plan_through_poses.cpp
@@ -127,7 +127,7 @@ Tester::Tester()
   executor_->add_node(tester_node_->get_node_base_interface());
   executor_thread_ = std::make_unique<nav2::NodeThread>(executor_);
 
-  robot_pose_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(tester_node_);
+  robot_pose_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*tester_node_);
   action_client_ = tester_node_->create_action_client<Action>("compute_path_through_poses");
 
   map_publisher_ = tester_node_->create_publisher<nav_msgs::msg::OccupancyGrid>(

--- a/nav2_rotation_shim_controller/test/test_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/test/test_shim_controller.cpp
@@ -218,12 +218,12 @@ TEST(RotationShimControllerTest, computeVelocityTests)
   auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
   std::string name = "PathFollower";
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, node, true);
+  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, *node, true);
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
   costmap->declare_parameter("origin_x", 0.0);
   costmap->declare_parameter("origin_y", 0.0);
   costmap->configure();
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.header.frame_id = "base_link";
@@ -283,11 +283,11 @@ TEST(RotationShimControllerTest, openLoopRotationTests) {
   auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
   std::string name = "PathFollower";
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, node, true);
+  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, *node, true);
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
   rclcpp_lifecycle::State state;
   costmap->on_configure(state);
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.header.frame_id = "base_link";
@@ -370,11 +370,11 @@ TEST(RotationShimControllerTest, computeVelocityGoalRotationTests) {
   auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
   std::string name = "PathFollower";
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, node, true);
+  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, *node, true);
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
   rclcpp_lifecycle::State state;
   costmap->on_configure(state);
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.header.frame_id = "base_link";
@@ -453,11 +453,11 @@ TEST(RotationShimControllerTest, accelerationTests) {
   auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
   std::string name = "PathFollower";
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, node, true);
+  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, *node, true);
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
   rclcpp_lifecycle::State state;
   costmap->on_configure(state);
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
 
   geometry_msgs::msg::TransformStamped transform;
   transform.header.frame_id = "base_link";
@@ -541,11 +541,11 @@ TEST(RotationShimControllerTest, isGoalChangedTest)
   auto node = std::make_shared<nav2::LifecycleNode>("ShimControllerTest");
   std::string name = "PathFollower";
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, node, true);
+  auto listener = std::make_shared<tf2_ros::TransformListener>(*tf, *node, true);
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("fake_costmap");
   rclcpp_lifecycle::State state;
   costmap->on_configure(state);
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
   geometry_msgs::msg::PoseStamped robot_pose;
   nav2_controller::SimpleGoalChecker checker;
   geometry_msgs::msg::Twist velocity;

--- a/nav2_route/src/route_server.cpp
+++ b/nav2_route/src/route_server.cpp
@@ -30,9 +30,7 @@ RouteServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Configuring");
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(),
-    get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_->setCreateTimerInterface(timer_interface);
   transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, true);
 

--- a/nav2_route/test/test_goal_intent_extractor.cpp
+++ b/nav2_route/test/test_goal_intent_extractor.cpp
@@ -71,12 +71,10 @@ TEST(GoalIntentExtractorTest, test_transform_pose)
   Graph graph;
   GraphToIDMap id_map;
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
   tf->setCreateTimerInterface(timer_interface);
   auto transform_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_subscriber = nullptr;
   extractor.configure(node, graph, &id_map, tf, costmap_subscriber, "map", "base_link");
 
@@ -107,9 +105,7 @@ TEST(GoalIntentExtractorTest, test_start_goal_finder)
   Graph graph;
   GraphToIDMap id_map;
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
   tf->setCreateTimerInterface(timer_interface);
 
   // Make a 3x3 graph of points 0,0 -> 2,2 (ROS logo)

--- a/nav2_route/test/test_graph_loader.cpp
+++ b/nav2_route/test/test_graph_loader.cpp
@@ -73,7 +73,7 @@ TEST(GraphLoader, test_transformation_api)
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
   tf->setUsingDedicatedThread(true);
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*node);
 
   std::string frame = "map";
 

--- a/nav2_route/test/test_graph_saver.cpp
+++ b/nav2_route/test/test_graph_saver.cpp
@@ -109,7 +109,7 @@ TEST(GraphSaver, test_transformation_api)
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
   tf->setUsingDedicatedThread(true);
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*node);
 
   std::string frame = "map";
 

--- a/nav2_route/test/test_route_tracker.cpp
+++ b/nav2_route/test/test_route_tracker.cpp
@@ -57,12 +57,10 @@ TEST(RouteTrackerTest, test_get_robot_pose)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("router_test");
   auto tf = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
   tf->setCreateTimerInterface(timer_interface);
   auto transform_listener = std::make_shared<tf2_ros::TransformListener>(*tf);
-  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_subscriber;
 
   RouteTracker tracker;

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -691,8 +691,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   // Setting up tf for initial pose
   tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(client_node_->get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    client_node_->get_node_base_interface(),
-    client_node_->get_node_timers_interface());
+    *client_node_);
   tf2_buffer_->setCreateTimerInterface(timer_interface);
   transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
 

--- a/nav2_smoother/src/nav2_smoother.cpp
+++ b/nav2_smoother/src/nav2_smoother.cpp
@@ -71,8 +71,7 @@ SmootherServer::on_configure(const rclcpp_lifecycle::State & state)
   }
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    get_node_base_interface(), get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
   tf_->setCreateTimerInterface(timer_interface);
   transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, this, true);
 

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -62,11 +62,10 @@ public:
     node_ = std::make_shared<nav2::LifecycleNode>("behavior_tree_handler");
 
     tf_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      node_->get_node_base_interface(), node_->get_node_timers_interface());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node_);
     tf_->setCreateTimerInterface(timer_interface);
     tf_->setUsingDedicatedThread(true);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, node_, false);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_, *node_, false);
 
     odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(node_);
 

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -113,7 +113,7 @@ PlannerTester::~PlannerTester()
 void PlannerTester::startRobotTransform()
 {
   // Provide the robot pose transform
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
 
   // Set an initial pose
   geometry_msgs::msg::Point robot_position;

--- a/nav2_util/src/base_footprint_publisher.hpp
+++ b/nav2_util/src/base_footprint_publisher.hpp
@@ -111,9 +111,7 @@ public:
   {
     RCLCPP_INFO(get_logger(), "Creating base footprint publisher");
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
-    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      get_node_base_interface(),
-      get_node_timers_interface());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*this);
     tf_buffer_->setCreateTimerInterface(timer_interface);
     listener_publisher_ = std::make_shared<BaseFootprintPublisherListener>(
       *tf_buffer_, true, *this);

--- a/nav2_util/test/test_base_footprint_publisher.cpp
+++ b/nav2_util/test/test_base_footprint_publisher.cpp
@@ -26,11 +26,9 @@ TEST(TestBaseFootprintPublisher, TestBaseFootprintPublisher)
   executor.add_node(node->get_node_base_interface());
   executor.spin_some();
 
-  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  auto tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
   auto buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
   buffer->setCreateTimerInterface(timer_interface);
   auto listener = std::make_shared<tf2_ros::TransformListener>(*buffer, true);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
