### PR TITLE
Reopen pr #6172

### DIFF
--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -14,7 +14,7 @@
 
 #include <cmath>
 #include <chrono>
-
+#include <stdexcept>
 #include "nav2_ros_common/node_utils.hpp"
 #include "opennav_docking/simple_charging_dock.hpp"
 #include "opennav_docking/utils.hpp"
@@ -323,6 +323,15 @@ void SimpleChargingDock::jointStateCallback(
 {
   double velocity = 0.0;
   double effort = 0.0;
+  if (state->velocity.size() < state->name.size() ||
+        state->effort.size() < state->name.size())
+    {
+      throw std::runtime_error(
+        "JointState message has mismatched array sizes: name=" +
+        std::to_string(state->name.size()) + ", velocity=" +
+        std::to_string(state->velocity.size()) + ", effort=" +
+        std::to_string(state->effort.size()));
+    }
   for (size_t i = 0; i < state->name.size(); ++i) {
     for (auto & name : stall_joint_names_) {
       if (state->name[i] == name) {

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -324,14 +324,14 @@ void SimpleChargingDock::jointStateCallback(
   double velocity = 0.0;
   double effort = 0.0;
   if (state->velocity.size() < state->name.size() ||
-        state->effort.size() < state->name.size())
-    {
-      throw std::runtime_error(
+    state->effort.size() < state->name.size())
+  {
+    throw std::runtime_error(
         "JointState message has mismatched array sizes: name=" +
         std::to_string(state->name.size()) + ", velocity=" +
         std::to_string(state->velocity.size()) + ", effort=" +
         std::to_string(state->effort.size()));
-    }
+  }
   for (size_t i = 0; i < state->name.size(); ++i) {
     for (auto & name : stall_joint_names_) {
       if (state->name[i] == name) {

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -326,11 +326,11 @@ void SimpleChargingDock::jointStateCallback(
   if (state->velocity.size() < state->name.size() ||
     state->effort.size() < state->name.size())
   {
-    throw std::runtime_error(
-        "JointState message has mismatched array sizes: name=" +
-        std::to_string(state->name.size()) + ", velocity=" +
-        std::to_string(state->velocity.size()) + ", effort=" +
-        std::to_string(state->effort.size()));
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "JointState message has mismatched array sizes: name=%zu, velocity=%zu, effort=%zu",
+      state->name.size(), state->velocity.size(), state->effort.size());
+    return;
   }
   for (size_t i = 0; i < state->name.size(); ++i) {
     for (auto & name : stall_joint_names_) {

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -184,7 +184,6 @@ TEST(DockingServerTests, testErrorExceptions)
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());
   node->on_shutdown(rclcpp_lifecycle::State());
-  node.reset();
 }
 
 TEST(DockingServerTests, getateGoalDock)

--- a/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/test/test_simple_charging_dock.cpp
@@ -642,6 +642,46 @@ TEST(SimpleChargingDockTests, SubscriptionPersistent)
   dock->cleanup();
 }
 
+
+TEST(SimpleChargingDockTests, JointStateMismatchedArrays)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto pub = node->create_publisher<sensor_msgs::msg::JointState>(
+    "joint_states", rclcpp::QoS(1));
+  pub->on_activate();
+  node->declare_parameter("my_dock.use_stall_detection", rclcpp::ParameterValue(true));
+  node->declare_parameter("my_dock.stall_joint_names", rclcpp::PARAMETER_STRING_ARRAY);
+  node->declare_parameter("my_dock.stall_velocity_threshold", rclcpp::ParameterValue(0.1));
+  node->declare_parameter("my_dock.stall_effort_threshold", rclcpp::ParameterValue(5.0));
+
+  std::vector<std::string> names = {"left_motor", "right_motor"};
+  node->set_parameter(
+    rclcpp::Parameter("my_dock.stall_joint_names", rclcpp::ParameterValue(names)));
+
+  auto dock = std::make_unique<opennav_docking::SimpleChargingDockShim>();
+  dock->configure(node, "my_dock", nullptr);
+  dock->activate();
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
+  // Publish JointState with names but empty velocity/effort arrays
+  sensor_msgs::msg::JointState msg;
+  msg.name = {"left_motor", "right_motor"};
+  msg.velocity = {};
+  msg.effort = {};
+  pub->publish(msg);
+  rclcpp::Rate r(2);
+  r.sleep();
+
+  EXPECT_THROW(executor.spin_some(), std::runtime_error);
+
+  dock->deactivate();
+  dock->cleanup();
+  dock.reset();
+}
+
+
 }  // namespace opennav_docking
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

Hi, really sorry for the late reply. I was away on a graduation trip for a few weeks and didn't check GitHub. I'm back now and have fixed the exception-throwing problem mentioned in #6172 .

The reason for the node.reset deletion: If the node.reset remains, the node_thread (spinning executor) is still alive when node.reset() destroys the DockingServer, and then the executor thread accesses destroyed timers, which is a UAF in TimerBase::~TimerBase(). Moreover, the destructions performed in node.reset will still be done by the c++'s destruction process.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
