### PR TITLE
Use const_cast in map server dirname fallback

### DIFF
--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -93,7 +93,7 @@ char * dirname(char * path)
     /* This assignment is ill-designed but the XPG specs require to
        return a string containing "." in any case no directory part is
        found and so a static and constant string is required.  */
-    path = reinterpret_cast<char *>(dot);
+    path = const_cast<char *>(dot);
   }
 
   return path;


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-nav2-map-server.win.patch`, authored by Daisuke Nishimatsu.

`nav2_map_server` has a local `dirname` fallback for Windows. When the input has no directory separator, it returns a mutable pointer to a static `"."` fallback string to match the surrounding helper signature. Using `const_cast` keeps the existing behavior while avoiding the broader cast used downstream.
