### PR TITLE
Fix exported package dependencies

### DIFF
--- a/nav2_route/package.xml
+++ b/nav2_route/package.xml
@@ -9,9 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>libnanoflann-dev</build_depend>
+  <depend>libnanoflann-dev</depend>
   <build_depend>nav2_common</build_depend>
-  <build_depend>nlohmann-json-dev</build_depend>
+  <depend>nlohmann-json-dev</depend>
   <build_depend>angles</build_depend>
 
   <depend>backward_ros</depend>

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>angles</build_depend>
+  <depend>angles</depend>
   <build_depend>nav2_common</build_depend>
 
   <depend>backward_ros</depend>


### PR DESCRIPTION
`nav2_util` and `nav2_route` export CMake dependencies that downstream packages must be able to find when loading their package configs. Declare those dependencies with `<depend>` instead of `<build_depend>` so generated binary packages propagate them at runtime:

- `nav2_util`: `angles`
- `nav2_route`: `libnanoflann-dev` and `nlohmann-json-dev`

This fixes isolated downstream builds such as `nav2_amcl` and `nav2_rviz_plugins` failing while loading the exported Nav2 CMake configs.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>