### PR TITLE
Fix costmap publication for late subscribers

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
@@ -155,11 +155,15 @@ private:
   Costmap2D * costmap_;
   std::string global_frame_;
   std::string topic_name_;
-  unsigned int x0_, xn_, y0_, yn_;
-  double saved_origin_x_;
-  double saved_origin_y_;
-  bool always_send_full_costmap_;
-  double map_vis_z_;
+  unsigned int x0_{0};
+  unsigned int xn_{0};
+  unsigned int y0_{0};
+  unsigned int yn_{0};
+  double saved_origin_x_{0.0};
+  double saved_origin_y_{0.0};
+  bool always_send_full_costmap_{false};
+  bool costmap_published_once_{false};
+  double map_vis_z_{0.0};
 
   // Publisher for translated costmap values as msg::OccupancyGrid used in visualization
   nav2::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr costmap_pub_;
@@ -175,8 +179,9 @@ private:
   nav2::ServiceServer<nav2_msgs::srv::GetCostmap>::SharedPtr
     costmap_service_;
 
-  float grid_resolution_;
-  unsigned int grid_width_, grid_height_;
+  float grid_resolution_{0.0};
+  unsigned int grid_width_{0};
+  unsigned int grid_height_{0};
   std::unique_ptr<nav_msgs::msg::OccupancyGrid> grid_;
   std::unique_ptr<nav2_msgs::msg::Costmap> costmap_raw_;
   // Translate from 0-255 values in costmap to -1 to 100 values in message.

--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -246,17 +246,19 @@ void Costmap2DPublisher::publishCostmap()
     grid_width_ != costmap_->getSizeInCellsX() ||
     grid_height_ != costmap_->getSizeInCellsY() ||
     saved_origin_x_ != costmap_->getOriginX() ||
-    saved_origin_y_ != costmap_->getOriginY())
+    saved_origin_y_ != costmap_->getOriginY() ||
+    !costmap_published_once_)
   {
     updateGridParams();
-    if (costmap_pub_->get_subscription_count() > 0) {
+    if (costmap_pub_->get_subscription_count() > 0 || !costmap_published_once_) {
       prepareGrid();
       costmap_pub_->publish(std::move(grid_));
     }
-    if (costmap_raw_pub_->get_subscription_count() > 0) {
+    if (costmap_raw_pub_->get_subscription_count() > 0 || !costmap_published_once_) {
       prepareCostmap();
       costmap_raw_pub_->publish(std::move(costmap_raw_));
     }
+    costmap_published_once_ = true;
   } else if (x0_ < xn_) {
     // Publish just update msgs
     std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));

--- a/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_subscriber.cpp
@@ -14,6 +14,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <future>
+
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d_publisher.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
@@ -298,6 +301,60 @@ TEST_F(
   throwExceptionIfGetCostmapMethodIsCalledBeforeAnyCostmapMsgReceived)
 {
   ASSERT_ANY_THROW(costmapSubscriber->getCostmap());
+}
+
+TEST(CostmapPublisherShould, publishInitialCostmapForLateSubscribers)
+{
+  constexpr unsigned int size_x = 10;
+  constexpr unsigned int size_y = 10;
+  auto node = std::make_shared<nav2::LifecycleNode>("test_late_costmap_subscriber");
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(
+    size_x, size_y, 1.0, 0.0, 0.0);
+  auto costmap_publisher = std::make_shared<nav2_costmap_2d::Costmap2DPublisher>(
+    node, costmap.get(), "map", "/late_costmap", false);
+  costmap_publisher->on_activate();
+
+  // Publish before any subscribers exist. The transient-local publishers must retain this
+  // initial full costmap for subscribers that join later.
+  costmap_publisher->publishCostmap();
+
+  std::promise<nav_msgs::msg::OccupancyGrid::ConstSharedPtr> costmap_promise;
+  auto costmap_future = costmap_promise.get_future();
+  auto costmap_subscriber = node->create_subscription<nav_msgs::msg::OccupancyGrid>(
+    "/late_costmap",
+    [&costmap_promise](nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg) {
+      costmap_promise.set_value(msg);
+    }, nav2::qos::LatchedSubscriptionQoS());
+
+  std::promise<nav2_msgs::msg::Costmap::ConstSharedPtr> raw_costmap_promise;
+  auto raw_costmap_future = raw_costmap_promise.get_future();
+  auto raw_costmap_subscriber = node->create_subscription<nav2_msgs::msg::Costmap>(
+    "/late_costmap_raw",
+    [&raw_costmap_promise](nav2_msgs::msg::Costmap::ConstSharedPtr msg) {
+      raw_costmap_promise.set_value(msg);
+    }, nav2::qos::LatchedSubscriptionQoS());
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
+  ASSERT_EQ(
+    executor.spin_until_future_complete(costmap_future, std::chrono::seconds(5)),
+    rclcpp::FutureReturnCode::SUCCESS);
+  ASSERT_EQ(
+    executor.spin_until_future_complete(raw_costmap_future, std::chrono::seconds(5)),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  const auto received_costmap = costmap_future.get();
+  EXPECT_EQ(received_costmap->info.width, size_x);
+  EXPECT_EQ(received_costmap->info.height, size_y);
+  EXPECT_EQ(received_costmap->data.size(), size_x * size_y);
+
+  const auto received_raw_costmap = raw_costmap_future.get();
+  EXPECT_EQ(received_raw_costmap->metadata.size_x, size_x);
+  EXPECT_EQ(received_raw_costmap->metadata.size_y, size_y);
+  EXPECT_EQ(received_raw_costmap->data.size(), size_x * size_y);
+
+  costmap_publisher->on_deactivate();
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6267 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Ubuntu, added a regression test |
| Does this PR contain AI generated software? | The regression test|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points


- Costmap metadata cache member variables have been default initialized to prevent undefined behavior during the first comparison with the costmap data.
- A boolean flag was introduced to ensure that the costmaps are published once before switching to "update only". Being the topics latched, this ensures that late subscribers get them even if the metadata doesn't change.

## Description of documentation updates required from your changes

None

## Description of how this change was tested

Added a regression test, verified that it fails without the fix.

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
