### PR TITLE
Fix path handler with small pose search distance

### DIFF
--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -182,14 +182,12 @@ nav2_core::PathSegment FeasiblePathHandler::findPlanSegment(
       return euclidean_distance(global_pose_, ps);
     });
 
-  // Make sure we always have at least 2 points on the transformed plan and that we don't prune
-  // the global plan below 2 points in order to have always enough point to interpolate the
-  // end of path direction
-  if (global_plan_up_to_constraint_.poses.begin() != closest_pose_upper_bound &&
-    global_plan_up_to_constraint_.poses.size() > 1 &&
-    closest_point == std::prev(closest_pose_upper_bound))
+  // Do not prune the global plan below 2 points, so there are enough points to interpolate the
+  // end-of-path direction.
+  if (global_plan_up_to_constraint_.poses.size() > 1 &&
+    closest_point == std::prev(global_plan_up_to_constraint_.poses.end()))
   {
-    closest_point = std::prev(std::prev(closest_pose_upper_bound));
+    closest_point = std::prev(closest_point);
   }
 
   auto pruned_plan_end =

--- a/nav2_controller/plugins/test/path_handler.cpp
+++ b/nav2_controller/plugins/test/path_handler.cpp
@@ -150,6 +150,48 @@ TEST(PathHandlerTests, TestBounds)
   EXPECT_EQ(path_inverted.poses.size(), 75u);
 }
 
+TEST(PathHandlerTests, SearchDistanceSmallerThanPoseSpacing)
+{
+  PathHandlerWrapper handler;
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(0.5));
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  rclcpp_lifecycle::State state;
+  costmap_ros->on_configure(state);
+  costmap_ros->set_parameters_atomically(
+    {rclcpp::Parameter("global_frame", "odom"),
+      rclcpp::Parameter("robot_base_frame", "base_link")});
+  handler.initialize(node, node->get_logger(), "dummy", costmap_ros, costmap_ros->getTfBuffer());
+
+  auto tf_broadcaster_ = nav2::create_transform_broadcaster(node);
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "map";
+  t.child_frame_id = "base_link";
+  tf_broadcaster_->sendTransform(t);
+  t.child_frame_id = "odom";
+  tf_broadcaster_->sendTransform(t);
+  std::this_thread::sleep_for(10ms);
+
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  path.poses.resize(3);
+  for (unsigned int i = 0; i != path.poses.size(); ++i) {
+    path.poses[i].pose.position.x = i;
+    path.poses[i].header.frame_id = "map";
+  }
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "odom";
+  robot_pose.pose.position.x = 0.9;
+
+  handler.setPlan(path);
+  auto [closest, pruned_plan_end] = handler.findPlanSegmentWrapper(robot_pose);
+  auto & bounded_path = handler.getInvertedPath();
+  EXPECT_EQ(closest, bounded_path.poses.begin());
+  EXPECT_EQ(pruned_plan_end, bounded_path.poses.end());
+}
+
 TEST(PathHandlerTests, TestBoundsWithConstraintCheck)
 {
   PathHandlerWrapper handler;


### PR DESCRIPTION
If the parameter max_robot_pose_search_dist_ is set to something small compared to the global plan resolution, the current logic in the Path handler can result in a segfault:

suppose: poses: [P0, P1, P2]
distance(P0, P1): 1.0 m
max_robot_pose_search_dist_: 0.5 m

first_after_integrated_distance() returns begin() + 1. 

Consequently:

closest_pose_upper_bound == begin() + 1
The search range contains only P0, so:
closest_point == begin()
closest_point == std::prev(closest_pose_upper_bound)
The following adjustment then executes:
closest_point = std::prev(std::prev(closest_pose_upper_bound));
which is equivalent to:
closest_point = begin() - 1;
That is an invalid iterator.

Example of crash log:

`[controller_server-2] Stack trace (most recent call last) in thread 122803:
[controller_server-2] #13   Object "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", at 0xffffffffffffffff, in 
[controller_server-2] #12   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x786c96d718cf, in 
[controller_server-2] #11   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x786c96cdfac2, in 
[controller_server-2] #10   Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x786c96f72252, in 
[controller_server-2] #9    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c977b5140, in std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<nav2::SimpleActionServer<nav2_msgs::action::FollowPath>::handle_accepted(std::shared_ptr<rclcpp_action::ServerGoalHandle<nav2_msgs::action::FollowPath> >)::{lambda()#1}> >, void>::_M_run()
[controller_server-2] #8    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x786c96ce4ee7, in 
[controller_server-2] #7    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c977a9e6c, in std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)
[controller_server-2] #6    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c978184d0, in std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<nav2::SimpleActionServer<nav2_msgs::action::FollowPath>::handle_accepted(std::shared_ptr<rclcpp_action::ServerGoalHandle<nav2_msgs::action::FollowPath> >)::{lambda()#1}> >, void> >::_M_invoke(std::_Any_data const&)
[controller_server-2] #5    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c9781778b, in nav2::SimpleActionServer<nav2_msgs::action::FollowPath>::work()
[controller_server-2] #4    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c9779cfe3, in nav2_controller::ControllerServer::computeControl()
[controller_server-2] #3    Object "/opt/ros/jazzy/install/lib/libcontroller_server_core.so", at 0x786c9779ab67, in nav2_controller::ControllerServer::computeAndPublishVelocity()
[controller_server-2] #2    Object "/opt/ros/jazzy/install/lib/libfeasible_path_handler.so", at 0x786c884a258d, in nav2_controller::FeasiblePathHandler::transformLocalPlan(__gnu_cxx::__normal_iterator<geometry_msgs::msg::PoseStamped_<std::allocator<void> >*, std::vector<geometry_msgs::msg::PoseStamped_<std::allocator<void> >, std::allocator<geometry_msgs::msg::PoseStamped_<std::allocator<void> > > > > const&, __gnu_cxx::__normal_iterator<geometry_msgs::msg::PoseStamped_<std::allocator<void> >*, std::vector<geometry_msgs::msg::PoseStamped_<std::allocator<void> >, std::allocator<geometry_msgs::msg::PoseStamped_<std::allocator<void> > > > > const&)
[controller_server-2] #1    Object "/opt/ros/jazzy/install/lib/libbehaviortree_cpp.so", at 0x786c97593ebe, in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
[controller_server-2] #0    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x786c96deb8cd, in 
[controller_server-2] Segmentation fault (Address not mapped to object [0x1])`

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu 24|
| Robotic platform tested on | Diff drive robot simulator |
| Does this PR contain AI generated software? | (Yes, the regression test) |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

The fix changes the logic that preserves the capability to compute the final path orientation

## Description of documentation updates required from your changes

None

## Description of how this change was tested

<!--
Wrote a regression test, still need to test this on a simulator.
-->

---

## Future work that may be required in bullet points

<!--
the min_by search excludes the final iterator, even if including it might make sense... I'll give it a better thought :)
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
