### PR TITLE
nav2_util: Export angles to dependent packages

### DIFF
--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>angles</build_depend>
   <build_depend>nav2_common</build_depend>
+  <build_export_depend>angles</build_export_depend>
 
   <depend>backward_ros</depend>
   <depend>bond</depend>


### PR DESCRIPTION
Dependent packages that include `path_utils.hpp` need to have `angles/angles.h` available. Add `build_export_depend` to `package.xml` to ensure that.

Without this change, we experience the following `nav2_behavior_tree` build failure in [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay), which builds packages in a sandbox containing only declared dependencies:

    CMake Error at /nix/store/vk9cd94x553a4vvq4b8yxj2y1hlj7yzf-ros-lyrical-nav2-util-1.5.0-r1/share/nav2_util/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
      By not providing "Findangles.cmake" in CMAKE_MODULE_PATH this project has
      asked CMake to find a package configuration file provided by "angles", but
      CMake did not find one.

      Could not find a package configuration file provided by "angles" with any
      of the following names:

        angles.cps
        anglesConfig.cmake
        angles-config.cmake

      Add the installation prefix of "angles" to CMAKE_PREFIX_PATH or set
      "angles_DIR" to a directory containing one of the above files.  If "angles"
      provides a separate development package or SDK, be sure it has been
      installed.
    Call Stack (most recent call first):
      /nix/store/vk9cd94x553a4vvq4b8yxj2y1hlj7yzf-ros-lyrical-nav2-util-1.5.0-r1/share/nav2_util/cmake/nav2_utilConfig.cmake:41 (include)
      CMakeLists.txt:11 (find_package)

This should be backported at least to lyrical.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
