### PR TITLE
Fix lifecycle service client shutdown

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_service_client.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_service_client.hpp
@@ -46,7 +46,7 @@ public:
   {
     // Block until server is up
     rclcpp::Rate r(20);
-    while (!get_state_.wait_for_service(2s)) {
+    while (rclcpp::ok() && !get_state_.wait_for_service(2s)) {
       RCLCPP_INFO(
         parent_node->get_logger(),
         "Waiting for service %s...", get_state_.getServiceName().c_str());


### PR DESCRIPTION
Allows the wait for service loop to exit at shutdown

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Noticed this while executing the integration tests locally: race conditions can trigger a shut-down while this loop is executed, resulting in plenty of logs :)

## Description of how this change was tested

Integration tests

---

## Future work that may be required in bullet points

None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
