### PR TITLE
Report bt action request error

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <cstdint>
 
 #include "behaviortree_cpp/action_node.h"
 #include "behaviortree_cpp/json_export.h"
@@ -40,6 +41,8 @@ template<class ActionT>
 class BtActionNode : public BT::ActionNodeBase
 {
 public:
+  using ActionResult = typename ActionT::Result;
+
   /**
    * @brief A nav2_behavior_tree::BtActionNode constructor
    * @param xml_tag_name Name for the XML tag for this node
@@ -72,6 +75,28 @@ public:
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
     result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
+
+    if constexpr (
+      !requires {ActionT::Result::TIMEOUT;} ||
+      !requires {ActionT::Result::GOAL_REJECTED;} ||
+      !requires {ActionT::Result::SEND_GOAL_FAILURE;})
+    {
+      if constexpr (requires {ActionT::Result::UNKNOWN;}) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Action type for \"%s\" does not define one or more of the TIMEOUT, "
+          "GOAL_REJECTED, and SEND_GOAL_FAILURE error codes. UNKNOWN will be "
+          "used for unavailable errors.",
+          xml_tag_name.c_str());
+      } else {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Action type for \"%s\" does not define one or more of the TIMEOUT, "
+          "GOAL_REJECTED, and SEND_GOAL_FAILURE error codes. The error_code_id "
+          "output will not be set for unavailable errors.",
+          xml_tag_name.c_str());
+      }
+    }
 
     std::string remapped_action_name;
     if (getInput("server_name", remapped_action_name)) {
@@ -121,7 +146,9 @@ public:
   {
     BT::PortsList basic = {
       BT::InputPort<std::string>("server_name", "Action server name"),
-      BT::InputPort<std::chrono::milliseconds>("server_timeout")
+      BT::InputPort<std::chrono::milliseconds>("server_timeout"),
+      BT::OutputPort<uint16_t>("error_code_id", "The action error code"),
+      BT::OutputPort<std::string>("error_msg", "The action error message")
     };
     basic.insert(addition.begin(), addition.end());
 
@@ -193,7 +220,40 @@ public:
    */
   virtual void on_timeout()
   {
-    return;
+    if constexpr (requires {ActionT::Result::TIMEOUT;}) {
+      setOutput("error_code_id", ActionResult::TIMEOUT);
+    } else if constexpr (requires {ActionT::Result::UNKNOWN;}) {
+      setOutput("error_code_id", ActionResult::UNKNOWN);
+    }
+    setOutput("error_msg", "Behavior Tree action client timed out waiting.");
+  }
+
+  /**
+   * @brief Function to perform work in a BT Node when the action server rejects a goal
+   * Such as setting the error code ID status for action clients.
+   */
+  virtual void on_goal_rejected()
+  {
+    if constexpr (requires {ActionT::Result::GOAL_REJECTED;}) {
+      setOutput("error_code_id", ActionResult::GOAL_REJECTED);
+    } else if constexpr (requires {ActionT::Result::UNKNOWN;}) {
+      setOutput("error_code_id", ActionResult::UNKNOWN);
+    }
+    setOutput("error_msg", "Goal was rejected by the action server.");
+  }
+
+  /**
+   * @brief Function to perform work when sending a goal to the action server fails
+   * Such as setting the error code ID status for action clients.
+   */
+  virtual void on_send_goal_failure()
+  {
+    if constexpr (requires {ActionT::Result::SEND_GOAL_FAILURE;}) {
+      setOutput("error_code_id", ActionResult::SEND_GOAL_FAILURE);
+    } else if constexpr (requires {ActionT::Result::UNKNOWN;}) {
+      setOutput("error_code_id", ActionResult::UNKNOWN);
+    }
+    setOutput("error_msg", "Failed to send goal to the action server.");
   }
 
   /**
@@ -285,9 +345,11 @@ public:
         }
       }
     } catch (const std::runtime_error & e) {
-      if (e.what() == std::string("send_goal failed") ||
-        e.what() == std::string("Goal was rejected by the action server"))
-      {
+      if (e.what() == std::string("Goal was rejected by the action server")) {
+        on_goal_rejected();
+        return BT::NodeStatus::FAILURE;
+      } else if (e.what() == std::string("send_goal failed")) {
+        on_send_goal_failure();
         // Action related failure that should not fail the tree, but the node
         return BT::NodeStatus::FAILURE;
       } else {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
@@ -73,12 +73,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();
@@ -93,10 +87,6 @@ public:
       {
         BT::InputPort<double>("time_allowance", 10.0, "Allowed time for running assisted teleop"),
         BT::InputPort<bool>("is_recovery", false, "If true the recovery count will be incremented"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The assisted teleop behavior server error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The assisted teleop behavior server error msg"),
       });
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -74,12 +74,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();
@@ -96,10 +90,6 @@ public:
         BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup"),
         BT::InputPort<double>("time_allowance", 10.0, "Allowed time for reversing"),
         BT::InputPort<bool>("disable_collision_checks", false, "Disable collision checking"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The back up behavior server error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The back up behavior server error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_and_track_route_action.hpp
@@ -73,12 +73,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Function to perform some user-defined operation after a timeout
    * waiting for a result that hasn't been received yet
    * @param feedback shared_ptr to latest feedback message
@@ -114,10 +108,6 @@ public:
         BT::OutputPort<builtin_interfaces::msg::Duration>(
           "execution_duration",
           "Time taken to compute and track route"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The compute route error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The compute route error msg"),
         BT::OutputPort<uint16_t>(
           "last_node_id",
           "ID of the previous node"),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -110,10 +110,6 @@ public:
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathThroughPoses node"),
         BT::OutputPort<int>(
           "last_reached_index", "Index of the last reachable pose from requested list of poses"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The compute path through poses error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The compute path through poses error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -75,12 +75,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;
@@ -111,10 +105,6 @@ public:
           "planner_id", "",
           "Mapped name to the planner plugin type to use"),
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The compute path to pose error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The compute path to pose error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_route_action.hpp
@@ -73,12 +73,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;
@@ -114,10 +108,6 @@ public:
           "planning_time",
           "Time taken to compute route"),
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputeRoute node"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The compute route error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The compute route error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
@@ -69,10 +69,6 @@ public:
         BT::InputPort<double>("speed", 0.025, "Speed at which to travel"),
         BT::InputPort<double>("time_allowance", 10.0, "Allowed time for driving on heading"),
         BT::InputPort<bool>("disable_collision_checks", false, "Disable collision checking"),
-        BT::OutputPort<Action::Result::_error_code_type>(
-          "error_code_id", "The drive on heading behavior server error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The drive on heading behavior server error msg"),
       });
   }
 
@@ -95,12 +91,6 @@ public:
    * @brief Function to perform some user-defined operation upon cancellation of the action
    */
   BT::NodeStatus on_cancelled() override;
-
-  /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_object_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_object_action.hpp
@@ -90,10 +90,6 @@ public:
 
         BT::OutputPort<ActionResult::_total_elapsed_time_type>(
           "total_elapsed_time", "Total elapsed time"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "Error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "Error message"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -111,10 +111,6 @@ public:
         BT::InputPort<std::string>("path_handler_id", ""),
         BT::OutputPort<nav2_msgs::msg::TrackingFeedback>("tracking_feedback",
           "Tracking feedback from controller server"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The follow path error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The follow path error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -75,12 +75,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */
@@ -94,10 +88,6 @@ public:
         BT::InputPort<nav_msgs::msg::Goals>(
           "goals", "Destinations to plan through"),
         BT::InputPort<std::string>("behavior_tree", "Behavior tree to run"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The navigate through poses error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The navigate through poses error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
@@ -75,12 +75,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */
@@ -93,10 +87,6 @@ public:
       {
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
         BT::InputPort<std::string>("behavior_tree", "Behavior tree to run"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "Navigate to pose error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "Navigate to pose error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
@@ -75,12 +75,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing basic ports along with node-specific ports
    */
@@ -103,10 +97,6 @@ public:
         BT::OutputPort<double>("smoothing_duration", "Time taken to smooth path"),
         BT::OutputPort<bool>(
           "was_completed", "True if smoothing was not interrupted by time limit"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The smooth path error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The smooth path error msg"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
@@ -58,12 +58,6 @@ public:
   void on_tick() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();
@@ -80,10 +74,6 @@ public:
         BT::InputPort<double>("time_allowance", 10.0, "Allowed time for spinning"),
         BT::InputPort<bool>("is_recovery", true, "True if recovery"),
         BT::InputPort<bool>("disable_collision_checks", false, "Disable collision checking"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The spin behavior error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The spin behavior error msg"),
       });
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
@@ -57,12 +57,6 @@ public:
   void on_tick() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * @brief Function to read parameters and initialize class variables
    */
   void initialize();
@@ -76,10 +70,6 @@ public:
     return providedBasicPorts(
       {
         BT::InputPort<double>("wait_duration", 1.0, "Wait time"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "The wait behavior error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "The wait behavior error msg"),
       });
   }
 

--- a/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
@@ -69,12 +69,6 @@ BT::NodeStatus AssistedTeleopAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void AssistedTeleopAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -78,12 +78,6 @@ BT::NodeStatus BackUpAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void BackUpAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_and_track_route_action.cpp
@@ -86,12 +86,6 @@ BT::NodeStatus ComputeAndTrackRouteAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void ComputeAndTrackRouteAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 void ComputeAndTrackRouteAction::on_wait_for_result(
   std::shared_ptr<const Action::Feedback> feedback)
 {

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -87,12 +87,6 @@ BT::NodeStatus ComputePathToPoseAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void ComputePathToPoseAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 void ComputePathToPoseAction::halt()
 {
   nav_msgs::msg::Path empty_path;

--- a/nav2_behavior_tree/plugins/action/compute_route_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_route_action.cpp
@@ -87,12 +87,6 @@ BT::NodeStatus ComputeRouteAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void ComputeRouteAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 void ComputeRouteAction::halt()
 {
   resetPorts();

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -76,12 +76,6 @@ BT::NodeStatus DriveOnHeadingAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void DriveOnHeadingAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -64,8 +64,8 @@ BT::NodeStatus FollowPathAction::on_cancelled()
 
 void FollowPathAction::on_timeout()
 {
+  BtActionNode<Action>::on_timeout();
   setOutput("error_code_id", ActionResult::CONTROLLER_TIMED_OUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
 }
 
 void FollowPathAction::on_wait_for_result(

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -61,12 +61,6 @@ BT::NodeStatus NavigateThroughPosesAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void NavigateThroughPosesAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -60,12 +60,6 @@ BT::NodeStatus NavigateToPoseAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void NavigateToPoseAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
@@ -65,12 +65,6 @@ BT::NodeStatus SmoothPathAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void SmoothPathAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/spin_action.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_action.cpp
@@ -71,12 +71,6 @@ BT::NodeStatus SpinAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void SpinAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -73,12 +73,6 @@ BT::NodeStatus WaitAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void WaitAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 }  // namespace nav2_behavior_tree
 
 #include "behaviortree_cpp/bt_factory.h"

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <vector>
@@ -60,6 +61,11 @@ public:
     server_loop_rate_ = server_loop_rate;
   }
 
+  void setGoalResponse(rclcpp_action::GoalResponse goal_response)
+  {
+    goal_response_ = goal_response;
+  }
+
 protected:
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID &,
@@ -69,7 +75,7 @@ protected:
     if (sleep_duration_ > 0ms) {
       std::this_thread::sleep_for(sleep_duration_);
     }
-    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+    return goal_response_;
   }
 
   rclcpp_action::CancelResponse handle_cancel(
@@ -123,6 +129,7 @@ protected:
   rclcpp_action::Server<test_msgs::action::Fibonacci>::SharedPtr action_server_;
   std::chrono::milliseconds sleep_duration_;
   std::chrono::nanoseconds server_loop_rate_;
+  rclcpp_action::GoalResponse goal_response_{rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE};
 };
 
 class FibonacciAction : public nav2_behavior_tree::BtActionNode<test_msgs::action::Fibonacci>
@@ -154,9 +161,27 @@ public:
     return BT::NodeStatus::SUCCESS;
   }
 
+  void on_goal_rejected() override
+  {
+    setOutput("error_code_id", GOAL_REJECTED_ERROR_CODE);
+    config().blackboard->set("on_goal_rejected_triggered", true);
+  }
+
+  void on_send_goal_failure() override
+  {
+    setOutput("error_code_id", SEND_GOAL_FAILURE_ERROR_CODE);
+    config().blackboard->set("on_send_goal_failure_triggered", true);
+  }
+
+  static constexpr uint16_t GOAL_REJECTED_ERROR_CODE = 1;
+  static constexpr uint16_t SEND_GOAL_FAILURE_ERROR_CODE = 2;
+
   static BT::PortsList providedPorts()
   {
-    return providedBasicPorts({BT::InputPort<int>("order", "Fibonacci order")});
+    return providedBasicPorts(
+    {
+      BT::InputPort<int>("order", "Fibonacci order"),
+      });
   }
 };
 
@@ -179,6 +204,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout", 1000ms);
     config_->blackboard->set("initial_pose_received", false);
     config_->blackboard->set("on_cancelled_triggered", false);
+    config_->blackboard->set("on_goal_rejected_triggered", false);
+    config_->blackboard->set("on_send_goal_failure_triggered", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -404,6 +431,28 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   // since the server timeout was smaller than the action server goal handling duration
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::SUCCESS);
+}
+
+TEST_F(BTActionNodeTestFixture, test_goal_rejected)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <Fibonacci order="2" error_code_id="{fibonacci_error_code}" />
+        </BehaviorTree>
+      </root>)";
+
+  config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 100ms);
+  config_->blackboard->set("on_goal_rejected_triggered", false);
+  action_server_->setGoalResponse(rclcpp_action::GoalResponse::REJECT);
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
+  EXPECT_TRUE(config_->blackboard->get<bool>("on_goal_rejected_triggered"));
+  EXPECT_EQ(config_->blackboard->get<uint16_t>("fibonacci_error_code"),
+    FibonacciAction::GOAL_REJECTED_ERROR_CODE);
 }
 
 TEST_F(BTActionNodeTestFixture, test_server_cancel)

--- a/nav2_behavior_tree/test/plugins/action/test_follow_object_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_object_action.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>
@@ -131,6 +132,36 @@ TEST_F(FollowObjectActionTestFixture, test_ports)
   EXPECT_EQ(tree_->rootNode()->getInput<std::string>("pose_topic"), "test_topic");
   EXPECT_EQ(tree_->rootNode()->getInput<double>("max_duration"), 20.0);
   EXPECT_EQ(tree_->rootNode()->getInput<std::string>("tracked_frame"), "test_frame");
+}
+
+TEST_F(FollowObjectActionTestFixture, test_generic_request_error_codes)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <FollowObject error_code_id="{follow_object_error_code}" />
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+  auto * node = dynamic_cast<nav2_behavior_tree::FollowObjectAction *>(tree_->rootNode());
+  ASSERT_NE(node, nullptr);
+
+  node->on_timeout();
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("follow_object_error_code"),
+    nav2_msgs::action::FollowObject::Result::TIMEOUT);
+
+  node->on_goal_rejected();
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("follow_object_error_code"),
+    nav2_msgs::action::FollowObject::Result::GOAL_REJECTED);
+
+  node->on_send_goal_failure();
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("follow_object_error_code"),
+    nav2_msgs::action::FollowObject::Result::SEND_GOAL_FAILURE);
 }
 
 TEST_F(FollowObjectActionTestFixture, test_tick)

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -14,9 +14,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
+#include <thread>
 
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -35,7 +38,34 @@ public:
   : TestActionServer("follow_path")
   {}
 
+  void blockGoalResponse()
+  {
+    std::lock_guard<std::mutex> lock(goal_response_mutex_);
+    goal_response_blocked_ = true;
+  }
+
+  void releaseGoalResponse()
+  {
+    {
+      std::lock_guard<std::mutex> lock(goal_response_mutex_);
+      goal_response_blocked_ = false;
+    }
+    goal_response_cv_.notify_all();
+  }
+
 protected:
+  rclcpp_action::GoalResponse handle_goal(
+    const rclcpp_action::GoalUUID & goal_id,
+    std::shared_ptr<const nav2_msgs::action::FollowPath::Goal> goal) override
+  {
+    {
+      std::unique_lock<std::mutex> lock(goal_response_mutex_);
+      goal_response_cv_.wait(lock, [this]() {return !goal_response_blocked_;});
+    }
+
+    return TestActionServer<nav2_msgs::action::FollowPath>::handle_goal(goal_id, goal);
+  }
+
   void execute(
     const typename std::shared_ptr<
       rclcpp_action::ServerGoalHandle<nav2_msgs::action::FollowPath>> goal_handle)
@@ -45,6 +75,10 @@ protected:
     auto result = std::make_shared<nav2_msgs::action::FollowPath::Result>();
     goal_handle->succeed(result);
   }
+
+  std::condition_variable goal_response_cv_;
+  std::mutex goal_response_mutex_;
+  bool goal_response_blocked_{false};
 };
 
 class FollowPathActionTestFixture : public ::testing::Test
@@ -161,6 +195,39 @@ TEST_F(FollowPathActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses.size(), 1u);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses[0].pose.position.x, -2.5);
+}
+
+TEST_F(FollowPathActionTestFixture, test_server_timeout)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <FollowPath path="{path}" controller_id="FollowPath"
+              error_code_id="{error_code}" error_msg="{error_msg}"/>
+        </BehaviorTree>
+      </root>)";
+
+  nav_msgs::msg::Path path;
+  path.poses.resize(1);
+  config_->blackboard->set("path", path);
+  action_server_->blockGoalResponse();
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  auto result = BT::NodeStatus::RUNNING;
+  while (result == BT::NodeStatus::RUNNING) {
+    result = tree_->tickOnce();
+  }
+
+  EXPECT_EQ(result, BT::NodeStatus::FAILURE);
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("error_code"),
+    nav2_msgs::action::FollowPath::Result::CONTROLLER_TIMED_OUT);
+  EXPECT_EQ(
+    config_->blackboard->get<std::string>("error_msg"),
+    "Behavior Tree action client timed out waiting.");
+
+  action_server_->releaseGoalResponse();
 }
 
 TEST(FollowPathAction, testProgressCheckerIdUpdate)

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -14,9 +14,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
+#include <thread>
 
 #include "behaviortree_cpp/bt_factory.h"
 
@@ -30,7 +33,56 @@ public:
   : TestActionServer("wait")
   {}
 
+  void setGoalResponse(rclcpp_action::GoalResponse goal_response)
+  {
+    goal_response_ = goal_response;
+  }
+
+  void blockGoalResponse()
+  {
+    std::lock_guard<std::mutex> lock(goal_response_mutex_);
+    goal_response_blocked_ = true;
+    goal_request_received_ = false;
+  }
+
+  void releaseGoalResponse()
+  {
+    {
+      std::lock_guard<std::mutex> lock(goal_response_mutex_);
+      goal_response_blocked_ = false;
+    }
+    goal_response_cv_.notify_all();
+  }
+
+  void waitForGoalRequest()
+  {
+    std::unique_lock<std::mutex> lock(goal_response_mutex_);
+    goal_response_cv_.wait(lock, [this]() {return goal_request_received_;});
+  }
+
 protected:
+  rclcpp_action::GoalResponse handle_goal(
+    const rclcpp_action::GoalUUID & goal_id,
+    std::shared_ptr<const nav2_msgs::action::Wait::Goal> goal) override
+  {
+    {
+      std::lock_guard<std::mutex> lock(goal_response_mutex_);
+      goal_request_received_ = true;
+    }
+    goal_response_cv_.notify_all();
+
+    {
+      std::unique_lock<std::mutex> lock(goal_response_mutex_);
+      goal_response_cv_.wait(lock, [this]() {return !goal_response_blocked_;});
+    }
+
+    if (goal_response_ == rclcpp_action::GoalResponse::REJECT) {
+      return goal_response_;
+    }
+
+    return TestActionServer<nav2_msgs::action::Wait>::handle_goal(goal_id, goal);
+  }
+
   void execute(
     const typename std::shared_ptr<rclcpp_action::ServerGoalHandle<nav2_msgs::action::Wait>>
     goal_handle)
@@ -38,6 +90,23 @@ protected:
   {
     auto result = std::make_shared<nav2_msgs::action::Wait::Result>();
     goal_handle->succeed(result);
+  }
+
+  rclcpp_action::GoalResponse goal_response_{rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE};
+  std::condition_variable goal_response_cv_;
+  std::mutex goal_response_mutex_;
+  bool goal_response_blocked_{false};
+  bool goal_request_received_{false};
+};
+
+class TestableWaitAction : public nav2_behavior_tree::WaitAction
+{
+public:
+  using WaitAction::WaitAction;
+
+  void cancelExecutor()
+  {
+    callback_group_executor_.cancel();
   }
 };
 
@@ -77,6 +146,14 @@ public:
       };
 
     factory_->registerBuilder<nav2_behavior_tree::WaitAction>("Wait", builder);
+
+    BT::NodeBuilder testable_builder =
+      [](const std::string & name, const BT::NodeConfiguration & config)
+      {
+        return std::make_unique<TestableWaitAction>(name, "wait", config);
+      };
+
+    factory_->registerBuilder<TestableWaitAction>("TestableWait", testable_builder);
   }
 
   static void TearDownTestCase()
@@ -91,6 +168,7 @@ public:
   void SetUp() override
   {
     config_->blackboard->set("number_recoveries", 0);
+    action_server_->setGoalResponse(rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE);
   }
 
   void TearDown() override
@@ -158,6 +236,59 @@ TEST_F(WaitActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(config_->blackboard->get<int>("number_recoveries"), 1);
   EXPECT_EQ(rclcpp::Duration(action_server_->getCurrentGoal()->time).seconds(), 5.0);
+}
+
+TEST_F(WaitActionTestFixture, test_goal_rejected_error_code)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <Wait error_code_id="{wait_error_code}" error_msg="{wait_error_msg}" />
+        </BehaviorTree>
+      </root>)";
+
+  action_server_->setGoalResponse(rclcpp_action::GoalResponse::REJECT);
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("wait_error_code"),
+    nav2_msgs::action::Wait::Result::GOAL_REJECTED);
+  EXPECT_EQ(
+    config_->blackboard->get<std::string>("wait_error_msg"),
+    "Goal was rejected by the action server.");
+}
+
+TEST_F(WaitActionTestFixture, test_send_goal_failure_error_code)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <TestableWait error_code_id="{wait_error_code}" error_msg="{wait_error_msg}" />
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+  auto * action = dynamic_cast<TestableWaitAction *>(tree_->rootNode());
+  ASSERT_NE(action, nullptr);
+
+  action_server_->blockGoalResponse();
+  std::thread cancel_thread([action]() {
+      WaitActionTestFixture::action_server_->waitForGoalRequest();
+      action->cancelExecutor();
+    });
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
+  action_server_->releaseGoalResponse();
+  cancel_thread.join();
+  EXPECT_EQ(
+    config_->blackboard->get<uint16_t>("wait_error_code"),
+    nav2_msgs::action::Wait::Result::SEND_GOAL_FAILURE);
+  EXPECT_EQ(
+    config_->blackboard->get<std::string>("wait_error_msg"),
+    "Failed to send goal to the action server.");
 }
 
 int main(int argc, char ** argv)

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -185,7 +185,6 @@ TEST(DockingServerTests, testErrorExceptions)
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());
   node->on_shutdown(rclcpp_lifecycle::State());
-  node.reset();
 }
 
 TEST(DockingServerTests, getateGoalDock)

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/dock_robot.hpp
@@ -74,12 +74,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;
@@ -106,10 +100,6 @@ public:
 
         BT::OutputPort<ActionResult::_success_type>(
           "success", "If the action was successful"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "Error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "Error message"),
         BT::OutputPort<ActionResult::_num_retries_type>(
           "num_retries", "The number of retries executed"),
       });

--- a/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
+++ b/nav2_docking/opennav_docking_bt/include/opennav_docking_bt/undock_robot.hpp
@@ -74,12 +74,6 @@ public:
   BT::NodeStatus on_cancelled() override;
 
   /**
-   * @brief Function to perform work in a BT Node when the action server times out
-   * Such as setting the error code ID status to timed out for action clients.
-   */
-  void on_timeout() override;
-
-  /**
    * \brief Override required by the a BT action. Cancel the action and set the path output
    */
   void halt() override;
@@ -99,10 +93,6 @@ public:
 
         BT::OutputPort<ActionResult::_success_type>(
           "success", "If the action was successful"),
-        BT::OutputPort<ActionResult::_error_code_type>(
-          "error_code_id", "Error code"),
-        BT::OutputPort<std::string>(
-          "error_msg", "Error message"),
       });
   }
 };

--- a/nav2_docking/opennav_docking_bt/src/dock_robot.cpp
+++ b/nav2_docking/opennav_docking_bt/src/dock_robot.cpp
@@ -67,12 +67,6 @@ BT::NodeStatus DockRobotAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void DockRobotAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 void DockRobotAction::halt()
 {
   BtActionNode::halt();

--- a/nav2_docking/opennav_docking_bt/src/undock_robot.cpp
+++ b/nav2_docking/opennav_docking_bt/src/undock_robot.cpp
@@ -58,12 +58,6 @@ BT::NodeStatus UndockRobotAction::on_cancelled()
   return BT::NodeStatus::SUCCESS;
 }
 
-void UndockRobotAction::on_timeout()
-{
-  setOutput("error_code_id", ActionResult::TIMEOUT);
-  setOutput("error_msg", "Behavior Tree action client timed out waiting.");
-}
-
 void UndockRobotAction::halt()
 {
   BtActionNode::halt();

--- a/nav2_msgs/action/AssistedTeleop.action
+++ b/nav2_msgs/action/AssistedTeleop.action
@@ -6,6 +6,8 @@ builtin_interfaces/Duration time_allowance
 # Error codes
 # Note: The expected priority order of the error should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=730
 uint16 TIMEOUT=731
 uint16 TF_ERROR=732

--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -10,6 +10,8 @@ bool disable_collision_checks False
 # Error codes
 # Note: The expected priority order of the error should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=710
 uint16 TIMEOUT=711
 uint16 TF_ERROR=712

--- a/nav2_msgs/action/ComputeAndTrackRoute.action
+++ b/nav2_msgs/action/ComputeAndTrackRoute.action
@@ -11,6 +11,8 @@ bool use_poses # Whether to use the poses or the IDs fields for request
 
 # Error codes
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=400
 uint16 TF_ERROR=401
 uint16 NO_VALID_GRAPH=402

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -12,6 +12,8 @@ int16 ALL_GOALS = -1
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=300
 uint16 INVALID_PLANNER=301
 uint16 TF_ERROR=302

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -10,6 +10,8 @@ bool use_start # If false, use current robot pose as path start, if true, use st
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=200
 uint16 INVALID_PLANNER=201
 uint16 TF_ERROR=202

--- a/nav2_msgs/action/ComputeRoute.action
+++ b/nav2_msgs/action/ComputeRoute.action
@@ -11,6 +11,8 @@ bool use_poses # Whether to use the poses or the IDs fields for request
 
 # Error codes
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=400
 uint16 TF_ERROR=401
 uint16 NO_VALID_GRAPH=402

--- a/nav2_msgs/action/DockRobot.action
+++ b/nav2_msgs/action/DockRobot.action
@@ -15,6 +15,8 @@ bool navigate_to_staging_pose True  # Whether or not to navigate to staging pose
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 DOCK_NOT_IN_DB=901
 uint16 DOCK_NOT_VALID=902
 uint16 FAILED_TO_STAGE=903

--- a/nav2_msgs/action/DriveOnHeading.action
+++ b/nav2_msgs/action/DriveOnHeading.action
@@ -10,6 +10,8 @@ bool disable_collision_checks False
 # Error codes
 # Note: The expected priority order of the error should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=720
 uint16 TIMEOUT=721
 uint16 TF_ERROR=722

--- a/nav2_msgs/action/FollowObject.action
+++ b/nav2_msgs/action/FollowObject.action
@@ -10,9 +10,12 @@ builtin_interfaces/Duration max_duration
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 TF_ERROR=901
 uint16 FAILED_TO_DETECT_OBJECT=902
 uint16 FAILED_TO_CONTROL=903
+uint16 TIMEOUT=904
 uint16 UNKNOWN=999
 
 builtin_interfaces/Duration total_elapsed_time

--- a/nav2_msgs/action/FollowPath.action
+++ b/nav2_msgs/action/FollowPath.action
@@ -10,6 +10,8 @@ string path_handler_id
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=100
 uint16 INVALID_CONTROLLER=101
 uint16 TF_ERROR=102
@@ -18,6 +20,7 @@ uint16 PATIENCE_EXCEEDED=104
 uint16 FAILED_TO_MAKE_PROGRESS=105
 uint16 NO_VALID_CONTROL=106
 uint16 CONTROLLER_TIMED_OUT=107
+uint16 TIMEOUT=108
 
 std_msgs/Empty result
 uint16 error_code

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -8,6 +8,8 @@ string behavior_tree
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=9100
 uint16 FAILED_TO_LOAD_BEHAVIOR_TREE=9101
 uint16 TF_ERROR=9102

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -7,6 +7,8 @@ string behavior_tree
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=9000
 uint16 FAILED_TO_LOAD_BEHAVIOR_TREE=9001
 uint16 TF_ERROR=9002

--- a/nav2_msgs/action/SmoothPath.action
+++ b/nav2_msgs/action/SmoothPath.action
@@ -9,6 +9,8 @@ bool check_for_collisions
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=500
 uint16 INVALID_SMOOTHER=501
 uint16 TIMEOUT=502

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -8,6 +8,8 @@ bool disable_collision_checks False
 # Error codes
 # Note: The expected priority order of the error should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=700
 uint16 TIMEOUT=701
 uint16 TF_ERROR=702

--- a/nav2_msgs/action/UndockRobot.action
+++ b/nav2_msgs/action/UndockRobot.action
@@ -14,6 +14,8 @@ float32 max_undocking_time 30.0 # Maximum time to undock
 # Error codes
 # Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 DOCK_NOT_VALID=902
 uint16 FAILED_TO_CONTROL=905
 uint16 TIMEOUT=907

--- a/nav2_msgs/action/Wait.action
+++ b/nav2_msgs/action/Wait.action
@@ -7,6 +7,8 @@ uint16 error_code
 string error_msg
 
 uint16 NONE=0
+uint16 GOAL_REJECTED=1
+uint16 SEND_GOAL_FAILURE=2
 uint16 UNKNOWN=740
 uint16 TIMEOUT=741
 ---


### PR DESCRIPTION
`BtActionNode` returned `FAILURE` when an action goal was rejected or could
not be sent, without giving derived nodes a way to report the reason.

This PR:

- Adds callbacks for goal rejection and send-goal failures.
- Adds corresponding action result error codes.
- Updates BT action nodes to set `error_code_id` for both failures.
- Adds regression coverage for rejected goals.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | / |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | / |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
