### PR TITLE
Backport #5617 to Jazzy

### DIFF
--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -54,6 +54,7 @@ This process is then repeated a number of times and returns a converged solution
  | visualize                  | bool   | Default: false. Publish visualization of trajectories, which can slow down the controller significantly. Use only for debugging.                                                                                                                                       |
  | retry_attempt_limit        | int    | Default 1. Number of attempts to find feasible trajectory on failure for soft-resets before reporting failure.                                                                                                                                                                                                       |
  | regenerate_noises          | bool   | Default false. Whether to regenerate noises each iteration or use single noise distribution computed on initialization and reset. Practically, this is found to work fine since the trajectories are being sampled stochastically from a normal distribution and reduces compute jittering at run-time due to thread wake-ups to resample normal distribution. |
+ | open_loop        | bool    | Default false. Useful when using low accelerations and when wheel odometry's latency causes issues in initial state estimation. |
 
 #### Trajectory Visualizer
  | Parameter             | Type   | Definition                                                                                                  |

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp
@@ -38,6 +38,7 @@ struct OptimizerSettings
   unsigned int iteration_count{0u};
   bool shift_control_sequence{false};
   size_t retry_attempt_limit{0};
+  bool open_loop{false};
 };
 
 }  // namespace mppi::models

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -267,6 +267,8 @@ protected:
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
+
+  geometry_msgs::msg::Twist last_command_vel_;
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -86,6 +86,7 @@ void Optimizer::getParams()
   getParam(s.sampling_std.vy, "vy_std", 0.2f);
   getParam(s.sampling_std.wz, "wz_std", 0.4f);
   getParam(s.retry_attempt_limit, "retry_attempt_limit", 1);
+  getParam(s.open_loop, "open_loop", false);
 
   s.base_constraints.ax_max = std::abs(s.base_constraints.ax_max);
   if (s.base_constraints.ax_min > 0.0) {
@@ -143,6 +144,10 @@ void Optimizer::reset(bool reset_dynamic_speed_limits)
   control_history_[2] = {0.0f, 0.0f, 0.0f};
   control_history_[3] = {0.0f, 0.0f, 0.0f};
 
+  if (settings_.open_loop) {
+    last_command_vel_ = geometry_msgs::msg::Twist();
+  }
+
   if (reset_dynamic_speed_limits) {
     settings_.constraints = settings_.base_constraints;
   }
@@ -176,6 +181,8 @@ geometry_msgs::msg::TwistStamped Optimizer::evalControl(
 
   utils::savitskyGolayFilter(control_sequence_, control_history_, settings_);
   auto control = getControlFromSequenceAsTwist(plan.header.stamp);
+
+  last_command_vel_ = control.twist;
 
   if (settings_.shift_control_sequence) {
     shiftControlSequence();
@@ -220,7 +227,7 @@ void Optimizer::prepare(
   nav2_core::GoalChecker * goal_checker)
 {
   state_.pose = robot_pose;
-  state_.speed = robot_speed;
+  state_.speed = settings_.open_loop ? last_command_vel_ : robot_speed;
   path_ = utils::toTensor(plan);
   costs_.fill(0.0f);
   goal_ = goal;

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -659,3 +659,61 @@ TEST(OptimizerTests, integrateStateVelocitiesTests)
     EXPECT_NEAR(traj.y(1, i), y, 1e-6);
   }
 }
+
+TEST(OptimizerTests, Omni_openLoopMppiTest)
+{
+  // Mirrors mppic.model_dt below. #5617 reads this from getSettings(), which
+  // jazzy's OptimizerTester does not expose.
+  constexpr double model_dt = 0.05;
+
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
+  OptimizerTester optimizer_tester;
+  node->declare_parameter("controller_frequency", rclcpp::ParameterValue(30.0));
+  node->declare_parameter("mppic.batch_size", rclcpp::ParameterValue(1000));
+  node->declare_parameter("mppic.model_dt", rclcpp::ParameterValue(model_dt));
+  node->declare_parameter("mppic.time_steps", rclcpp::ParameterValue(80));
+  node->declare_parameter("mppic.ax_max", rclcpp::ParameterValue(0.5));
+  node->declare_parameter("mppic.az_max", rclcpp::ParameterValue(0.5));
+  node->declare_parameter("mppic.ay_max", rclcpp::ParameterValue(0.5));
+  node->declare_parameter("mppic.open_loop", rclcpp::ParameterValue(true));
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", "dummy_costmap", true);
+  ParametersHandler param_handler(node);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+  optimizer_tester.initialize(node, "mppic", costmap_ros, &param_handler);
+  optimizer_tester.resetMotionModel();
+  optimizer_tester.testSetOmniModel();
+
+  geometry_msgs::msg::PoseStamped pose;
+  pose.pose.position.x = 999;
+  geometry_msgs::msg::Twist robot_speed;
+  robot_speed.linear.x = 100.0;
+  robot_speed.angular.z = 100.0;
+  robot_speed.linear.y = 100.0;
+  nav_msgs::msg::Path path;
+  geometry_msgs::msg::Pose goal;
+  path.poses.resize(17);
+
+  auto cmd1 = optimizer_tester.evalControl(pose, robot_speed, path, goal, nullptr);
+
+  EXPECT_LE(
+    std::abs(cmd1.twist.linear.x),
+    model_dt * optimizer_tester.getControlConstraints().ax_max);
+  EXPECT_LE(
+    std::abs(cmd1.twist.angular.z),
+    model_dt * optimizer_tester.getControlConstraints().az_max);
+  EXPECT_LE(
+    std::abs(cmd1.twist.linear.y),
+    model_dt * optimizer_tester.getControlConstraints().ay_max);
+
+  auto cmd2 = optimizer_tester.evalControl(pose, robot_speed, path, goal, nullptr);
+
+  const double vx_delta = std::abs(cmd2.twist.linear.x - cmd1.twist.linear.x);
+  const double wz_delta = std::abs(cmd2.twist.angular.z - cmd1.twist.angular.z);
+  const double vy_delta = std::abs(cmd2.twist.linear.y - cmd1.twist.linear.y);
+
+  EXPECT_LE(vx_delta, model_dt * optimizer_tester.getControlConstraints().ax_max);
+  EXPECT_LE(wz_delta, model_dt * optimizer_tester.getControlConstraints().az_max);
+  EXPECT_LE(vy_delta, model_dt * optimizer_tester.getControlConstraints().ay_max);
+}


### PR DESCRIPTION
Backport of #5617 to jazzy.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #5617) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  MuJoCo simulation of a Clearpath Ridgeback (mecanum base) with a UR5e |
| Does this PR contain AI generated software? | Yes, AI created the initial fork and cherry pick|
| Was this PR description generated by AI software? | No, I wrote the description |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* Cherry-pick of #5617, already merged to main, never labeled backport-jazzy
* Fixes a Humble to Jazzy regression: MPPI seeds rollouts from lagging odometry instead of its own last command
* Defaulting to false so no behavior change unless opted in

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* README parameter table row included, copied from #5617
* If merged, docs.nav2.org jazzy page would need the same row

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
 Tested: Ubuntu 24.04, MuJoCo sim. Our measurement on a simulated Ridgeback mecanum base, vx_max: 0.5: commanded speed 0.165 to 0.466 m/s; ground truth 0.138 to 0.452
We saw the same symptom class as #5386 and #5694 (that one reported 0.17 m/s and we similarly measured 0.173)

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
~~* upstream's unit test wasn't included because jazzy's test API has drifted, and not sure if you wanted this adapted~~

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
