### PR TITLE
Fix nav2_ros_common platform portability

### DIFF
--- a/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
@@ -35,7 +35,12 @@
   #include <pthread.h>
   #include <mach/mach.h>
   #include <mach/thread_policy.h>
-#elif !defined(_WIN32)
+#elif defined(_WIN32)
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
+#else
   #include <sched.h>
   #include <errno.h>
 #endif
@@ -378,7 +383,14 @@ inline void setSoftRealTimePriority()
     throw std::runtime_error(errmsg);
   }
 #elif defined(_WIN32)
-  throw std::runtime_error("Soft real-time prioritization is not supported on Windows");
+  // Windows: Raise only the current thread to the highest non-real-time priority.
+  // Keeping the process in its normal priority class avoids requiring elevated
+  // privileges and prevents the process from starving critical system threads.
+  if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL)) {
+    throw std::runtime_error(
+            "Failed to set soft real-time thread priority on Windows. Error: " +
+            std::to_string(GetLastError()));
+  }
 #else
   // Linux: True real-time scheduling (requires privileges)
   sched_param sch;

--- a/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
@@ -35,7 +35,7 @@
   #include <pthread.h>
   #include <mach/mach.h>
   #include <mach/thread_policy.h>
-#else
+#elif !defined(_WIN32)
   #include <sched.h>
   #include <errno.h>
 #endif
@@ -377,6 +377,8 @@ inline void setSoftRealTimePriority()
       std::to_string(result);
     throw std::runtime_error(errmsg);
   }
+#elif defined(_WIN32)
+  throw std::runtime_error("Soft real-time prioritization is not supported on Windows");
 #else
   // Linux: True real-time scheduling (requires privileges)
   sched_param sch;

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -82,10 +82,10 @@ bool validateMsg(const std::array<double, N> & msg)
   return true;
 }
 
-const int NSEC_PER_SEC = 1e9;  // 1 second = 1e9 nanosecond
+constexpr int NANOSECONDS_PER_SECOND = 1e9;
 bool validateMsg(const builtin_interfaces::msg::Time & msg)
 {
-  if (msg.nanosec >= NSEC_PER_SEC) {
+  if (msg.nanosec >= NANOSECONDS_PER_SECOND) {
     return false;                                      // invalid nanosec-stamp
   }
   return true;

--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -186,11 +187,13 @@ bool validateMsg(const nav_msgs::msg::OccupancyGrid & msg)
     return false;
   }
 
-  uint32_t num_cells;
-  if (__builtin_mul_overflow(msg.info.width, msg.info.height, &num_cells)) {
+  if (msg.info.width != 0 &&
+    msg.info.height > std::numeric_limits<uint32_t>::max() / msg.info.width)
+  {
     // avoid overflow msg.info.width * msg.info.height in nav2_amcl::convertMap()
     return false;
   }
+  const uint32_t num_cells = msg.info.width * msg.info.height;
 
   // check logic
   if (msg.data.size() != static_cast<size_t>(num_cells)) {
@@ -221,8 +224,9 @@ bool validateMsg(const map_msgs::msg::OccupancyGridUpdate & msg)
     return false;
   }
 
-  uint32_t num_cells;
-  if (__builtin_mul_overflow(msg.width, msg.height, &num_cells)) {
+  if (msg.width != 0 &&
+    msg.height > std::numeric_limits<uint32_t>::max() / msg.width)
+  {
     // avoid overflow msg.width * msg.height in StaticLayer::incomingUpdate()
     return false;
   }


### PR DESCRIPTION
Fix two platform-specific issues in `nav2_ros_common`:

- macOS defines `NSEC_PER_SEC` as a macro in `<mach/clock_types.h>`, causing `validate_messages.hpp` to fail with `expected unqualified-id`. Use a collision-resistant constant name.
- Windows does not provide `<sched.h>` or POSIX real-time scheduling APIs. Avoid including the header and report the unsupported soft real-time request explicitly.

These fixes allow downstream Nav2 packages to compile with current macOS and Windows toolchains.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>