### PR TITLE
Use portable atomic shared pointer operations

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
@@ -93,7 +93,11 @@ protected:
   std::string robot_base_frame_;
   double transform_tolerance_;
   std::atomic_bool footprint_received_{false};
+#ifdef __cpp_lib_atomic_shared_ptr
   std::atomic<geometry_msgs::msg::PolygonStamped::ConstSharedPtr> footprint_;
+#else
+  geometry_msgs::msg::PolygonStamped::ConstSharedPtr footprint_;
+#endif
   nav2::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr footprint_sub_;
 };
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -190,7 +190,11 @@ public:
   /** @brief Returns the latest footprint stored with setFootprint(). */
   const std::vector<geometry_msgs::msg::Point> & getFootprint()
   {
+#ifdef __cpp_lib_atomic_shared_ptr
     return *footprint_.load();
+#else
+    return *std::atomic_load(&footprint_);
+#endif
   }
 
   /** @brief The radius of a circle centered at the origin of the
@@ -231,7 +235,11 @@ private:
   bool initialized_;
   bool size_locked_;
   std::atomic<double> circumscribed_radius_, inscribed_radius_;
+#ifdef __cpp_lib_atomic_shared_ptr
   std::atomic<std::shared_ptr<std::vector<geometry_msgs::msg::Point>>> footprint_;
+#else
+  std::shared_ptr<std::vector<geometry_msgs::msg::Point>> footprint_;
+#endif
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -31,7 +31,11 @@ FootprintSubscriber::getFootprintRaw(
     return false;
   }
 
+#ifdef __cpp_lib_atomic_shared_ptr
   auto current_footprint = footprint_.load();
+#else
+  auto current_footprint = std::atomic_load(&footprint_);
+#endif
   if (!current_footprint) {
     return false;
   }
@@ -77,7 +81,11 @@ void
 FootprintSubscriber::footprint_callback(
   const geometry_msgs::msg::PolygonStamped::ConstSharedPtr & msg)
 {
+#ifdef __cpp_lib_atomic_shared_ptr
   footprint_.store(msg);
+#else
+  std::atomic_store(&footprint_, msg);
+#endif
   if (!footprint_received_.load()) {
     footprint_received_.store(true);
   }

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -301,8 +301,12 @@ void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::msg::Point> &
     footprint_spec);
   // use atomic store here since footprint is used by various planners/controllers
   // and not otherwise locked
-  footprint_.store(
+#ifdef __cpp_lib_atomic_shared_ptr
+  footprint_.store(std::make_shared<std::vector<geometry_msgs::msg::Point>>(footprint_spec));
+#else
+  std::atomic_store(&footprint_,
     std::make_shared<std::vector<geometry_msgs::msg::Point>>(footprint_spec));
+#endif
   inscribed_radius_.store(std::get<0>(inside_outside));
   circumscribed_radius_.store(std::get<1>(inside_outside));
 


### PR DESCRIPTION
Some standard library versions, including libc++ 19 used by current conda-forge macOS toolchains, do not implement the C++20 `std::atomic<std::shared_ptr<T>>` specialization. Compilation then fails because the primary `std::atomic` template requires a trivially copyable type.

Store plain `std::shared_ptr` objects and use the portable `std::atomic_load`/`std::atomic_store` shared-pointer overloads instead. This preserves atomic access and is supported by older standard library implementations.

This covers both `LayeredCostmap` and `FootprintSubscriber`.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>