### PR TITLE
Fix robin_hood macro continuation for MSVC

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/thirdparty/robin_hood.h
+++ b/nav2_smac_planner/include/nav2_smac_planner/thirdparty/robin_hood.h
@@ -147,7 +147,8 @@ static Counts& counts() {
 #        pragma intrinsic(ROBIN_HOOD(BITSCANFORWARD))
 #        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x)                                       \
             [](size_t mask) noexcept -> int {                                             \
-                unsigned long index;                                                      \  // NOLINT
+                /* NOLINTNEXTLINE(runtime/int) */                                        \
+                unsigned long index;                                                      \
                 return ROBIN_HOOD(BITSCANFORWARD)(&index, mask) ? static_cast<int>(index) \
                                                                 : ROBIN_HOOD(BITNESS);    \
             }(x)


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: [`patch/ros-rolling-nav2-smac-planner.win.patch`](https://github.com/RoboStack/ros-rolling/blob/main/patch/ros-rolling-nav2-smac-planner.win.patch), authored by Daisuke Nishimatsu.

RoboStack's Windows patch previously avoided the bundled `robin_hood` container on Windows. After re-checking with a dedicated RoboStack CI probe, the specific MSVC failure is in the vendored `robin_hood.h` macro body: a `// NOLINT` comment appears after a macro-continuation backslash, so MSVC does not continue the macro and reports syntax errors around the following `return`.

This keeps `robin_hood::unordered_node_map` as the Smac planner graph container on Windows and fixes the macro continuation instead, avoiding the performance concern from falling back to `std::unordered_map`.

The RoboStack ODE packaging workaround from the downstream patch is intentionally not included here.

Related RoboStack tracking issue: https://github.com/RoboStack/robostack.github.io/issues/16
