### PR TITLE
Fixes null dock object access cases in dock database

### DIFF
--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -76,6 +76,7 @@ public:
    * @brief Generate a dock from action goal
    * @param goal Action goal
    * @return Raw dock pointer to manage;
+   * @throw DockNotValid if the goal's dock type resolves to no plugin
    */
   Dock * generateGoalDock(std::shared_ptr<const DockRobot::Goal> goal);
 

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -285,18 +285,20 @@ void DockingServer::dockRobot()
             }
             result->success = true;
             result->num_retries = num_retries_;
+            ChargingDock::Ptr dock_plugin = dock->plugin;
             stashDockData(goal->use_dock_id, dock, true);
             publishZeroVelocity();
-            dock->plugin->stopDetectionProcess();
+            dock_plugin->stopDetectionProcess();
             docking_action_server_->succeeded_current(result);
             return;
           }
         }
 
         // Cancelled, preempted, or shutting down (recoverable errors throw DockingException)
+        ChargingDock::Ptr dock_plugin = dock->plugin;
         stashDockData(goal->use_dock_id, dock, false);
         publishZeroVelocity();
-        dock->plugin->stopDetectionProcess();
+        dock_plugin->stopDetectionProcess();
         docking_action_server_->terminate_all(result);
         return;
       } catch (opennav_docking_core::DockingException & e) {
@@ -310,9 +312,10 @@ void DockingServer::dockRobot()
       // Reset to staging pose to try again
       if (!resetApproach(staging_pose, dock_backward)) {
         // Cancelled, preempted, or shutting down
+        ChargingDock::Ptr dock_plugin = dock->plugin;
         stashDockData(goal->use_dock_id, dock, false);
         publishZeroVelocity();
-        dock->plugin->stopDetectionProcess();
+        dock_plugin->stopDetectionProcess();
         docking_action_server_->terminate_all(result);
         return;
       }
@@ -357,10 +360,13 @@ void DockingServer::dockRobot()
   }
 
   // Store dock state for later undocking and delete temp dock, if applicable
+  ChargingDock::Ptr dock_plugin = dock ? dock->plugin : nullptr;
   stashDockData(goal->use_dock_id, dock, false);
   result->num_retries = num_retries_;
   publishZeroVelocity();
-  dock->plugin->stopDetectionProcess();
+  if (dock_plugin) {
+    dock_plugin->stopDetectionProcess();
+  }
   docking_action_server_->terminate_current(result);
 }
 
@@ -383,6 +389,10 @@ Dock * DockingServer::generateGoalDock(std::shared_ptr<const DockRobot::Goal> go
   dock->pose = goal->dock_pose.pose;
   dock->type = goal->dock_type;
   dock->plugin = dock_db_->findDockPlugin(dock->type);
+  if (!dock->plugin) {
+    delete dock;
+    throw opennav_docking_core::DockNotValid("Dock requested has no valid plugin!");
+  }
   return dock;
 }
 

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -285,20 +285,18 @@ void DockingServer::dockRobot()
             }
             result->success = true;
             result->num_retries = num_retries_;
-            ChargingDock::Ptr dock_plugin = dock->plugin;
-            stashDockData(goal->use_dock_id, dock, true);
             publishZeroVelocity();
-            dock_plugin->stopDetectionProcess();
+            dock->plugin->stopDetectionProcess();
+            stashDockData(goal->use_dock_id, dock, true);
             docking_action_server_->succeeded_current(result);
             return;
           }
         }
 
         // Cancelled, preempted, or shutting down (recoverable errors throw DockingException)
-        ChargingDock::Ptr dock_plugin = dock->plugin;
-        stashDockData(goal->use_dock_id, dock, false);
         publishZeroVelocity();
-        dock_plugin->stopDetectionProcess();
+        dock->plugin->stopDetectionProcess();
+        stashDockData(goal->use_dock_id, dock, false);
         docking_action_server_->terminate_all(result);
         return;
       } catch (opennav_docking_core::DockingException & e) {
@@ -312,10 +310,9 @@ void DockingServer::dockRobot()
       // Reset to staging pose to try again
       if (!resetApproach(staging_pose, dock_backward)) {
         // Cancelled, preempted, or shutting down
-        ChargingDock::Ptr dock_plugin = dock->plugin;
-        stashDockData(goal->use_dock_id, dock, false);
         publishZeroVelocity();
-        dock_plugin->stopDetectionProcess();
+        dock->plugin->stopDetectionProcess();
+        stashDockData(goal->use_dock_id, dock, false);
         docking_action_server_->terminate_all(result);
         return;
       }
@@ -359,14 +356,13 @@ void DockingServer::dockRobot()
     RCLCPP_ERROR(get_logger(), "%s", result->error_msg.c_str());
   }
 
-  // Store dock state for later undocking and delete temp dock, if applicable
-  ChargingDock::Ptr dock_plugin = dock ? dock->plugin : nullptr;
-  stashDockData(goal->use_dock_id, dock, false);
   result->num_retries = num_retries_;
   publishZeroVelocity();
-  if (dock_plugin) {
-    dock_plugin->stopDetectionProcess();
+  if (dock) {
+    dock->plugin->stopDetectionProcess();
   }
+  // Store dock state for later undocking and delete temp dock, if applicable
+  stashDockData(goal->use_dock_id, dock, false);
   docking_action_server_->terminate_current(result);
 }
 
@@ -384,15 +380,17 @@ void DockingServer::stashDockData(bool use_dock_id, Dock * dock, bool successful
 
 Dock * DockingServer::generateGoalDock(std::shared_ptr<const DockRobot::Goal> goal)
 {
+  auto plugin = dock_db_->findDockPlugin(goal->dock_type);
+  if (!plugin) {
+    throw opennav_docking_core::DockNotValid(
+      "Dock type '" + goal->dock_type + "' has no valid plugin!");
+  }
+
   auto dock = new Dock();
   dock->frame = goal->dock_pose.header.frame_id;
   dock->pose = goal->dock_pose.pose;
   dock->type = goal->dock_type;
-  dock->plugin = dock_db_->findDockPlugin(dock->type);
-  if (!dock->plugin) {
-    delete dock;
-    throw opennav_docking_core::DockNotValid("Dock requested has no valid plugin!");
-  }
+  dock->plugin = plugin;
   return dock;
 }
 

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -219,6 +219,47 @@ TEST(DockingServerTests, getateGoalDock)
   node.reset();
 }
 
+TEST(DockingServerTests, generateGoalDockNoPlugin)
+{
+  auto node = std::make_shared<opennav_docking::DockingServer>();
+
+  node->declare_parameter(
+    "docks",
+    rclcpp::ParameterValue(std::vector<std::string>{"test_dock"}));
+  node->declare_parameter(
+    "test_dock.type",
+    rclcpp::ParameterValue(std::string{"dock_plugin"}));
+  node->declare_parameter(
+    "test_dock.pose",
+    rclcpp::ParameterValue(std::vector<double>{0.0, 0.0, 0.0}));
+  node->declare_parameter(
+    "dock_plugins",
+    rclcpp::ParameterValue(std::vector<std::string>{"dock_plugin", "dock_plugin2"}));
+  node->declare_parameter(
+    "dock_plugin.plugin",
+    rclcpp::ParameterValue(std::string{"opennav_docking::TestFailureDock"}));
+  node->declare_parameter(
+    "dock_plugin2.plugin",
+    rclcpp::ParameterValue(std::string{"opennav_docking::TestFailureDock"}));
+
+  node->on_configure(rclcpp_lifecycle::State());
+
+  // Empty dock_type with >1 plugin registered: findDockPlugin returns nullptr
+  auto empty_type_goal = std::make_shared<const DockRobot::Goal>();
+  EXPECT_THROW(
+    node->generateGoalDock(empty_type_goal), opennav_docking_core::DockNotValid);
+
+  // Unknown dock_type: findDockPlugin returns nullptr
+  auto unknown_goal = std::make_shared<DockRobot::Goal>();
+  unknown_goal->dock_type = "not_a_registered_dock_type";
+  EXPECT_THROW(
+    node->generateGoalDock(unknown_goal), opennav_docking_core::DockNotValid);
+
+  node->on_cleanup(rclcpp_lifecycle::State());
+  node->on_shutdown(rclcpp_lifecycle::State());
+  node.reset();
+}
+
 TEST(DockingServerTests, testDynamicParams)
 {
   auto node = std::make_shared<opennav_docking::DockingServer>();


### PR DESCRIPTION
  - stashDockData deletes `dock` leaving `dock->plugin` dangling.
  - an unknown dock type yields a null plugin

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6354 |
| Primary OS tested on | Ubuntu 24.04.4 LTS (Noble) |
| Robotic platform tested on | Gazebo and hardware industrial cleaning robot |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* `generateGoalDock()` now throws `DockNotValid` when `findDockPlugin()` returns null.
* The `ChargingDock::Ptr` is copied out of `dock` before `stashDockData()` at all four
  `stopDetectionProcess()` calls. `stashDockData()` takes dock pointer by value and deletes it, so
  the caller's pointer becomes dangling.
* Added tests that produces the case that throws DockNotValid.

## Description of documentation updates required from your changes

* None. No new parameters, no new plugins, no behavior change to document.

## Description of how this change was tested

* Added a unit test in `test_docking_server_unit.cpp` calling `generateGoalDock()` with a dock type
  that doesn't have a registered plugin.

---

## Future work that may be required in bullet points

* `stashDockData()` takes dock pointer by value and assigns `dock = nullptr`, which doesn't effect
  caller. It would be clearer with a smart pointer or a `Dock *&` parameter.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
