### PR TITLE
Expose number_of_loops and goal_index in BasicNavigator.followWaypoints

### DIFF
--- a/nav2_simple_commander/README.md
+++ b/nav2_simple_commander/README.md
@@ -21,7 +21,7 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 | setInitialPose(initial_pose)      | Sets the initial pose (`PoseStamped`) of the robot to localization.        |
 | goThroughPoses(poses, behavior_tree='') | Requests the robot to drive through a set of poses (list of `PoseStamped`).|
 | goToPose(pose, behavior_tree='')  | Requests the robot to drive to a pose (`PoseStamped`).                     |
-| followWaypoints(poses)            | Requests the robot to follow a set of waypoints (list of `PoseStamped`). This will execute the specific `TaskExecutor` at each pose.   |
+| followWaypoints(poses, number_of_loops=0) | Requests the robot to follow a set of waypoints (list of `PoseStamped`), repeating the full set `number_of_loops` additional times after the first pass (0 runs it once). This will execute the specific `TaskExecutor` at each pose.   |
 | followPath(path, controller_id='', goal_checker_id='', progress_checker_id='', path_handler_id='') | Requests the robot to follow a path from a starting to a goal `PoseStamped`, `nav_msgs/Path`.     |
 | spin(spin_dist=1.57, time_allowance=10, disable_collision_checks=False)   | Requests the robot to performs an in-place rotation by a given angle.      |
 | backup(backup_dist=0.15, backup_speed=0.025, time_allowance=10, disable_collision_checks=False) | Requests the robot to back up by a given distance.         |

--- a/nav2_simple_commander/README.md
+++ b/nav2_simple_commander/README.md
@@ -21,7 +21,7 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 | setInitialPose(initial_pose)      | Sets the initial pose (`PoseStamped`) of the robot to localization.        |
 | goThroughPoses(poses, behavior_tree='') | Requests the robot to drive through a set of poses (list of `PoseStamped`).|
 | goToPose(pose, behavior_tree='')  | Requests the robot to drive to a pose (`PoseStamped`).                     |
-| followWaypoints(poses, number_of_loops=0) | Requests the robot to follow a set of waypoints (list of `PoseStamped`), repeating the full set `number_of_loops` additional times after the first pass (0 runs it once). This will execute the specific `TaskExecutor` at each pose.   |
+| followWaypoints(poses, number_of_loops=0, goal_index=0) | Requests the robot to follow a set of waypoints (list of `PoseStamped`), repeating the full set `number_of_loops` additional times after the first pass (0 runs it once), starting from `goal_index` into `poses` rather than the beginning. This will execute the specific `TaskExecutor` at each pose.   |
 | followPath(path, controller_id='', goal_checker_id='', progress_checker_id='', path_handler_id='') | Requests the robot to follow a path from a starting to a goal `PoseStamped`, `nav_msgs/Path`.     |
 | spin(spin_dist=1.57, time_allowance=10, disable_collision_checks=False)   | Requests the robot to performs an in-place rotation by a given angle.      |
 | backup(backup_dist=0.15, backup_speed=0.025, time_allowance=10, disable_collision_checks=False) | Requests the robot to back up by a given distance.         |

--- a/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
+++ b/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
@@ -279,7 +279,9 @@ class BasicNavigator(Node):
         self.result_future = self.goal_handle.get_result_async()
         return RunningTask.NAVIGATE_TO_POSE
 
-    def followWaypoints(self, poses: list[PoseStamped], number_of_loops: int = 0):
+    def followWaypoints(
+        self, poses: list[PoseStamped], number_of_loops: int = 0, goal_index: int = 0
+    ):
         """Send a `FollowWaypoints` action request."""
         self.clearPreviousState()
         self.debug("Waiting for 'FollowWaypoints' action server")
@@ -289,6 +291,7 @@ class BasicNavigator(Node):
         goal_msg = FollowWaypoints.Goal()
         goal_msg.poses = poses
         goal_msg.number_of_loops = number_of_loops
+        goal_msg.goal_index = goal_index
 
         self.info(f'Following {len(goal_msg.poses)} goals....')
         send_goal_future = self.follow_waypoints_client.send_goal_async(

--- a/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
+++ b/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
@@ -279,7 +279,7 @@ class BasicNavigator(Node):
         self.result_future = self.goal_handle.get_result_async()
         return RunningTask.NAVIGATE_TO_POSE
 
-    def followWaypoints(self, poses: list[PoseStamped]):
+    def followWaypoints(self, poses: list[PoseStamped], number_of_loops: int = 0):
         """Send a `FollowWaypoints` action request."""
         self.clearPreviousState()
         self.debug("Waiting for 'FollowWaypoints' action server")
@@ -288,6 +288,7 @@ class BasicNavigator(Node):
 
         goal_msg = FollowWaypoints.Goal()
         goal_msg.poses = poses
+        goal_msg.number_of_loops = number_of_loops
 
         self.info(f'Following {len(goal_msg.poses)} goals....')
         send_goal_future = self.follow_waypoints_client.send_goal_async(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None — I searched open issues/PRs on ros-navigation/navigation2 for "number_of_loops" and "goal_index", found nothing.|
| Primary OS tested on | Ubuntu 24.04 with ROS 2 Kilted |
| Robotic platform tested on | LeKiwi (github.com/adityakamath/lekiwi_ros2) - 3 omni-wheeled robot |
| Does this PR contain AI generated software? | No; README updates were AI-generated, but manually reviewed |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* `FollowWaypoints.action` has always defined `number_of_loops` and `goal_index`, but the Python wrapper `BasicNavigator.followWaypoints()` in `nav2_simple_commander` never sets either of them, leaving both at their zero defaults.
* Added `number_of_loops: int = 0` and `goal_index: int = 0` as optional keyword arguments to `followWaypoints()`. 
* Updated the README's method table entry for `followWaypoints` to document the new signature and the actual loop semantics


## Description of documentation updates required from your changes

* The PR includes updates to the `nav2_simple_commander/README.md` table
* Not sure whether docs.nav2.org needs updating

## Description of how this change was tested

* Validated on the actual robot, recorded three waypoint poses (A, B, C), set the number of loops to 3, and goal_index to 1. The robot starts driving to B (goal_index 1), then to C, and then performs 3 loops of (A->B->C)

---

## Future work that may be required in bullet points

* I would like to see this tested on a second robot to verify. 
* `followGpsWaypoints()` / `FollowGPSWaypoints.Goal.number_of_loops` has the identical gap — not addressed in this PR. I could add it as well, but I don't have a way of testing it. 
* `nav2_simple_commander` has no unit tests at all for its action-sending methods; it would be great to add some, as gaps such as the one addressed here could be caught early.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
