### PR TITLE
Rebalance CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,9 +203,7 @@ _commands:
                         # Keep only packages that are in both lists
                         BUILD_PACKAGES=$(echo "$BUILD_PACKAGES" | tr ' ' '\n' | \
                           grep -F -x -f <(echo "$SELECTED_PACKAGES" | tr ' ' '\n') | \
-                          xargs || echo "$SELECTED_PACKAGES")
-                      else
-                        BUILD_PACKAGES="$SELECTED_PACKAGES"
+                          xargs || true)
                       fi
                     fi
                     echo BUILD_PACKAGES: $BUILD_PACKAGES
@@ -368,6 +366,13 @@ _steps:
       name: Post Checkout
       command: |
         cp $OVERLAY_WS/src/navigation2/.circleci/defaults.yaml $COLCON_DEFAULTS_FILE
+
+        # Patch colcon-cache for Python 3.14 compatibility
+        # https://github.com/ruffsl/colcon-cache/issues/50
+        pip install --break-system-packages --force-reinstall --no-deps git+https://github.com/ruffsl/colcon-cache.git@master
+        DIRHASH_FILE=$(python3 -c "import colcon_cache.task.lock.dirhash as m; print(m.__file__)")
+        sed -i 's/modifier_group = parser.add_mutually_exclusive_group()/modifier_group = parser/' "$DIRHASH_FILE"
+
         if ! cmp \
           $OVERLAY_WS/src/navigation2/tools/underlay.repos \
           $UNDERLAY_WS/underlay.repos >/dev/null 2>&1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,6 +552,14 @@ jobs:
       - build_source:
           packages_skip_regex: << parameters.packages_skip_regex >>
           packages_select: << parameters.packages_select >>
+  plugin_build:
+    <<: *job_build
+    executor: release_exec
+    steps:
+      - restore_build
+      - build_source:
+          packages_skip_regex: << parameters.packages_skip_regex >>
+          packages_select: << parameters.packages_select >>
   system_build:
     <<: *job_build
     executor: release_exec
@@ -576,7 +584,10 @@ _parameters:
     packages_select: "nav2_common nav2_voxel_grid nav_2d_msgs dwb_msgs nav2_msgs nav2_ros_common nav2_simple_commander nav2_util nav2_amcl nav2_lifecycle_manager nav2_map_server nav_2d_utils nav2_velocity_smoother nav2_costmap_2d costmap_queue"
   algorithm_build_parameters: &algorithm_build_parameters
     packages_skip_regex: ""
-    packages_select: "nav2_core nav2_behavior_tree nav2_collision_monitor dwb_core dwb_critics dwb_plugins nav2_dwb_controller nav2_controller nav2_bt_navigator nav2_constrained_smoother nav2_navfn_planner nav2_planner nav2_regulated_pure_pursuit_controller nav2_theta_star_planner nav2_graceful_controller"
+    packages_select: "nav2_behavior_tree nav2_collision_monitor nav2_core nav2_bt_navigator"
+  plugin_build_parameters: &plugin_build_parameters
+    packages_skip_regex: ""
+    packages_select: "dwb_core dwb_critics dwb_plugins nav2_dwb_controller nav2_controller nav2_constrained_smoother nav2_navfn_planner nav2_planner nav2_regulated_pure_pursuit_controller nav2_theta_star_planner nav2_graceful_controller"
   system_build_parameters: &system_build_parameters
     packages_skip_regex: "'(nav2_common|nav2_voxel_grid|nav_2d_msgs|dwb_msgs|nav2_msgs|nav2_ros_common|nav2_simple_commander|nav2_util|nav2_amcl|nav2_behavior_tree|nav2_lifecycle_manager|nav2_map_server|nav_2d_utils|nav2_velocity_smoother|nav2_costmap_2d|costmap_queue|nav2_core|nav2_collision_monitor|dwb_core|dwb_critics|dwb_plugins|nav2_dwb_controller|nav2_controller|nav2_bt_navigator|nav2_constrained_smoother|nav2_navfn_planner|nav2_planner|nav2_regulated_pure_pursuit_controller|nav2_theta_star_planner|nav2_graceful_controller)'"
     packages_select: ""
@@ -593,10 +604,14 @@ workflows:
           <<: *algorithm_build_parameters
           requires:
             - core_build
+      - plugin_build:
+          <<: *plugin_build_parameters
+          requires:
+            - algorithm_build
       - system_build:
           <<: *system_build_parameters
           requires:
-            - algorithm_build
+            - plugin_build
       - release_test:
           <<: *release_test_parameters
           requires:
@@ -610,10 +625,14 @@ workflows:
           <<: *algorithm_build_parameters
           requires:
             - core_build
+      - plugin_build:
+          <<: *plugin_build_parameters
+          requires:
+            - algorithm_build
       - system_build:
           <<: *system_build_parameters
           requires:
-            - algorithm_build
+            - plugin_build
       - release_test:
           requires:
             - system_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,10 +584,10 @@ _parameters:
     packages_select: "nav2_common nav2_voxel_grid nav_2d_msgs dwb_msgs nav2_msgs nav2_ros_common nav2_simple_commander nav2_util nav2_amcl nav2_lifecycle_manager nav2_map_server nav_2d_utils nav2_velocity_smoother nav2_costmap_2d costmap_queue"
   algorithm_build_parameters: &algorithm_build_parameters
     packages_skip_regex: ""
-    packages_select: "nav2_behavior_tree nav2_collision_monitor nav2_core nav2_bt_navigator"
+    packages_select: "nav2_behavior_tree nav2_collision_monitor"
   plugin_build_parameters: &plugin_build_parameters
     packages_skip_regex: ""
-    packages_select: "dwb_core dwb_critics dwb_plugins nav2_dwb_controller nav2_controller nav2_constrained_smoother nav2_navfn_planner nav2_planner nav2_regulated_pure_pursuit_controller nav2_theta_star_planner nav2_graceful_controller"
+    packages_select: "nav2_core nav2_bt_navigator dwb_core dwb_critics dwb_plugins nav2_dwb_controller nav2_controller nav2_constrained_smoother nav2_navfn_planner nav2_planner nav2_regulated_pure_pursuit_controller nav2_theta_star_planner nav2_graceful_controller"
   system_build_parameters: &system_build_parameters
     packages_skip_regex: "'(nav2_common|nav2_voxel_grid|nav_2d_msgs|dwb_msgs|nav2_msgs|nav2_ros_common|nav2_simple_commander|nav2_util|nav2_amcl|nav2_behavior_tree|nav2_lifecycle_manager|nav2_map_server|nav_2d_utils|nav2_velocity_smoother|nav2_costmap_2d|costmap_queue|nav2_core|nav2_collision_monitor|dwb_core|dwb_critics|dwb_plugins|nav2_dwb_controller|nav2_controller|nav2_bt_navigator|nav2_constrained_smoother|nav2_navfn_planner|nav2_planner|nav2_regulated_pure_pursuit_controller|nav2_theta_star_planner|nav2_graceful_controller)'"
     packages_select: ""


### PR DESCRIPTION
ah, there's an actual bug from the Python3.14 upgrade as well 

```
ERROR:colcon.colcon_core.task:Exception in task extension 'lock.dirhash': argument groups cannot be nested
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/task/__init__.py", line 257, in add_task_arguments
    retval = extension.add_arguments(parser=group)
  File "/usr/local/lib/python3.14/dist-packages/colcon_cache/task/lock/dirhash.py", line 57, in add_arguments
    filter_options = parser.add_argument_group(
        title='Filtering options',
    ...<14 lines>...
        'https://github.com/andhus/dirhash/README.md#filtering'
    )
  File "/usr/lib/python3/dist-packages/colcon_core/argument_parser/__init__.py", line 155, in add_argument_group
    self._parser.add_argument_group(*args, **kwargs))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/colcon_core/argument_parser/__init__.py", line 155, in add_argument_group
    self._parser.add_argument_group(*args, **kwargs))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/colcon_core/argument_parser/__init__.py", line 155, in add_argument_group
    self._parser.add_argument_group(*args, **kwargs))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  [Previous line repeated 1 more time]
  File "/usr/lib/python3.14/argparse.py", line 1806, in add_argument_group
    raise ValueError('argument groups cannot be nested')
ValueError: argument groups cannot be nested
```