### PR TITLE
opennav_following: fix rotateToObject() using stale/empty state for its first TF lookup

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -411,10 +411,18 @@ bool FollowingServer::rotateToObject(
 {
   const double dt = 1.0 / params_->controller_frequency;
 
+  // object_pose is still default-constructed (empty frame_id) if no detection has
+  // ever arrived for this goal, fall back to the fixed frame and let the robot search.
+  const std::string reference_frame =
+    object_pose.header.frame_id.empty() ? params_->fixed_frame : object_pose.header.frame_id;
+
+  // Refresh start time before transforming.
+  iteration_start_time_ = this->now();
+
   // Compute initial robot heading
   geometry_msgs::msg::PoseStamped robot_pose;
   if (!nav2_util::getCurrentPose(
-      robot_pose, *tf2_buffer_, object_pose.header.frame_id, params_->base_frame,
+      robot_pose, *tf2_buffer_, reference_frame, params_->base_frame,
       params_->transform_tolerance,
       iteration_start_time_))
   {
@@ -453,7 +461,7 @@ bool FollowingServer::rotateToObject(
 
       // Get current robot pose
       if (!nav2_util::getCurrentPose(
-          robot_pose, *tf2_buffer_, object_pose.header.frame_id, params_->base_frame,
+          robot_pose, *tf2_buffer_, reference_frame, params_->base_frame,
           params_->transform_tolerance,
           iteration_start_time_))
       {


### PR DESCRIPTION
Follow-up to the discussion in #6347 (Jazzy backport of `opennav_following`) and open-navigation/opennav_docking#100 — @SteveMacenski asked for this fix to go through `main` separately so it can be backported on its own.

Two related bugs in `rotateToObject()`'s search-by-rotating recovery path, found while porting/testing this package on Jazzy against a real robot and in Gazebo. Both are in the initial `getCurrentPose()` call at the top of the function:

```cpp
if (!nav2_util::getCurrentPose(
    robot_pose, *tf2_buffer_, object_pose.header.frame_id, params_->base_frame,
    params_->transform_tolerance,
    iteration_start_time_))
```

1. **`object_pose.header.frame_id` is still empty here on the very first lost-detection event** (no detection has ever arrived for this goal yet) — which is exactly the case this search rotation exists to recover from. Looking up TF against an empty target frame always fails, so the goal aborts instead of rotating to search. Repro: send a goal on a topic nobody is publishing to yet.

2. **`iteration_start_time_` is stale by the time you get here.** `getRefinedPose()`/`getTrackingPose()` blocks internally for up to `detection_timeout` waiting for a detection, without ever touching `iteration_start_time_`. Right after that wait times out, `iteration_start_time_` can be tens of seconds old — old enough to have aged out of the tf2 buffer's cache — so this lookup throws "extrapolation into the past" and `rotateToObject()` bails before it ever rotates.

Fix: fall back to `params_->fixed_frame` when the frame is empty, and refresh `iteration_start_time_` right before this first lookup. Same `reference_frame` reused for the second `getCurrentPose()` call inside the per-angle search loop.

## Testing

This exact fix (same logic, adapted to the pre-`nav2_ros_common` API) is already applied and tested on a Jazzy port of this package: [marcospontoexe/opennav_following@0b394d2](https://github.com/marcospontoexe/opennav_following/commit/0b394d2) — validated against both a real robot and Gazebo simulation (repro steps above match exactly what triggered it there).

I wasn't able to build/test this specific diff against `main` itself — my local environment only has ROS 2 Jazzy installed, and this package depends on `nav2_ros_common`, which isn't part of Jazzy. The change itself doesn't touch any API surface though, just local control flow (an added `const std::string` and one `this->now()` call), so I'm fairly confident it carries over cleanly, but flagging this gap rather than claiming a build I didn't actually run.
