### PR TITLE
Validate retained path state against local costmap (#6235)

### DIFF
--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -191,22 +191,18 @@ protected:
   void publishZeroVelocity();
   /**
    * @brief Called on goal exit
-   * @param force_stop If true, publish a zero-velocity command (cancel/failure)
-   * @param reset_path_handler_state If true, clear prune caches on all path handlers
-   *        (success and cancel). Leave false on control failure so BT FollowPath
-   *        retries can retain prune progress for the active handler.
+   * @param force_stop If true, publish a zero-velocity command
+   * @param reset_path_handler_state If true, reset all path handlers
    */
   void onGoalExit(bool force_stop, bool reset_path_handler_state);
 
   /**
-   * @brief Select the active path handler, resetting outgoing and incoming caches
-   *        when the plugin id changes so stale prune state cannot leak across
-   *        preemption or later missions that reuse the same geometry.
+   * @brief Select the active path handler, resetting caches when the id changes
    */
   void setCurrentPathHandler(const std::string & path_handler_id);
 
   /**
-   * @brief Clear identical-plan prune caches on every registered path handler
+   * @brief Reset every registered path handler
    */
   void resetAllPathHandlers();
   /**

--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -198,8 +198,19 @@ protected:
   void publishZeroVelocity();
   /**
    * @brief Called on goal exit
+   * @param force_stop Whether to publish a zero velocity regardless of configuration
+   * @param reset_path_handler_state Whether to clear the path state retained for goal retries
    */
-  void onGoalExit(bool force_stop);
+  void onGoalExit(bool force_stop, bool reset_path_handler_state);
+  /**
+   * @brief Select the path handler to use, resetting state cached by the handlers involved
+   * @param path_handler_id Name of the path handler to select
+   */
+  void setCurrentPathHandler(const std::string & path_handler_id);
+  /**
+   * @brief Clear the state retained by all path handlers
+   */
+  void resetAllPathHandlers();
   /**
    * @brief Wait for costmap to become current, with timeout
    * @return Duration in seconds spent waiting for the costmap (0.0 if already current)

--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -191,8 +191,24 @@ protected:
   void publishZeroVelocity();
   /**
    * @brief Called on goal exit
+   * @param force_stop If true, publish a zero-velocity command (cancel/failure)
+   * @param reset_path_handler_state If true, clear prune caches on all path handlers
+   *        (success and cancel). Leave false on control failure so BT FollowPath
+   *        retries can retain prune progress for the active handler.
    */
-  void onGoalExit(bool force_stop);
+  void onGoalExit(bool force_stop, bool reset_path_handler_state);
+
+  /**
+   * @brief Select the active path handler, resetting outgoing and incoming caches
+   *        when the plugin id changes so stale prune state cannot leak across
+   *        preemption or later missions that reuse the same geometry.
+   */
+  void setCurrentPathHandler(const std::string & path_handler_id);
+
+  /**
+   * @brief Clear identical-plan prune caches on every registered path handler
+   */
+  void resetAllPathHandlers();
   /**
    * @brief Wait for costmap to become current, with timeout
    * @return Duration in seconds spent waiting for the costmap (0.0 if already current)

--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -69,6 +69,11 @@ public:
   void setPlan(const nav_msgs::msg::Path & path) override;
 
   /**
+   * @brief Clear identical-plan cache and pruned path state
+   */
+  void reset() override;
+
+  /**
    * @brief Determines the portion of the global plan to be used for local control.
    * This function locates the start and end iterators of the global plan segment
    * that is relevant for controller computation based on the robot's current pose and local costmap.

--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -132,6 +132,16 @@ protected:
     */
   void prunePlan(nav_msgs::msg::Path & plan, const nav2_core::PathIterator end);
 
+  /**
+    * @brief Compare two plans by frame and pose geometry, ignoring stamps
+    * @param path1 First path
+    * @param path2 Second path
+    * @return True if the plans contain the same ordered poses
+    */
+  bool isSamePlan(
+    const nav_msgs::msg::Path & path1,
+    const nav_msgs::msg::Path & path2) const;
+
   // Dynamic parameters handler
   std::mutex mutex_;
   rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;
@@ -141,6 +151,8 @@ protected:
   std::string plugin_name_;
   nav2::TransformBuffer::SharedPtr tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
+  // Unmodified copy of the last path passed to setPlan, used to detect reissued goals
+  nav_msgs::msg::Path last_set_plan_;
   nav_msgs::msg::Path global_plan_;
   nav_msgs::msg::Path global_plan_up_to_constraint_;
   geometry_msgs::msg::PoseStamped global_pose_;

--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -69,6 +69,11 @@ public:
   void setPlan(const nav_msgs::msg::Path & path) override;
 
   /**
+   * @brief Clear the retained path state
+   */
+  void reset() override;
+
+  /**
    * @brief Determines the portion of the global plan to be used for local control.
    * This function locates the start and end iterators of the global plan segment
    * that is relevant for controller computation based on the robot's current pose and local costmap.
@@ -132,6 +137,27 @@ protected:
     */
   void prunePlan(nav_msgs::msg::Path & plan, const nav2_core::PathIterator end);
 
+  /**
+    * @brief Populate the working plan from the full plan, applying any path constraints.
+    * Expects mutex_ to already be held by the caller.
+    */
+  void initializeWorkingPlan();
+
+  /**
+    * @brief Find the closest pose to the robot on the working plan, bounded by
+    * max_robot_pose_search_dist. Expects mutex_ to already be held by the caller.
+    * @return Iterator to the closest pose
+    */
+  nav2_core::PathIterator findClosestPose();
+
+  /**
+    * @brief Check whether a pose of the working plan is within the local costmap
+    * @param pose Pose in the global plan frame
+    * @return bool If the pose falls inside the costmap bounds
+    * @throw nav2_core::ControllerTFError If the pose cannot be transformed to the costmap frame
+    */
+  bool isPoseInCostmap(const geometry_msgs::msg::PoseStamped & pose);
+
   // Dynamic parameters handler
   std::mutex mutex_;
   rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;
@@ -141,10 +167,12 @@ protected:
   std::string plugin_name_;
   nav2::TransformBuffer::SharedPtr tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
+  nav_msgs::msg::Path unpruned_global_plan_;
   nav_msgs::msg::Path global_plan_;
   nav_msgs::msg::Path global_plan_up_to_constraint_;
   geometry_msgs::msg::PoseStamped global_pose_;
   unsigned int constraint_locale_{0u};
+  bool retained_state_needs_validation_{false};
   bool reject_unit_path_, enforce_path_inversion_, enforce_path_rotation_;
   double max_robot_pose_search_dist_, transform_tolerance_, prune_distance_;
   float inversion_xy_tolerance_, inversion_yaw_tolerance_, minimum_rotation_angle_;

--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -69,7 +69,7 @@ public:
   void setPlan(const nav_msgs::msg::Path & path) override;
 
   /**
-   * @brief Clear identical-plan cache and pruned path state
+   * @brief Clear path handler state
    */
   void reset() override;
 
@@ -156,8 +156,7 @@ protected:
   std::string plugin_name_;
   nav2::TransformBuffer::SharedPtr tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
-  // Unmodified copy of the last path passed to setPlan, used to detect reissued goals
-  nav_msgs::msg::Path last_set_plan_;
+  nav_msgs::msg::Path unpruned_global_plan_;
   nav_msgs::msg::Path global_plan_;
   nav_msgs::msg::Path global_plan_up_to_constraint_;
   geometry_msgs::msg::PoseStamped global_pose_;

--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -137,16 +137,6 @@ protected:
     */
   void prunePlan(nav_msgs::msg::Path & plan, const nav2_core::PathIterator end);
 
-  /**
-    * @brief Compare two plans by frame and pose geometry, ignoring stamps
-    * @param path1 First path
-    * @param path2 Second path
-    * @return True if the plans contain the same ordered poses
-    */
-  bool isSamePlan(
-    const nav_msgs::msg::Path & path1,
-    const nav_msgs::msg::Path & path2) const;
-
   // Dynamic parameters handler
   std::mutex mutex_;
   rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -135,28 +135,12 @@ void FeasiblePathHandler::reset()
   constraint_locale_ = 0u;
 }
 
-bool FeasiblePathHandler::isSamePlan(
-  const nav_msgs::msg::Path & path1,
-  const nav_msgs::msg::Path & path2) const
-{
-  if (path1.header.frame_id != path2.header.frame_id ||
-    path1.poses.size() != path2.poses.size())
-  {
-    return false;
-  }
-
-  for (size_t i = 0; i < path1.poses.size(); ++i) {
-    if (path1.poses[i].pose != path2.poses[i].pose) {
-      return false;
-    }
-  }
-  return true;
-}
-
 void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
-  if (!unpruned_global_plan_.poses.empty() && isSamePlan(path, unpruned_global_plan_)) {
+  if (!unpruned_global_plan_.poses.empty() &&
+    nav2_util::isSamePlan(path, unpruned_global_plan_))
+  {
     RCLCPP_INFO(
       logger_,
       "Received identical plan; retaining pruned path state (%zu of %zu poses remaining).",

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -126,6 +126,16 @@ bool FeasiblePathHandler::isWithinInversionTolerances(
          fabs(angle_distance) <= inversion_yaw_tolerance_;
 }
 
+void FeasiblePathHandler::reset()
+{
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+  // AI-assisted contribution for ros-navigation/navigation2#6235
+  last_set_plan_ = nav_msgs::msg::Path();
+  global_plan_ = nav_msgs::msg::Path();
+  global_plan_up_to_constraint_ = nav_msgs::msg::Path();
+  constraint_locale_ = 0u;
+}
+
 bool FeasiblePathHandler::isSamePlan(
   const nav_msgs::msg::Path & path1,
   const nav_msgs::msg::Path & path2) const
@@ -156,6 +166,7 @@ bool FeasiblePathHandler::isSamePlan(
 void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
+  // AI-assisted contribution for ros-navigation/navigation2#6235
   // When FollowPath is reissued with the same global path, keep pruning progress so
   // max_robot_pose_search_dist still reaches the robot (see ros-navigation/navigation2#6235).
   if (!last_set_plan_.poses.empty() && isSamePlan(path, last_set_plan_)) {

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -126,9 +126,47 @@ bool FeasiblePathHandler::isWithinInversionTolerances(
          fabs(angle_distance) <= inversion_yaw_tolerance_;
 }
 
+bool FeasiblePathHandler::isSamePlan(
+  const nav_msgs::msg::Path & path1,
+  const nav_msgs::msg::Path & path2) const
+{
+  if (path1.header.frame_id != path2.header.frame_id ||
+    path1.poses.size() != path2.poses.size())
+  {
+    return false;
+  }
+
+  for (size_t i = 0; i < path1.poses.size(); ++i) {
+    const auto & pose1 = path1.poses[i].pose;
+    const auto & pose2 = path2.poses[i].pose;
+    if (pose1.position.x != pose2.position.x ||
+      pose1.position.y != pose2.position.y ||
+      pose1.position.z != pose2.position.z ||
+      pose1.orientation.x != pose2.orientation.x ||
+      pose1.orientation.y != pose2.orientation.y ||
+      pose1.orientation.z != pose2.orientation.z ||
+      pose1.orientation.w != pose2.orientation.w)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
+  // When FollowPath is reissued with the same global path, keep pruning progress so
+  // max_robot_pose_search_dist still reaches the robot (see ros-navigation/navigation2#6235).
+  if (!last_set_plan_.poses.empty() && isSamePlan(path, last_set_plan_)) {
+    RCLCPP_DEBUG(
+      logger_,
+      "Received identical plan; retaining pruned path state (%zu of %zu poses remaining).",
+      global_plan_up_to_constraint_.poses.size(), path.poses.size());
+    return;
+  }
+
+  last_set_plan_ = path;
   global_plan_ = path;
   global_plan_up_to_constraint_ = global_plan_;
   if (enforce_path_inversion_ || enforce_path_rotation_) {

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -126,15 +126,42 @@ bool FeasiblePathHandler::isWithinInversionTolerances(
          fabs(angle_distance) <= inversion_yaw_tolerance_;
 }
 
-void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
+void FeasiblePathHandler::initializeWorkingPlan()
 {
-  std::lock_guard<std::mutex> lock_reinit(mutex_);
-  global_plan_ = path;
+  global_plan_ = unpruned_global_plan_;
   global_plan_up_to_constraint_ = global_plan_;
+  constraint_locale_ = 0u;
   if (enforce_path_inversion_ || enforce_path_rotation_) {
     constraint_locale_ = nav2_util::removePosesAfterFirstConstraint(global_plan_up_to_constraint_,
       enforce_path_inversion_, minimum_rotation_angle_);
   }
+}
+
+void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
+{
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+
+  // An identical plan is only a candidate for resuming the retained state, which is validated
+  // against the local costmap on the next findPlanSegment call.
+  if (!unpruned_global_plan_.poses.empty() && nav2_util::isSamePlan(path, unpruned_global_plan_)) {
+    RCLCPP_INFO(logger_, "Received identical plan; validating retained path state.");
+    retained_state_needs_validation_ = true;
+    return;
+  }
+
+  unpruned_global_plan_ = path;
+  retained_state_needs_validation_ = false;
+  initializeWorkingPlan();
+}
+
+void FeasiblePathHandler::reset()
+{
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+  unpruned_global_plan_ = nav_msgs::msg::Path();
+  global_plan_ = nav_msgs::msg::Path();
+  global_plan_up_to_constraint_ = nav_msgs::msg::Path();
+  constraint_locale_ = 0u;
+  retained_state_needs_validation_ = false;
 }
 
 geometry_msgs::msg::PoseStamped FeasiblePathHandler::transformToGlobalPlanFrame(
@@ -160,12 +187,8 @@ geometry_msgs::msg::PoseStamped FeasiblePathHandler::transformToGlobalPlanFrame(
   return robot_pose;
 }
 
-nav2_core::PathSegment FeasiblePathHandler::findPlanSegment(
-  const geometry_msgs::msg::PoseStamped & pose)
+nav2_core::PathIterator FeasiblePathHandler::findClosestPose()
 {
-  std::lock_guard<std::mutex> lock_reinit(mutex_);
-  global_pose_ = transformToGlobalPlanFrame(pose);
-
   // Limit the search for the closest pose up to max_robot_pose_search_dist on the path
   auto closest_pose_upper_bound =
     nav2_util::geometry_utils::first_after_integrated_distance(
@@ -175,12 +198,52 @@ nav2_core::PathSegment FeasiblePathHandler::findPlanSegment(
   // First find the closest pose on the path to the robot
   // bounded by when the path turns around (if it does) so we don't get a pose from a later
   // portion of the path
-  auto closest_point =
-    nav2_util::geometry_utils::min_by(
+  return nav2_util::geometry_utils::min_by(
     global_plan_up_to_constraint_.poses.begin(), closest_pose_upper_bound,
     [this](const geometry_msgs::msg::PoseStamped & ps) {
       return euclidean_distance(global_pose_, ps);
     });
+}
+
+bool FeasiblePathHandler::isPoseInCostmap(const geometry_msgs::msg::PoseStamped & pose)
+{
+  geometry_msgs::msg::PoseStamped plan_pose = pose;
+  plan_pose.header.stamp = global_pose_.header.stamp;
+  plan_pose.header.frame_id = global_plan_.header.frame_id;
+
+  geometry_msgs::msg::PoseStamped costmap_pose;
+  if (!nav2_util::transformPoseInTargetFrame(plan_pose, costmap_pose, *tf_,
+      costmap_ros_->getGlobalFrameID(), transform_tolerance_))
+  {
+    throw nav2_core::ControllerTFError("Unable to transform path pose into the costmap frame");
+  }
+
+  unsigned int mx, my;
+  return costmap_ros_->getCostmap()->worldToMap(
+    costmap_pose.pose.position.x, costmap_pose.pose.position.y, mx, my);
+}
+
+nav2_core::PathSegment FeasiblePathHandler::findPlanSegment(
+  const geometry_msgs::msg::PoseStamped & pose)
+{
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+  global_pose_ = transformToGlobalPlanFrame(pose);
+
+  auto closest_point = findClosestPose();
+
+  // A retained plan is only resumed while its closest pose is still within the local costmap,
+  // otherwise the robot has moved away from it and the full path is restored. A transform
+  // failure leaves the state pending for a later attempt.
+  if (retained_state_needs_validation_) {
+    const bool is_retained_state_local = isPoseInCostmap(*closest_point);
+    retained_state_needs_validation_ = false;
+    if (!is_retained_state_local) {
+      RCLCPP_INFO(
+        logger_, "Retained path state is outside the local costmap; restoring the full path.");
+      initializeWorkingPlan();
+      closest_point = findClosestPose();
+    }
+  }
 
   // Do not prune the global plan below 2 points, so there are enough points to interpolate the
   // end-of-path direction.

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -129,8 +129,7 @@ bool FeasiblePathHandler::isWithinInversionTolerances(
 void FeasiblePathHandler::reset()
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
-  // AI-assisted contribution for ros-navigation/navigation2#6235
-  last_set_plan_ = nav_msgs::msg::Path();
+  unpruned_global_plan_ = nav_msgs::msg::Path();
   global_plan_ = nav_msgs::msg::Path();
   global_plan_up_to_constraint_ = nav_msgs::msg::Path();
   constraint_locale_ = 0u;
@@ -147,16 +146,7 @@ bool FeasiblePathHandler::isSamePlan(
   }
 
   for (size_t i = 0; i < path1.poses.size(); ++i) {
-    const auto & pose1 = path1.poses[i].pose;
-    const auto & pose2 = path2.poses[i].pose;
-    if (pose1.position.x != pose2.position.x ||
-      pose1.position.y != pose2.position.y ||
-      pose1.position.z != pose2.position.z ||
-      pose1.orientation.x != pose2.orientation.x ||
-      pose1.orientation.y != pose2.orientation.y ||
-      pose1.orientation.z != pose2.orientation.z ||
-      pose1.orientation.w != pose2.orientation.w)
-    {
+    if (path1.poses[i].pose != path2.poses[i].pose) {
       return false;
     }
   }
@@ -166,18 +156,15 @@ bool FeasiblePathHandler::isSamePlan(
 void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
-  // AI-assisted contribution for ros-navigation/navigation2#6235
-  // When FollowPath is reissued with the same global path, keep pruning progress so
-  // max_robot_pose_search_dist still reaches the robot (see ros-navigation/navigation2#6235).
-  if (!last_set_plan_.poses.empty() && isSamePlan(path, last_set_plan_)) {
-    RCLCPP_DEBUG(
+  if (!unpruned_global_plan_.poses.empty() && isSamePlan(path, unpruned_global_plan_)) {
+    RCLCPP_INFO(
       logger_,
       "Received identical plan; retaining pruned path state (%zu of %zu poses remaining).",
       global_plan_up_to_constraint_.poses.size(), path.poses.size());
     return;
   }
 
-  last_set_plan_ = path;
+  unpruned_global_plan_ = path;
   global_plan_ = path;
   global_plan_up_to_constraint_ = global_plan_;
   if (enforce_path_inversion_ || enforce_path_rotation_) {

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -150,6 +150,65 @@ TEST(PathHandlerTests, TestBounds)
   EXPECT_EQ(path_inverted.poses.size(), 75u);
 }
 
+TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  rclcpp_lifecycle::State state;
+  costmap_ros->on_configure(state);
+  costmap_ros->set_parameters_atomically(
+    {rclcpp::Parameter("global_frame", "odom"),
+      rclcpp::Parameter("robot_base_frame", "base_link")});
+
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster_ = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster_->sendTransform(t);
+  t.header.frame_id = "map";
+  t.child_frame_id = "odom";
+  tf_broadcaster_->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  path.poses.resize(100);
+  for (unsigned int i = 0; i != path.poses.size(); i++) {
+    path.poses[i].pose.position.x = i;
+    path.poses[i].header.frame_id = "map";
+  }
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 25.0;
+
+  handler.setPlan(path);
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+  const auto initial_segment_len = pruned_plan_end - closest;
+  EXPECT_THROW(handler.transformLocalPlanWrapper(closest, pruned_plan_end), std::runtime_error);
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
+
+  // Reissuing the same FollowPath goal must keep pruning progress (issue #6235)
+  handler.setPlan(path);
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
+
+  auto [closest_after, pruned_after] = handler.findPlanSegmentWrapper(robot_pose);
+  EXPECT_EQ(closest_after - handler.getInvertedPath().poses.begin(), 0);
+  EXPECT_EQ(pruned_after - closest_after, initial_segment_len);
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
+
+  // A geometrically different path should reset pruning
+  nav_msgs::msg::Path new_path = path;
+  new_path.poses.back().pose.position.x = 200.0;
+  handler.setPlan(new_path);
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 100u);
+}
+
 TEST(PathHandlerTests, TestBoundsWithConstraintCheck)
 {
   PathHandlerWrapper handler;

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
+#include <string>
 #include <thread>
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_controller/plugins/feasible_path_handler.hpp"
+#include "nav2_core/controller_exceptions.hpp"
 #include "nav2_ros_common/tf2_factories.hpp"
 
 using namespace std::chrono_literals;
@@ -69,6 +72,11 @@ public:
   nav_msgs::msg::Path & getInvertedPath()
   {
     return global_plan_up_to_constraint_;
+  }
+
+  bool retainedStateNeedsValidation()
+  {
+    return retained_state_needs_validation_;
   }
 
   geometry_msgs::msg::PoseStamped getTransformedGoalWrapper(
@@ -420,6 +428,318 @@ TEST(PathHandlerTests, TestDynamicParams)
     results);
   // Value should remain unchanged
   EXPECT_EQ(node->get_parameter("dummy.inversion_xy_tolerance").as_double(), 200.0);
+}
+
+// Builds a costmap whose bounds are stated by the test, so that the poses used for retained
+// state validation are unambiguously inside or outside of it.
+std::shared_ptr<nav2_costmap_2d::Costmap2DROS> createBoundedCostmap(double origin, int size_meters)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("global_frame", "odom"),
+      rclcpp::Parameter("robot_base_frame", "base_link"),
+      rclcpp::Parameter("width", size_meters),
+      rclcpp::Parameter("height", size_meters),
+      rclcpp::Parameter("resolution", 0.1),
+      rclcpp::Parameter("origin_x", origin),
+      rclcpp::Parameter("origin_y", origin)});
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(options);
+  rclcpp_lifecycle::State state;
+  costmap_ros->on_configure(state);
+  return costmap_ros;
+}
+
+nav_msgs::msg::Path createStraightPath(unsigned int num_poses)
+{
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  path.poses.resize(num_poses);
+  for (unsigned int i = 0; i != num_poses; ++i) {
+    path.poses[i].header.frame_id = "map";
+    path.poses[i].pose.position.x = i;
+    path.poses[i].pose.orientation.w = 1.0;
+  }
+  return path;
+}
+
+// Tracks the path in one metre steps, pruning the working plan on every step
+void followPathTo(PathHandlerWrapper & handler, double x_end)
+{
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  for (double x = 0.0; x <= x_end; x += 1.0) {
+    robot_pose.pose.position.x = x;
+    auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+    handler.transformLocalPlanWrapper(closest, pruned_plan_end);
+  }
+}
+
+TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlanWithinCostmap)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 20);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+  followPathTo(handler, 5.0);
+
+  // The robot is now further along the path than a bounded search from the start could reach
+  ASSERT_EQ(handler.getInvertedPath().poses.size(), 26u);
+  ASSERT_EQ(handler.getInvertedPath().poses.front().pose.position.x, 5.0);
+
+  handler.setPlan(path);
+  EXPECT_TRUE(handler.retainedStateNeedsValidation());
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 5.0;
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+
+  EXPECT_FALSE(handler.retainedStateNeedsValidation());
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 26u);
+  EXPECT_EQ(closest, handler.getInvertedPath().poses.begin());
+  EXPECT_EQ(closest->pose.position.x, 5.0);
+  EXPECT_NE(pruned_plan_end, closest);
+}
+
+TEST(PathHandlerTests, ResetRetainedStateWhenCandidateLeavesCostmap)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-5.0, 10);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+
+  // Stands in for having tracked the path beyond the costmap before the goal was reissued
+  nav_msgs::msg::Path retained_plan = path;
+  retained_plan.poses.erase(retained_plan.poses.begin(), retained_plan.poses.begin() + 8);
+  handler.setGlobalPlanUpToInversion(retained_plan);
+
+  handler.setPlan(path);
+  EXPECT_TRUE(handler.retainedStateNeedsValidation());
+
+  // Teleoperated back to the start, the retained poses are no longer within the costmap
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 0.0;
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+
+  EXPECT_FALSE(handler.retainedStateNeedsValidation());
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), path.poses.size());
+  EXPECT_EQ(closest, handler.getInvertedPath().poses.begin());
+  EXPECT_EQ(closest->pose.position.x, 0.0);
+  EXPECT_NE(pruned_plan_end, closest);
+}
+
+TEST(PathHandlerTests, RetainStateAfterLocalRecoveryMotion)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 20);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+  followPathTo(handler, 5.0);
+  handler.setPlan(path);
+
+  // Backed up during a recovery, but still alongside the retained portion of the path
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 4.6;
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 26u);
+  EXPECT_EQ(closest->pose.position.x, 5.0);
+  EXPECT_NE(pruned_plan_end, closest);
+}
+
+TEST(PathHandlerTests, ReplaceRetainedStateWhenPlanDiffers)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 20);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+  followPathTo(handler, 5.0);
+  ASSERT_EQ(handler.getInvertedPath().poses.size(), 26u);
+
+  auto different_path = createStraightPath(31);
+  different_path.poses[10].pose.position.y = 1.0;
+  handler.setPlan(different_path);
+
+  EXPECT_FALSE(handler.retainedStateNeedsValidation());
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), different_path.poses.size());
+  EXPECT_EQ(handler.getInvertedPath().poses.front().pose.position.x, 0.0);
+}
+
+TEST(PathHandlerTests, ResetClearsRetainedState)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 20);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+  followPathTo(handler, 5.0);
+  ASSERT_EQ(handler.getInvertedPath().poses.size(), 26u);
+
+  handler.reset();
+  EXPECT_TRUE(handler.getInvertedPath().poses.empty());
+
+  // The same geometry after a reset is a new navigation
+  handler.setPlan(path);
+  EXPECT_FALSE(handler.retainedStateNeedsValidation());
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), path.poses.size());
+  EXPECT_EQ(handler.getInvertedPath().poses.front().pose.position.x, 0.0);
+}
+
+TEST(PathHandlerTests, RetainedStateValidationStaysPendingOnTfFailure)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 20);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  // The plan frame is available, the costmap frame is not
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  auto path = createStraightPath(31);
+  handler.setPlan(path);
+  handler.setPlan(path);
+  ASSERT_TRUE(handler.retainedStateNeedsValidation());
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "base_link";
+  EXPECT_THROW(
+    handler.findPlanSegmentWrapper(robot_pose), nav2_core::ControllerTFError);
+  EXPECT_TRUE(handler.retainedStateNeedsValidation());
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), path.poses.size());
+
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  EXPECT_NO_THROW(handler.findPlanSegmentWrapper(robot_pose));
+  EXPECT_FALSE(handler.retainedStateNeedsValidation());
+}
+
+TEST(PathHandlerTests, RetainedStateValidationKeepsOrderedSearch)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(2.0));
+  auto costmap_ros = createBoundedCostmap(-10.0, 40);
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  // A path that comes back alongside where it started
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  for (unsigned int i = 0; i != 11; ++i) {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.frame_id = "map";
+    pose.pose.position.x = i;
+    pose.pose.orientation.w = 1.0;
+    path.poses.push_back(pose);
+  }
+  for (unsigned int i = 0; i != 11; ++i) {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.frame_id = "map";
+    pose.pose.position.x = 10 - i;
+    pose.pose.position.y = 0.5;
+    pose.pose.orientation.w = 1.0;
+    path.poses.push_back(pose);
+  }
+
+  handler.setPlan(path);
+  nav_msgs::msg::Path retained_plan = path;
+  retained_plan.poses.erase(retained_plan.poses.begin(), retained_plan.poses.begin() + 18);
+  handler.setGlobalPlanUpToInversion(retained_plan);
+  handler.setPlan(path);
+
+  // The outbound leg is closer to the robot, but has already been traversed
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 3.0;
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), retained_plan.poses.size());
+  EXPECT_EQ(closest->pose.position.x, 3.0);
+  EXPECT_EQ(closest->pose.position.y, 0.5);
+  EXPECT_NE(pruned_plan_end, closest);
 }
 
 int main(int argc, char **argv)

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -193,7 +193,6 @@ TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
   EXPECT_THROW(handler.transformLocalPlanWrapper(closest, pruned_plan_end), std::runtime_error);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
 
-  // Reissuing the same FollowPath goal must keep pruning progress (issue #6235)
   handler.setPlan(path);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
 
@@ -202,17 +201,14 @@ TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
   EXPECT_EQ(pruned_after - closest_after, initial_segment_len);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
 
-  // A geometrically different path should reset pruning
   nav_msgs::msg::Path new_path = path;
   new_path.poses.back().pose.position.x = 200.0;
   handler.setPlan(new_path);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 100u);
 
-  // After an explicit reset (successful/canceled goal), identical geometry starts fresh
   handler.setPlan(path);
   auto [closest2, pruned2] = handler.findPlanSegmentWrapper(robot_pose);
-  (void)closest2;
-  (void)pruned2;
+  EXPECT_THROW(handler.transformLocalPlanWrapper(closest2, pruned2), std::runtime_error);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
   handler.reset();
   handler.setPlan(path);
@@ -221,8 +217,6 @@ TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
 
 TEST(PathHandlerTests, MultiHandlerSwitchClearsStalePruneState)
 {
-  // Mirrors controller_server lifecycle: prune on A, switch to B, complete/cancel
-  // (reset all), switch back to A with identical geometry → A must start fresh.
   auto node = std::make_shared<nav2::LifecycleNode>("multi_handler_node");
   node->declare_parameter("handler_a.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
   node->declare_parameter("handler_b.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
@@ -263,23 +257,19 @@ TEST(PathHandlerTests, MultiHandlerSwitchClearsStalePruneState)
   robot_pose.header.frame_id = "odom";
   robot_pose.pose.position.x = 25.0;
 
-  // Handler A prunes path X and retains cache after a control failure.
   handler_a.setPlan(path);
   auto [closest_a, pruned_a] = handler_a.findPlanSegmentWrapper(robot_pose);
   EXPECT_THROW(handler_a.transformLocalPlanWrapper(closest_a, pruned_a), std::runtime_error);
   EXPECT_EQ(handler_a.getInvertedPath().poses.size(), 75u);
 
-  // Preemption switches to B: reset outgoing A and incoming B before setPlan.
   handler_a.reset();
   handler_b.reset();
   handler_b.setPlan(path);
   EXPECT_EQ(handler_b.getInvertedPath().poses.size(), 100u);
 
-  // Goal on B finishes or is canceled: reset all registered handlers.
   handler_a.reset();
   handler_b.reset();
 
-  // Later goal selects A again with identical geometry → full path, not stale prune.
   handler_a.setPlan(path);
   EXPECT_EQ(handler_a.getInvertedPath().poses.size(), 100u);
 }

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -207,6 +207,16 @@ TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
   new_path.poses.back().pose.position.x = 200.0;
   handler.setPlan(new_path);
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 100u);
+
+  // After an explicit reset (successful/canceled goal), identical geometry starts fresh
+  handler.setPlan(path);
+  auto [closest2, pruned2] = handler.findPlanSegmentWrapper(robot_pose);
+  (void)closest2;
+  (void)pruned2;
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 75u);
+  handler.reset();
+  handler.setPlan(path);
+  EXPECT_EQ(handler.getInvertedPath().poses.size(), 100u);
 }
 
 TEST(PathHandlerTests, TestBoundsWithConstraintCheck)

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -219,6 +219,71 @@ TEST(PathHandlerTests, RetainPruneStateOnIdenticalPlan)
   EXPECT_EQ(handler.getInvertedPath().poses.size(), 100u);
 }
 
+TEST(PathHandlerTests, MultiHandlerSwitchClearsStalePruneState)
+{
+  // Mirrors controller_server lifecycle: prune on A, switch to B, complete/cancel
+  // (reset all), switch back to A with identical geometry → A must start fresh.
+  auto node = std::make_shared<nav2::LifecycleNode>("multi_handler_node");
+  node->declare_parameter("handler_a.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
+  node->declare_parameter("handler_b.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  rclcpp_lifecycle::State state;
+  costmap_ros->on_configure(state);
+  costmap_ros->set_parameters_atomically(
+    {rclcpp::Parameter("global_frame", "odom"),
+      rclcpp::Parameter("robot_base_frame", "base_link")});
+
+  PathHandlerWrapper handler_a;
+  PathHandlerWrapper handler_b;
+  handler_a.initialize(
+    node, node->get_logger(), "handler_a", costmap_ros, costmap_ros->getTfBuffer());
+  handler_b.initialize(
+    node, node->get_logger(), "handler_b", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster_ = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster_->sendTransform(t);
+  t.header.frame_id = "map";
+  t.child_frame_id = "odom";
+  tf_broadcaster_->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  path.poses.resize(100);
+  for (unsigned int i = 0; i != path.poses.size(); i++) {
+    path.poses[i].pose.position.x = i;
+    path.poses[i].header.frame_id = "map";
+  }
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 25.0;
+
+  // Handler A prunes path X and retains cache after a control failure.
+  handler_a.setPlan(path);
+  auto [closest_a, pruned_a] = handler_a.findPlanSegmentWrapper(robot_pose);
+  EXPECT_THROW(handler_a.transformLocalPlanWrapper(closest_a, pruned_a), std::runtime_error);
+  EXPECT_EQ(handler_a.getInvertedPath().poses.size(), 75u);
+
+  // Preemption switches to B: reset outgoing A and incoming B before setPlan.
+  handler_a.reset();
+  handler_b.reset();
+  handler_b.setPlan(path);
+  EXPECT_EQ(handler_b.getInvertedPath().poses.size(), 100u);
+
+  // Goal on B finishes or is canceled: reset all registered handlers.
+  handler_a.reset();
+  handler_b.reset();
+
+  // Later goal selects A again with identical geometry → full path, not stale prune.
+  handler_a.setPlan(path);
+  EXPECT_EQ(handler_a.getInvertedPath().poses.size(), 100u);
+}
+
 TEST(PathHandlerTests, TestBoundsWithConstraintCheck)
 {
   PathHandlerWrapper handler;

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -527,7 +527,7 @@ void ControllerServer::computeControl()
     std::string ph_name = goal->path_handler_id;
     std::string current_path_handler;
     if(findPathHandlerId(ph_name, current_path_handler)) {
-      current_path_handler_ = current_path_handler;
+      setCurrentPathHandler(current_path_handler);
     } else {
       throw nav2_core::ControllerException("Failed to find path handler name: " + ph_name);
     }
@@ -551,7 +551,7 @@ void ControllerServer::computeControl()
         if (controllers_[current_controller_]->cancel()) {
           RCLCPP_INFO(get_logger(), "Cancellation was successful. Stopping the robot.");
           action_server_->terminate_all();
-          onGoalExit(true);
+          onGoalExit(true, true);
           return;
         } else {
           RCLCPP_INFO_THROTTLE(
@@ -585,7 +585,7 @@ void ControllerServer::computeControl()
     }
   } catch (nav2_core::InvalidController & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::INVALID_CONTROLLER;
     result->error_msg = e.what();
@@ -593,7 +593,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerTFError & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::TF_ERROR;
     result->error_msg = e.what();
@@ -601,7 +601,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::NoValidControl & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::NO_VALID_CONTROL;
     result->error_msg = e.what();
@@ -609,7 +609,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::FailedToMakeProgress & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::FAILED_TO_MAKE_PROGRESS;
     result->error_msg = e.what();
@@ -617,7 +617,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::PatienceExceeded & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::PATIENCE_EXCEEDED;
     result->error_msg = e.what();
@@ -625,7 +625,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::InvalidPath & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::INVALID_PATH;
     result->error_msg = e.what();
@@ -633,7 +633,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerTimedOut & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::CONTROLLER_TIMED_OUT;
     result->error_msg = e.what();
@@ -641,7 +641,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerException & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::UNKNOWN;
     result->error_msg = e.what();
@@ -649,7 +649,7 @@ void ControllerServer::computeControl()
     return;
   } catch (std::exception & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::UNKNOWN;
     result->error_msg = e.what();
@@ -659,7 +659,7 @@ void ControllerServer::computeControl()
 
   RCLCPP_DEBUG(get_logger(), "Controller succeeded, setting result");
 
-  onGoalExit(false);
+  onGoalExit(false, true);
 
   // TODO(orduno) #861 Handle a pending preemption and set controller name
   action_server_->succeeded_current();
@@ -886,7 +886,7 @@ void ControllerServer::updateGlobalPath()
         RCLCPP_INFO(
           get_logger(), "Change of path handler %s requested, resetting it",
           goal->path_handler_id.c_str());
-        current_path_handler_ = current_path_handler;
+        setCurrentPathHandler(current_path_handler);
       }
     } else {
       std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
@@ -926,7 +926,31 @@ void ControllerServer::publishZeroVelocity()
   publishVelocity(velocity);
 }
 
-void ControllerServer::onGoalExit(bool force_stop)
+void ControllerServer::setCurrentPathHandler(const std::string & path_handler_id)
+{
+  if (current_path_handler_ == path_handler_id) {
+    return;
+  }
+
+  auto outgoing = path_handlers_.find(current_path_handler_);
+  if (outgoing != path_handlers_.end()) {
+    outgoing->second->reset();
+  }
+  auto incoming = path_handlers_.find(path_handler_id);
+  if (incoming != path_handlers_.end()) {
+    incoming->second->reset();
+  }
+  current_path_handler_ = path_handler_id;
+}
+
+void ControllerServer::resetAllPathHandlers()
+{
+  for (auto & path_handler : path_handlers_) {
+    path_handler.second->reset();
+  }
+}
+
+void ControllerServer::onGoalExit(bool force_stop, bool reset_path_handler_state)
 {
   if (params_->publish_zero_velocity || force_stop) {
     publishZeroVelocity();
@@ -935,6 +959,11 @@ void ControllerServer::onGoalExit(bool force_stop)
   // Reset controller state
   for (auto & controller : controllers_) {
     controller.second->reset();
+  }
+
+  // Path state is retained across failures so a retry of the same goal can resume it
+  if (reset_path_handler_state) {
+    resetAllPathHandlers();
   }
 }
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -509,6 +509,10 @@ void ControllerServer::computeControl()
           RCLCPP_INFO(get_logger(), "Cancellation was successful. Stopping the robot.");
           action_server_->terminate_all();
           onGoalExit(true);
+          // Canceled goals should not keep identical-plan prune identity for a later mission.
+          if (path_handlers_.find(current_path_handler_) != path_handlers_.end()) {
+            path_handlers_[current_path_handler_]->reset();
+          }
           return;
         } else {
           RCLCPP_INFO_THROTTLE(
@@ -892,6 +896,13 @@ void ControllerServer::onGoalExit(bool force_stop)
   // Reset controller state
   for (auto & controller : controllers_) {
     controller.second->reset();
+  }
+
+  // On success only: drop identical-plan cache so a later Navigate that reuses the
+  // same path geometry starts pruning from the beginning. Failure exits keep the
+  // cache so BT FollowPath retries retain prune progress (navigation2#6235).
+  if (!force_stop && path_handlers_.find(current_path_handler_) != path_handlers_.end()) {
+    path_handlers_[current_path_handler_]->reset();
   }
 }
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -483,8 +483,8 @@ void ControllerServer::computeControl()
 
     std::string ph_name = goal->path_handler_id;
     std::string current_path_handler;
-    if(findPathHandlerId(ph_name, current_path_handler)) {
-      current_path_handler_ = current_path_handler;
+    if (findPathHandlerId(ph_name, current_path_handler)) {
+      setCurrentPathHandler(current_path_handler);
     } else {
       throw nav2_core::ControllerException("Failed to find path handler name: " + ph_name);
     }
@@ -508,11 +508,8 @@ void ControllerServer::computeControl()
         if (controllers_[current_controller_]->cancel()) {
           RCLCPP_INFO(get_logger(), "Cancellation was successful. Stopping the robot.");
           action_server_->terminate_all();
-          onGoalExit(true);
-          // Canceled goals should not keep identical-plan prune identity for a later mission.
-          if (path_handlers_.find(current_path_handler_) != path_handlers_.end()) {
-            path_handlers_[current_path_handler_]->reset();
-          }
+          // Cancel clears prune caches on all handlers so a later mission starts fresh.
+          onGoalExit(true, true);
           return;
         } else {
           RCLCPP_INFO_THROTTLE(
@@ -546,7 +543,8 @@ void ControllerServer::computeControl()
     }
   } catch (nav2_core::InvalidController & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    // Keep path-handler prune caches so BT FollowPath retries retain progress.
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::INVALID_CONTROLLER;
     result->error_msg = e.what();
@@ -554,7 +552,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerTFError & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::TF_ERROR;
     result->error_msg = e.what();
@@ -562,7 +560,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::NoValidControl & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::NO_VALID_CONTROL;
     result->error_msg = e.what();
@@ -570,7 +568,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::FailedToMakeProgress & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::FAILED_TO_MAKE_PROGRESS;
     result->error_msg = e.what();
@@ -578,7 +576,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::PatienceExceeded & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::PATIENCE_EXCEEDED;
     result->error_msg = e.what();
@@ -586,7 +584,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::InvalidPath & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::INVALID_PATH;
     result->error_msg = e.what();
@@ -594,7 +592,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerTimedOut & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::CONTROLLER_TIMED_OUT;
     result->error_msg = e.what();
@@ -602,7 +600,7 @@ void ControllerServer::computeControl()
     return;
   } catch (nav2_core::ControllerException & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::UNKNOWN;
     result->error_msg = e.what();
@@ -610,7 +608,7 @@ void ControllerServer::computeControl()
     return;
   } catch (std::exception & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    onGoalExit(true);
+    onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::UNKNOWN;
     result->error_msg = e.what();
@@ -620,7 +618,8 @@ void ControllerServer::computeControl()
 
   RCLCPP_DEBUG(get_logger(), "Controller succeeded, setting result");
 
-  onGoalExit(false);
+  // Success clears prune caches on all handlers so a later mission starts fresh.
+  onGoalExit(false, true);
 
   // TODO(orduno) #861 Handle a pending preemption and set controller name
   action_server_->succeeded_current();
@@ -847,7 +846,7 @@ void ControllerServer::updateGlobalPath()
         RCLCPP_INFO(
           get_logger(), "Change of path handler %s requested, resetting it",
           goal->path_handler_id.c_str());
-        current_path_handler_ = current_path_handler;
+        setCurrentPathHandler(current_path_handler);
       }
     } else {
       std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
@@ -887,7 +886,35 @@ void ControllerServer::publishZeroVelocity()
   publishVelocity(velocity);
 }
 
-void ControllerServer::onGoalExit(bool force_stop)
+void ControllerServer::setCurrentPathHandler(const std::string & path_handler_id)
+{
+  if (current_path_handler_ == path_handler_id) {
+    return;
+  }
+
+  // Drop prune caches on both the outgoing and incoming plugins so a later
+  // preemption back to the old handler cannot revive stale identical-plan state.
+  if (!current_path_handler_.empty()) {
+    auto outgoing = path_handlers_.find(current_path_handler_);
+    if (outgoing != path_handlers_.end()) {
+      outgoing->second->reset();
+    }
+  }
+  auto incoming = path_handlers_.find(path_handler_id);
+  if (incoming != path_handlers_.end()) {
+    incoming->second->reset();
+  }
+  current_path_handler_ = path_handler_id;
+}
+
+void ControllerServer::resetAllPathHandlers()
+{
+  for (auto & path_handler : path_handlers_) {
+    path_handler.second->reset();
+  }
+}
+
+void ControllerServer::onGoalExit(bool force_stop, bool reset_path_handler_state)
 {
   if (params_->publish_zero_velocity || force_stop) {
     publishZeroVelocity();
@@ -898,11 +925,10 @@ void ControllerServer::onGoalExit(bool force_stop)
     controller.second->reset();
   }
 
-  // On success only: drop identical-plan cache so a later Navigate that reuses the
-  // same path geometry starts pruning from the beginning. Failure exits keep the
-  // cache so BT FollowPath retries retain prune progress (navigation2#6235).
-  if (!force_stop && path_handlers_.find(current_path_handler_) != path_handlers_.end()) {
-    path_handlers_[current_path_handler_]->reset();
+  // Success and cancel clear every handler's identical-plan cache. Failure exits
+  // leave caches intact so BT FollowPath retries retain prune progress (#6235).
+  if (reset_path_handler_state) {
+    resetAllPathHandlers();
   }
 }
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -508,7 +508,6 @@ void ControllerServer::computeControl()
         if (controllers_[current_controller_]->cancel()) {
           RCLCPP_INFO(get_logger(), "Cancellation was successful. Stopping the robot.");
           action_server_->terminate_all();
-          // Cancel clears prune caches on all handlers so a later mission starts fresh.
           onGoalExit(true, true);
           return;
         } else {
@@ -543,7 +542,6 @@ void ControllerServer::computeControl()
     }
   } catch (nav2_core::InvalidController & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    // Keep path-handler prune caches so BT FollowPath retries retain progress.
     onGoalExit(true, false);
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
     result->error_code = Action::Result::INVALID_CONTROLLER;
@@ -618,7 +616,6 @@ void ControllerServer::computeControl()
 
   RCLCPP_DEBUG(get_logger(), "Controller succeeded, setting result");
 
-  // Success clears prune caches on all handlers so a later mission starts fresh.
   onGoalExit(false, true);
 
   // TODO(orduno) #861 Handle a pending preemption and set controller name
@@ -892,8 +889,6 @@ void ControllerServer::setCurrentPathHandler(const std::string & path_handler_id
     return;
   }
 
-  // Drop prune caches on both the outgoing and incoming plugins so a later
-  // preemption back to the old handler cannot revive stale identical-plan state.
   if (!current_path_handler_.empty()) {
     auto outgoing = path_handlers_.find(current_path_handler_);
     if (outgoing != path_handlers_.end()) {
@@ -925,8 +920,6 @@ void ControllerServer::onGoalExit(bool force_stop, bool reset_path_handler_state
     controller.second->reset();
   }
 
-  // Success and cancel clear every handler's identical-plan cache. Failure exits
-  // leave caches intact so BT FollowPath retries retain prune progress (#6235).
   if (reset_path_handler_state) {
     resetAllPathHandlers();
   }

--- a/nav2_controller/test/test_controller_server.cpp
+++ b/nav2_controller/test/test_controller_server.cpp
@@ -22,10 +22,79 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "nav2_core/controller_exceptions.hpp"
+#include "nav2_core/path_handler.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_controller/controller_server.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_ros_common/tf2_factories.hpp"
+
+class CountingPathHandler : public nav2_core::PathHandler
+{
+public:
+  void initialize(
+    const nav2::LifecycleNode::WeakPtr &,
+    const rclcpp::Logger &,
+    const std::string &,
+    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS>,
+    nav2::TransformBuffer::SharedPtr) override {}
+
+  void setPlan(const nav_msgs::msg::Path &) override {}
+
+  void reset() override {++reset_count;}
+
+  nav2_core::PathSegment findPlanSegment(
+    const geometry_msgs::msg::PoseStamped &) override
+  {
+    return {};
+  }
+
+  nav_msgs::msg::Path transformLocalPlan(
+    const nav2_core::PathIterator &,
+    const nav2_core::PathIterator &) override
+  {
+    return nav_msgs::msg::Path();
+  }
+
+  geometry_msgs::msg::PoseStamped getTransformedGoal(
+    const builtin_interfaces::msg::Time &) override
+  {
+    return geometry_msgs::msg::PoseStamped();
+  }
+
+  int reset_count{0};
+};
+
+class DefaultResetPathHandler : public nav2_core::PathHandler
+{
+public:
+  void initialize(
+    const nav2::LifecycleNode::WeakPtr &,
+    const rclcpp::Logger &,
+    const std::string &,
+    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS>,
+    nav2::TransformBuffer::SharedPtr) override {}
+
+  void setPlan(const nav_msgs::msg::Path &) override {}
+
+  nav2_core::PathSegment findPlanSegment(
+    const geometry_msgs::msg::PoseStamped &) override
+  {
+    return {};
+  }
+
+  nav_msgs::msg::Path transformLocalPlan(
+    const nav2_core::PathIterator &,
+    const nav2_core::PathIterator &) override
+  {
+    return nav_msgs::msg::Path();
+  }
+
+  geometry_msgs::msg::PoseStamped getTransformedGoal(
+    const builtin_interfaces::msg::Time &) override
+  {
+    return geometry_msgs::msg::PoseStamped();
+  }
+};
 
 class ControllerServerShim : public nav2_controller::ControllerServer
 {
@@ -35,11 +104,28 @@ public:
   void setEndPoseFrame(const std::string & frame) {end_pose_.header.frame_id = frame;}
   bool callIsGoalReached() {return isGoalReached();}
   nav2::TransformBuffer & getTfBuffer() {return *costmap_ros_->getTfBuffer();}
+
+  void callSetCurrentPathHandler(const std::string & path_handler_id)
+  {
+    setCurrentPathHandler(path_handler_id);
+  }
+
+  void callResetAllPathHandlers()
+  {
+    resetAllPathHandlers();
+  }
+
+  void callOnGoalExit(bool force_stop, bool reset_path_handler_state)
+  {
+    onGoalExit(force_stop, reset_path_handler_state);
+  }
+
+  PathHandlerMap & pathHandlers() {return path_handlers_;}
+  std::string & currentPathHandler() {return current_path_handler_;}
 };
 
 TEST(ControllerServerTest, IsGoalReachedThrowsOnTfFailure)
 {
-  // aa
   rclcpp::NodeOptions options;
   options.parameter_overrides({
     rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
@@ -65,6 +151,63 @@ TEST(ControllerServerTest, IsGoalReachedThrowsOnTfFailure)
   server->setEndPoseFrame("nonexistent_frame_xyz");
   EXPECT_THROW(server->callIsGoalReached(), nav2_core::ControllerTFError);
   server->cleanup();
+}
+
+TEST(ControllerServerTest, PathHandlerResetHelpers)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("goal_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("controller_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("path_handler_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("filters", std::vector<std::string>{}),
+    rclcpp::Parameter("publish_zero_velocity", false),
+  });
+
+  auto server = std::make_shared<ControllerServerShim>(options);
+  ASSERT_EQ(
+    server->configure().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  auto handler_a = std::make_shared<CountingPathHandler>();
+  auto handler_b = std::make_shared<CountingPathHandler>();
+  server->pathHandlers()["handler_a"] = handler_a;
+  server->pathHandlers()["handler_b"] = handler_b;
+
+  server->callSetCurrentPathHandler("handler_a");
+  EXPECT_EQ(server->currentPathHandler(), "handler_a");
+  EXPECT_EQ(handler_a->reset_count, 1);
+  EXPECT_EQ(handler_b->reset_count, 0);
+
+  server->callSetCurrentPathHandler("handler_a");
+  EXPECT_EQ(handler_a->reset_count, 1);
+
+  server->callSetCurrentPathHandler("handler_b");
+  EXPECT_EQ(server->currentPathHandler(), "handler_b");
+  EXPECT_EQ(handler_a->reset_count, 2);
+  EXPECT_EQ(handler_b->reset_count, 1);
+
+  server->callOnGoalExit(false, false);
+  EXPECT_EQ(handler_a->reset_count, 2);
+  EXPECT_EQ(handler_b->reset_count, 1);
+
+  server->callOnGoalExit(false, true);
+  EXPECT_EQ(handler_a->reset_count, 3);
+  EXPECT_EQ(handler_b->reset_count, 2);
+
+  server->callResetAllPathHandlers();
+  EXPECT_EQ(handler_a->reset_count, 4);
+  EXPECT_EQ(handler_b->reset_count, 3);
+
+  server->cleanup();
+}
+
+TEST(ControllerServerTest, DefaultPathHandlerReset)
+{
+  DefaultResetPathHandler handler;
+  handler.reset();
 }
 
 TEST(ControllerServerTest, GoalCheckerPluginTypeException)

--- a/nav2_controller/test/test_controller_server.cpp
+++ b/nav2_controller/test/test_controller_server.cpp
@@ -35,7 +35,132 @@ public:
   void setEndPoseFrame(const std::string & frame) {end_pose_.header.frame_id = frame;}
   bool callIsGoalReached() {return isGoalReached();}
   nav2::TransformBuffer & getTfBuffer() {return *costmap_ros_->getTfBuffer();}
+
+  void addPathHandler(const std::string & id, nav2_core::PathHandler::Ptr path_handler)
+  {
+    path_handlers_[id] = path_handler;
+  }
+  void selectPathHandler(const std::string & id) {setCurrentPathHandler(id);}
+  std::string currentPathHandler() {return current_path_handler_;}
+  void callOnGoalExit(bool force_stop, bool reset_path_handler_state)
+  {
+    onGoalExit(force_stop, reset_path_handler_state);
+  }
 };
+
+// Path handler that relies on the default no-op reset of the interface
+class StubPathHandler : public nav2_core::PathHandler
+{
+public:
+  void initialize(
+    const nav2::LifecycleNode::WeakPtr &, const rclcpp::Logger &, const std::string &,
+    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS>,
+    nav2::TransformBuffer::SharedPtr) override {}
+
+  void setPlan(const nav_msgs::msg::Path &) override {}
+
+  nav2_core::PathSegment findPlanSegment(const geometry_msgs::msg::PoseStamped &) override
+  {
+    return {plan_.poses.begin(), plan_.poses.end()};
+  }
+
+  nav_msgs::msg::Path transformLocalPlan(
+    const nav2_core::PathIterator &, const nav2_core::PathIterator &) override
+  {
+    return nav_msgs::msg::Path();
+  }
+
+  geometry_msgs::msg::PoseStamped getTransformedGoal(
+    const builtin_interfaces::msg::Time &) override
+  {
+    return geometry_msgs::msg::PoseStamped();
+  }
+
+protected:
+  nav_msgs::msg::Path plan_;
+};
+
+class CountingPathHandler : public StubPathHandler
+{
+public:
+  void reset() override {++reset_count;}
+
+  unsigned int reset_count{0};
+};
+
+std::shared_ptr<ControllerServerShim> createConfiguredServer()
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("goal_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("controller_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("path_handler_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("filters", std::vector<std::string>{}),
+  });
+
+  auto server = std::make_shared<ControllerServerShim>(options);
+  server->configure();
+  return server;
+}
+
+TEST(ControllerServerTest, PathHandlerSelectionResetsState)
+{
+  auto server = createConfiguredServer();
+  auto handler_a = std::make_shared<CountingPathHandler>();
+  auto handler_b = std::make_shared<CountingPathHandler>();
+  server->addPathHandler("a", handler_a);
+  server->addPathHandler("b", handler_b);
+
+  server->selectPathHandler("a");
+  EXPECT_EQ(server->currentPathHandler(), "a");
+  EXPECT_EQ(handler_a->reset_count, 1u);
+
+  // Selecting the same handler again keeps its state
+  server->selectPathHandler("a");
+  EXPECT_EQ(handler_a->reset_count, 1u);
+
+  // Switching clears the state of both the outgoing and incoming handler
+  server->selectPathHandler("b");
+  EXPECT_EQ(server->currentPathHandler(), "b");
+  EXPECT_EQ(handler_a->reset_count, 2u);
+  EXPECT_EQ(handler_b->reset_count, 1u);
+
+  server->cleanup();
+}
+
+TEST(ControllerServerTest, GoalExitResetsPathHandlersOnlyWhenRequested)
+{
+  auto server = createConfiguredServer();
+  auto handler_a = std::make_shared<CountingPathHandler>();
+  auto handler_b = std::make_shared<CountingPathHandler>();
+  server->addPathHandler("a", handler_a);
+  server->addPathHandler("b", handler_b);
+
+  // A controller failure leaves the path state in place for a retry of the same goal
+  server->callOnGoalExit(true, false);
+  EXPECT_EQ(handler_a->reset_count, 0u);
+  EXPECT_EQ(handler_b->reset_count, 0u);
+
+  // A successful or canceled goal clears it
+  server->callOnGoalExit(false, true);
+  EXPECT_EQ(handler_a->reset_count, 1u);
+  EXPECT_EQ(handler_b->reset_count, 1u);
+
+  server->cleanup();
+}
+
+TEST(ControllerServerTest, DefaultPathHandlerResetIsCallable)
+{
+  auto server = createConfiguredServer();
+  server->addPathHandler("stub", std::make_shared<StubPathHandler>());
+
+  EXPECT_NO_THROW(server->selectPathHandler("stub"));
+  EXPECT_NO_THROW(server->callOnGoalExit(false, true));
+
+  server->cleanup();
+}
 
 TEST(ControllerServerTest, IsGoalReachedThrowsOnTfFailure)
 {

--- a/nav2_core/include/nav2_core/path_handler.hpp
+++ b/nav2_core/include/nav2_core/path_handler.hpp
@@ -69,10 +69,7 @@ public:
   virtual void setPlan(const nav_msgs::msg::Path & path) = 0;
 
   /**
-   * @brief Clear handler state after a completed or canceled FollowPath goal.
-   *
-   * Failed goals should typically leave state intact so a BT retry that
-   * reissues the same path can retain prune progress.
+   * @brief Clear handler state (e.g. after a completed or canceled goal)
    */
   virtual void reset() {}
 

--- a/nav2_core/include/nav2_core/path_handler.hpp
+++ b/nav2_core/include/nav2_core/path_handler.hpp
@@ -69,6 +69,14 @@ public:
   virtual void setPlan(const nav_msgs::msg::Path & path) = 0;
 
   /**
+   * @brief Clear handler state after a completed or canceled FollowPath goal.
+   *
+   * Failed goals should typically leave state intact so a BT retry that
+   * reissues the same path can retain prune progress.
+   */
+  virtual void reset() {}
+
+  /**
    * @brief Determines the portion of the global plan to be used for local control.
    * This function locates the start and end iterators of the global plan segment
    * that is relevant for controller computation based on the robot's current pose and local costmap.

--- a/nav2_core/include/nav2_core/path_handler.hpp
+++ b/nav2_core/include/nav2_core/path_handler.hpp
@@ -69,6 +69,11 @@ public:
   virtual void setPlan(const nav_msgs::msg::Path & path) = 0;
 
   /**
+   * @brief Clear any path state retained between goals
+   */
+  virtual void reset() {}
+
+  /**
    * @brief Determines the portion of the global plan to be used for local control.
    * This function locates the start and end iterators of the global plan segment
    * that is relevant for controller computation based on the robot's current pose and local costmap.

--- a/nav2_util/include/nav2_util/path_utils.hpp
+++ b/nav2_util/include/nav2_util/path_utils.hpp
@@ -119,6 +119,16 @@ bool isPathUpdated(
 bool isGoalUpdated(
   nav_msgs::msg::Path & new_path,
   nav_msgs::msg::Path & old_path);
+
+/**
+ * @brief Checks if two paths have the same frame and ordered pose geometry
+ * @param path1 First path
+ * @param path2 Second path
+ * @return whether the plans contain the same ordered poses (stamps ignored)
+ */
+bool isSamePlan(
+  const nav_msgs::msg::Path & path1,
+  const nav_msgs::msg::Path & path2);
 }  // namespace nav2_util
 
 #endif  // NAV2_UTIL__PATH_UTILS_HPP_

--- a/nav2_util/include/nav2_util/path_utils.hpp
+++ b/nav2_util/include/nav2_util/path_utils.hpp
@@ -119,6 +119,16 @@ bool isPathUpdated(
 bool isGoalUpdated(
   nav_msgs::msg::Path & new_path,
   nav_msgs::msg::Path & old_path);
+
+/**
+ * @brief Checks if two paths contain the same frame and ordered pose geometry
+ * @param path1 First path to compare
+ * @param path2 Second path to compare
+ * @return whether both paths hold the same ordered poses, ignoring timestamps
+ */
+bool isSamePlan(
+  const nav_msgs::msg::Path & path1,
+  const nav_msgs::msg::Path & path2);
 }  // namespace nav2_util
 
 #endif  // NAV2_UTIL__PATH_UTILS_HPP_

--- a/nav2_util/src/path_utils.cpp
+++ b/nav2_util/src/path_utils.cpp
@@ -239,4 +239,22 @@ bool isGoalUpdated(
          new_path.poses.back().pose.position != old_path.poses.back().pose.position;
 }
 
+bool isSamePlan(
+  const nav_msgs::msg::Path & path1,
+  const nav_msgs::msg::Path & path2)
+{
+  if (path1.header.frame_id != path2.header.frame_id ||
+    path1.poses.size() != path2.poses.size())
+  {
+    return false;
+  }
+
+  for (size_t i = 0; i < path1.poses.size(); ++i) {
+    if (path1.poses[i].pose != path2.poses[i].pose) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace nav2_util

--- a/nav2_util/test/test_path_utils.cpp
+++ b/nav2_util/test/test_path_utils.cpp
@@ -639,3 +639,49 @@ TEST(UtilsTests, IsPathOrGoalUpdatedTest)
   EXPECT_FALSE(nav2_util::isPathUpdated(old_path, new_path));
   EXPECT_TRUE(nav2_util::isGoalUpdated(old_path, new_path));
 }
+
+TEST(UtilsTests, IsSamePlanTest)
+{
+  auto makePose = [](double x, double y, double yaw = 0.0) {
+      geometry_msgs::msg::PoseStamped pose;
+      pose.pose.position.x = x;
+      pose.pose.position.y = y;
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, yaw);
+      pose.pose.orientation = tf2::toMsg(q);
+      return pose;
+    };
+
+  nav_msgs::msg::Path path_a, path_b;
+  path_a.header.frame_id = "map";
+  path_a.poses.push_back(makePose(0.0, 0.0));
+  path_a.poses.push_back(makePose(1.0, 0.0, 0.2));
+
+  // Identical geometry, timestamps are ignored
+  path_b = path_a;
+  path_b.poses.front().header.stamp.sec = 42;
+  EXPECT_TRUE(nav2_util::isSamePlan(path_a, path_b));
+
+  // Different frame
+  path_b = path_a;
+  path_b.header.frame_id = "odom";
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  // Different pose count
+  path_b = path_a;
+  path_b.poses.push_back(makePose(2.0, 0.0));
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  // Different position
+  path_b = path_a;
+  path_b.poses.back().pose.position.y = 0.5;
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  // Different orientation
+  path_b = path_a;
+  path_b.poses.back() = makePose(1.0, 0.0, 1.0);
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  nav_msgs::msg::Path empty_a, empty_b;
+  EXPECT_TRUE(nav2_util::isSamePlan(empty_a, empty_b));
+}

--- a/nav2_util/test/test_path_utils.cpp
+++ b/nav2_util/test/test_path_utils.cpp
@@ -639,3 +639,46 @@ TEST(UtilsTests, IsPathOrGoalUpdatedTest)
   EXPECT_FALSE(nav2_util::isPathUpdated(old_path, new_path));
   EXPECT_TRUE(nav2_util::isGoalUpdated(old_path, new_path));
 }
+
+TEST(UtilsTests, IsSamePlanTest)
+{
+  auto makePose = [](double x, double y, double yaw = 0.0) {
+      geometry_msgs::msg::PoseStamped pose;
+      pose.pose.position.x = x;
+      pose.pose.position.y = y;
+      pose.pose.position.z = 0.0;
+      pose.pose.orientation.z = std::sin(yaw * 0.5);
+      pose.pose.orientation.w = std::cos(yaw * 0.5);
+      return pose;
+    };
+
+  nav_msgs::msg::Path path_a, path_b;
+  path_a.header.frame_id = "map";
+  path_b.header.frame_id = "map";
+  path_a.poses.push_back(makePose(0.0, 0.0));
+  path_a.poses.push_back(makePose(1.0, 0.0, 0.2));
+  path_b.poses = path_a.poses;
+  path_b.poses.front().header.stamp.sec = 42;
+  EXPECT_TRUE(nav2_util::isSamePlan(path_a, path_b));
+
+  path_b.header.frame_id = "odom";
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  path_b.header.frame_id = "map";
+  path_b.poses.push_back(makePose(2.0, 0.0));
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  path_b.poses = path_a.poses;
+  path_b.poses.back().pose.position.x = 9.0;
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  path_b.poses = path_a.poses;
+  path_b.poses.back().pose.orientation.z = std::sin(0.5);
+  path_b.poses.back().pose.orientation.w = std::cos(0.5);
+  EXPECT_FALSE(nav2_util::isSamePlan(path_a, path_b));
+
+  nav_msgs::msg::Path empty_a, empty_b;
+  empty_a.header.frame_id = "map";
+  empty_b.header.frame_id = "map";
+  EXPECT_TRUE(nav2_util::isSamePlan(empty_a, empty_b));
+}


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6235 |
| Primary OS tested on | Ubuntu (ROS Rolling); Windows for source review |
| Robotic platform tested on | N/A (unit tests) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* FollowPath abort/retry can reissue the same global path while `FeasiblePathHandler::setPlan` previously always reset the pruned front to pose 0. With a bounded `max_robot_pose_search_dist`, the nearest-pose search could miss the robot and throw "Resulting plan has 0 poses".
* An identical geometric plan is now only a **resume candidate**. On the next `findPlanSegment()` call, the retained bounded-search state is validated against the local costmap.
* If the closest retained candidate is still inside the costmap, keep the retained prune/constraint state. If it is outside, restore the unpruned path, reconstruct the working plan (including inversion/rotation constraints), and rerun the normal bounded search once.
* A transform failure during that costmap check leaves validation pending (`unknown`, not stale), so temporary TF unavailability does not discard retained state.
* Preserve the #6318 end-of-path two-pose guard after continuity validation.
* Clear retained path-handler state on successful goal exit and cancel for all registered handlers. Failed goals keep it so BT retries can still resume after continuity validation.
* When `path_handler_id` changes, reset both the outgoing and incoming handler before installing the new path.
* `onGoalExit` takes an explicit `reset_path_handler_state` flag separate from `force_stop`.
* Promote exact-path identity checks to `nav2_util::isSamePlan` with unit coverage.

## Description of documentation updates required from your changes

* None required.

## Description of how this change was tested

* Fresh Release build of `--packages-up-to nav2_controller` on ROS Rolling.
* Full `nav2_util` + `nav2_controller` package tests: 385 tests, 0 failures (includes retained-state path-handler cases, `SearchDistanceSmallerThanPoseSpacing`, controller reset helpers, and `isSamePlan`).
* Lint targets for both packages, including uncrustify/cpplint/cppcheck/xmllint/lint_cmake.
* Expected to be validated again by PR CI after this update.

## Future work that may be required in bullet points

* Optional TruncatePathLocal BT workaround is no longer needed if this lands.

#### For Maintainers:
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
