### PR TITLE
modeToStr should be inline

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
@@ -37,7 +37,7 @@ enum class PathAngleMode
 /**
  * @brief Method to convert mode enum to string for printing
  */
-std::string modeToStr(const PathAngleMode & mode)
+inline std::string modeToStr(const PathAngleMode & mode)
 {
   if (mode == PathAngleMode::FORWARD_PREFERENCE) {
     return "Forward Preference";


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

This function is defined in the header so it should be marked `inline`. Otherwise when you include the header in multiple translation units, the linker will give a duplicate symbol error.

## Description of documentation updates required from your changes


## Description of how this change was tested

Compiling when linking with my own code.

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
