### PR TITLE
Match velocity_smoother acceleration limits with MPPI defaults

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -496,8 +496,8 @@ velocity_smoother:
     feedback: "OPEN_LOOP"
     max_velocity: [0.5, 0.0, 2.0]
     min_velocity: [-0.5, 0.0, -2.0]
-    max_accel: [2.5, 0.0, 3.2]
-    max_decel: [-2.5, 0.0, -3.2]
+    max_accel: [3.0, 0.0, 3.5]
+    max_decel: [-3.0, 0.0, -3.5]
     odom_topic: "odom"
     odom_duration: 0.1
     deadband_velocity: [0.0, 0.0, 0.0]


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6357 |
| Primary OS tested on | N/A — not executed |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No — written by me in Japanese and translated with AI assistance. |

---

## Description of contribution in a few bullet points

* The acceleration/deceleration limits in `velocity_smoother` in `nav2_bringup/params/nav2_params.yaml` were changed to match the declared values in the MPPI controller in the same file.
  * `max_accel: [2.5, 0.0, 3.2]` → `[3.0, 0.0, 3.5]`
  * `max_decel: [-2.5, 0.0, -3.2]` → `[-3.0, 0.0, -3.5]`
* Both are the compiled default values for their respective packages (`ax_max: 3.0` / `az_max: 3.5` in `optimizer.cpp`, `max_accel: {2.5, 0.0, 3.2}` in `velocity_smoother.cpp`), and `nav2_params.yaml` inherited both as is.
* This mismatch was confirmed to be unintentional in #6357.

## Description of documentation updates required from your changes

* No new parameters have been added; only default values have been changed. We believe no documentation updates are necessary.
* However, we would like to ask the maintainer for their judgment on whether this should be reflected in the tuning guide.

## Description of how this change was tested

* Operation has not been verified on actual hardware or in simulations.
* Only two default parameter lines have been changed, with the linear values provided by the maintainer in #6357.

---

## Future work that may be required in bullet points

* Angular velocity (`max_accel[2]` / `max_decel[2]`) was also adjusted to MPPI's `az_max: 3.5`. #6357 only mentioned the linear 3.0, but it was judged to be for the same reason. If it is better to revert to linear only, we will do so.
* Lowering MPPI to 2.5 and raising smoother to 3.0 are not equivalent. If smoother represents the hardware limit, the latter would be an assertion that the robot can brake at 3.0 m/s². With `vx_max: 0.5`, the difference in stopping distance is about 8 mm, so there seems to be no practical difference, but it will have an effect on faster platforms.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
