### PR TITLE
fix(smac_planner): apply reverse penalty to analytic expansion

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion.hpp
@@ -91,8 +91,14 @@ public:
       direction_changes = changes;
     }
 
+    void setReverseDistance(float distance)
+    {
+      reverse_distance = distance;
+    }
+
     std::vector<AnalyticExpansionNode> nodes;
     int direction_changes{0};
+    float reverse_distance{0.0f};
   };
 
   /**
@@ -183,6 +189,22 @@ public:
   int countDirectionChanges(const ompl::base::ReedsSheppStateSpace::PathType & path);
   #else
   int countDirectionChanges(const ompl::base::ReedsSheppStateSpace::ReedsSheppPath & path);
+  #endif
+
+  /**
+    * @brief Computes the distance traveled in reverse in a Reeds-Shepp path
+    * @param path The Reeds-Shepp path to inspect
+    * @param path_distance The total path distance in grid coordinates
+    * @return The reverse distance in grid coordinates
+    */
+  #if OMPL_VERSION_VALUE >= 2000000  // 2.0.0
+  float getReverseDistance(
+    const ompl::base::ReedsSheppStateSpace::PathType & path,
+    const float path_distance);
+  #else
+  float getReverseDistance(
+    const ompl::base::ReedsSheppStateSpace::ReedsSheppPath & path,
+    const float path_distance);
   #endif
 
   /**

--- a/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion_impl.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/analytic_expansion_impl.hpp
@@ -187,6 +187,31 @@ int AnalyticExpansion<NodeT>::countDirectionChanges(
 }
 
 template<typename NodeT>
+float AnalyticExpansion<NodeT>::getReverseDistance(
+#if OMPL_VERSION_VALUE >= 2000000  // 2.0.0
+  const ompl::base::ReedsSheppStateSpace::PathType & path,
+#else
+  const ompl::base::ReedsSheppStateSpace::ReedsSheppPath & path,
+#endif
+  const float path_distance)
+{
+  float normalized_distance = 0.0f;
+  float normalized_reverse_distance = 0.0f;
+  for (int i = 0; i < 5; ++i) {
+    const float segment_distance = static_cast<float>(path.length_[i]);
+    normalized_distance += std::abs(segment_distance);
+    if (segment_distance < 0.0f) {
+      normalized_reverse_distance -= segment_distance;
+    }
+  }
+
+  if (normalized_distance == 0.0f) {
+    return 0.0f;
+  }
+  return path_distance * normalized_reverse_distance / normalized_distance;
+}
+
+template<typename NodeT>
 typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<NodeT>::getAnalyticPath(
   const NodePtr & node,
   const NodePtr & goal,
@@ -209,12 +234,15 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
     auto rs_state_space = dynamic_cast<ompl::base::ReedsSheppStateSpace *>(state_space.get());
     int direction_changes = 0;
+    float reverse_distance = 0.0f;
     if (rs_state_space) {
       #if OMPL_VERSION_VALUE >= 2000000  // 2.0.0
-      direction_changes = countDirectionChanges(rs_state_space->getPath(from.get(), to.get()));
+      const auto path = rs_state_space->getPath(from.get(), to.get());
       #else
-      direction_changes = countDirectionChanges(rs_state_space->reedsShepp(from.get(), to.get()));
+      const auto path = rs_state_space->reedsShepp(from.get(), to.get());
       #endif
+      direction_changes = countDirectionChanges(path);
+      reverse_distance = getReverseDistance(path, d);
     }
 
     // A move of sqrt(2) is guaranteed to be in a new cell
@@ -330,6 +358,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
     }
 
     possible_nodes.setDirectionChanges(direction_changes);
+    possible_nodes.setReverseDistance(reverse_distance);
     return possible_nodes;
   }
 }
@@ -396,12 +425,12 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
           // Search's Traversal Cost Function
           score += distance * (1.0 + weight * normalized_cost);
         }
+        score += expansion.reverse_distance * (_ctx->motion_table.reverse_penalty - 1.0f);
         return score;
       };
 
     float original_score = scoringFn(analytic_nodes);
     float best_score = original_score;
-    float score = std::numeric_limits<float>::max();
     float min_turn_rad = _ctx->motion_table.min_turning_radius;
     const float max_min_turn_rad = 4.0 * min_turn_rad;  // Up to 4x the turning radius
 
@@ -409,6 +438,43 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
     if (_ctx->motion_table.motion_model == MotionModel::OMNI) {
       return best_score;
     }
+
+    auto considerCandidate = [&](AnalyticExpansionNodes & candidate) {
+        const float candidate_score = scoringFn(candidate);
+        // Normal scoring: prioritize lower cost as long as not more directional changes
+        if (candidate_score <= best_score &&
+          candidate.direction_changes <= analytic_nodes.direction_changes)
+        {
+          analytic_nodes = candidate;
+          best_score = candidate_score;
+          return;
+        }
+
+        // Special case: If we have a better score than original (only) and less directional changes
+        // the path quality is still better than the original and is less operationally complex
+        if (candidate_score <= original_score &&
+          candidate.direction_changes < analytic_nodes.direction_changes)
+        {
+          analytic_nodes = candidate;
+          best_score = candidate_score;
+        }
+      };
+
+    auto considerForwardCandidate =
+      [&](const AnalyticExpansionNodes & reversible_candidate, const float turning_radius) {
+        if (_ctx->motion_table.motion_model != MotionModel::REEDS_SHEPP ||
+          _ctx->motion_table.reverse_penalty <= 1.0f ||
+          reversible_candidate.reverse_distance <= 0.0f)
+        {
+          return;
+        }
+
+        auto state_space = std::make_shared<ompl::base::DubinsStateSpace>(turning_radius);
+        refined_analytic_nodes = getAnalyticPath(node, goal_node, getter, state_space);
+        considerCandidate(refined_analytic_nodes);
+      };
+
+    considerForwardCandidate(analytic_nodes, min_turn_rad);
 
     while (min_turn_rad < max_min_turn_rad) {
       min_turn_rad += 0.5;  // In Grid Coords, 1/2 cell steps
@@ -419,25 +485,8 @@ float AnalyticExpansion<NodeT>::refineAnalyticPath(
         state_space = std::make_shared<ompl::base::ReedsSheppStateSpace>(min_turn_rad);
       }
       refined_analytic_nodes = getAnalyticPath(node, goal_node, getter, state_space);
-      score = scoringFn(refined_analytic_nodes);
-
-      // Normal scoring: prioritize lower cost as long as not more directional changes
-      if (score <= best_score &&
-        refined_analytic_nodes.direction_changes <= analytic_nodes.direction_changes)
-      {
-        analytic_nodes = refined_analytic_nodes;
-        best_score = score;
-        continue;
-      }
-
-      // Special case: If we have a better score than original (only) and less directional changes
-      // the path quality is still better than the original and is less operationally complex
-      if (score <= original_score &&
-        refined_analytic_nodes.direction_changes < analytic_nodes.direction_changes)
-      {
-        analytic_nodes = refined_analytic_nodes;
-        best_score = score;
-      }
+      considerCandidate(refined_analytic_nodes);
+      considerForwardCandidate(refined_analytic_nodes, min_turn_rad);
     }
 
     return best_score;

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -238,7 +238,7 @@ TEST(AStarTest, test_a_star_analytic_expansion)
   nav2_smac_planner::SearchInfo info;
   info.change_penalty = 0.0;
   info.non_straight_penalty = 1.1;
-  info.reverse_penalty = 0.0;
+  info.reverse_penalty = 1000.0;
   info.minimum_turning_radius = 8;  // in grid coordinates
   info.retrospective_penalty = 0.015;
   info.analytic_expansion_max_length = 2000.0;  // in grid coordinates
@@ -291,6 +291,77 @@ TEST(AStarTest, test_a_star_analytic_expansion)
   }
 
   delete costmapA;
+}
+
+namespace
+{
+
+nav2_smac_planner::NodeHybrid::CoordinateVector createReversePenaltyPath(
+  const float reverse_penalty)
+{
+  auto lnode = std::make_shared<nav2::LifecycleNode>("reverse_penalty_test");
+  nav2_smac_planner::SearchInfo info;
+  info.change_penalty = 0.0;
+  info.non_straight_penalty = 1.1;
+  info.reverse_penalty = reverse_penalty;
+  info.minimum_turning_radius = 8.0;
+  info.retrospective_penalty = 0.0;
+  info.analytic_expansion_max_length = 2000.0;
+  info.analytic_expansion_ratio = 3.5;
+  info.cost_penalty = 1.7;
+
+  constexpr unsigned int size_theta = 72;
+  nav2_smac_planner::AStarAlgorithm<nav2_smac_planner::NodeHybrid> a_star(
+    nav2_smac_planner::MotionModel::REEDS_SHEPP, info);
+  int max_iterations = 10000;
+  a_star.initialize(false, max_iterations, 1000, 5000, 120.0, 401, size_theta);
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>();
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+  auto costmap = costmap_ros->getCostmap();
+  *costmap = nav2_costmap_2d::Costmap2D(120, 120, 0.1, 0.0, 0.0, 0);
+
+  auto checker = std::make_unique<nav2_smac_planner::GridCollisionChecker>(
+    costmap_ros, size_theta, lnode);
+  checker->setFootprint(nav2_costmap_2d::Footprint(), true, 0.0);
+
+  a_star.setCollisionChecker(checker.get());
+  a_star.setStart(80u, 60u, 0u);
+  a_star.setGoal(40u, 60u, 0u);
+
+  nav2_smac_planner::NodeHybrid::CoordinateVector path;
+  int num_iterations = 0;
+  auto cancel_checker = []() {return false;};
+  EXPECT_TRUE(a_star.createPath(path, num_iterations, 0.0, cancel_checker));
+  return path;
+}
+
+float reverseDistance(const nav2_smac_planner::NodeHybrid::CoordinateVector & path)
+{
+  float distance = 0.0;
+  for (size_t i = path.size(); i > 1; --i) {
+    const auto & from = path[i - 1];
+    const auto & to = path[i - 2];
+    const float dx = to.x - from.x;
+    const float dy = to.y - from.y;
+    if (dx * std::cos(from.theta) + dy * std::sin(from.theta) < 0.0) {
+      distance += std::hypot(dx, dy);
+    }
+  }
+  return distance;
+}
+
+}  // namespace
+
+TEST(AStarTest, test_analytic_expansion_reverse_penalty)
+{
+  const auto baseline_penalty_path = createReversePenaltyPath(1.0);
+  const auto high_penalty_path = createReversePenaltyPath(1000.0);
+  const float baseline_penalty_reverse_distance = reverseDistance(baseline_penalty_path);
+  const float high_penalty_reverse_distance = reverseDistance(high_penalty_path);
+
+  EXPECT_NEAR(baseline_penalty_reverse_distance, 40.0, 1e-3);
+  EXPECT_NEAR(high_penalty_reverse_distance, 0.0, 1e-3);
 }
 
 TEST(AStarTest, test_a_star_lattice)


### PR DESCRIPTION
## Summary

Fixes #6075 by applying `reverse_penalty` to Reeds-Shepp analytic-expansion scoring and allowing penalized reversible candidates to compete with a valid forward-only Dubins candidate.

The forward candidate is generated only when the motion model is Reeds-Shepp, `reverse_penalty > 1.0`, and the corresponding reversible candidate contains reverse travel. This avoids extra candidate work for unpenalized and already-forward paths.

No public parameter or API is added. Dubins and OMNI behavior is unchanged.

## Root cause

Ordinary Hybrid-A* and State Lattice traversal applied the configured reverse-motion multiplier, but analytic refinement scored only path distance and costmap cost. The Reeds-Shepp analytic shortcut therefore bypassed the planner-wide reverse cost policy. Analytic refinement also produced no forward-only candidate for the configured penalty to select.

## Changes

- Carry exact reverse distance from OMPL's signed Reeds-Shepp segments with each analytic candidate.
- Add `(reverse_penalty - 1) * reverse_distance` to analytic scoring, preserving existing scoring when `reverse_penalty == 1.0`.
- Compare a collision-checked Dubins candidate only when a penalized Reeds-Shepp candidate actually reverses.
- Add a deterministic empty-costmap regression fixture.
- Exercise reverse-required geometry with a high reverse penalty to ensure reversing remains allowed.

## Reproduction and functional result

Fixture:

- empty `120 x 120` costmap
- Reeds-Shepp motion
- minimum turning radius: 8 cells
- start: `(80, 60, 0)`
- goal: `(40, 60, 0)`
- reverse travel measured by projecting displacement onto vehicle heading in start-to-goal order

Before this change:

| `reverse_penalty` | Reverse travel |
|---:|---:|
| 1.01 | 40 cells |
| 1000 | 40 cells |

After this change:

| `reverse_penalty` | Reverse travel |
|---:|---:|
| 1.0 | 40 cells |
| 1000 | 0 cells |

Reverse-required boundary geometry remains solvable at `reverse_penalty = 1000`.

## Validation

Tested from main commit `2f6e54f73c4c27004663e7afc55a2f1bd2ebd038` using the Nav2 Lyrical nightly image on Ubuntu 24.04:

- baseline: 306 tests, 0 errors, 0 failures, 54 skipped
- patched: 307 tests, 0 errors, 0 failures, 54 skipped
- all 21 `nav2_smac_planner` CTest targets passed
- package formatting and lint checks passed
- `git diff --check` passed

Jazzy compatibility was evaluated separately at `c92ea2fd9008f50c0ec8447610800214b2a0dafb`:

- the unpatched fixture reproduced 40 reverse cells at high penalty
- a bounded adaptation passed the witness
- 270 tests, 0 errors, 0 failures, 46 skipped
- all 20 package CTest targets passed

Jazzy uses the older vector-only analytic-result representation, so a backport would require a small distinct implementation; this PR does not target Jazzy.

## Bounded performance comparison

Matched Release builds at the same parent commit were run on a GCP `e2-standard-8`, pinned to one CPU. The harness timed only `AStarAlgorithm::createPath`, initialized the planner once per scenario, cleared graph state between trials, excluded five warmups, and used ABBA run ordering. Behavior-equivalent cases used 120 measured trials per variant, except the corrected thick-obstacle case with 60.

The declared materiality gate was median regression greater than 10% and 0.1 ms, or p95 regression greater than 20% and 0.2 ms.

| Scenario | Baseline median | Patched median | Median delta | p95 delta | Outcome |
|---|---:|---:|---:|---:|---|
| forward open | 13.392 ms | 13.527 ms | +1.0% | -35.1% | matched |
| Hybrid with thick obstacle | 14.090 ms | 14.233 ms | +1.0% | +5.3% | matched |
| reverse open, penalty 1 | 3.249 ms | 3.226 ms | -0.7% | -2.5% | matched |
| reverse required, penalty 1000 | 4.863 ms | 5.110 ms | +5.1% | -30.8% | matched |
| reversible Lattice | 0.698 ms | 0.689 ms | -1.3% | +6.9% | matched |

No behavior-equivalent case crossed the declared materiality gate.

The intentionally behavior-changing high-penalty fixture increased from 3.189 ms to 6.753 ms median (`+3.564 ms`, `+111.8%`), with p95 changing by `+1.6%`. This case changes the selected path from 40 reverse cells to zero and is reported separately rather than treated as a behavior-equivalent regression.

These measurements are bounded synthetic, single-machine evidence, not a production latency guarantee.