### PR TITLE
Backport of fixes in #6355 to jazzy

### DIFF
--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -73,6 +73,7 @@ public:
    * @brief Generate a dock from action goal
    * @param goal Action goal
    * @return Raw dock pointer to manage;
+   * @throw DockNotValid if the goal's dock type resolves to no plugin
    */
   Dock * generateGoalDock(std::shared_ptr<const DockRobot::Goal> goal);
 

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -373,11 +373,17 @@ void DockingServer::stashDockData(bool use_dock_id, Dock * dock, bool successful
 
 Dock * DockingServer::generateGoalDock(std::shared_ptr<const DockRobot::Goal> goal)
 {
+  auto plugin = dock_db_->findDockPlugin(goal->dock_type);
+  if (!plugin) {
+    throw opennav_docking_core::DockNotValid(
+            "Dock type '" + goal->dock_type + "' has no valid plugin!");
+  }
+
   auto dock = new Dock();
   dock->frame = goal->dock_pose.header.frame_id;
   dock->pose = goal->dock_pose.pose;
   dock->type = goal->dock_type;
-  dock->plugin = dock_db_->findDockPlugin(dock->type);
+  dock->plugin = plugin;
   return dock;
 }
 

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -213,6 +213,47 @@ TEST(DockingServerTests, getateGoalDock)
   node.reset();
 }
 
+TEST(DockingServerTests, generateGoalDockNoPlugin)
+{
+  auto node = std::make_shared<opennav_docking::DockingServer>();
+
+  node->declare_parameter(
+    "docks",
+    rclcpp::ParameterValue(std::vector<std::string>{"test_dock"}));
+  node->declare_parameter(
+    "test_dock.type",
+    rclcpp::ParameterValue(std::string{"dock_plugin"}));
+  node->declare_parameter(
+    "test_dock.pose",
+    rclcpp::ParameterValue(std::vector<double>{0.0, 0.0, 0.0}));
+  node->declare_parameter(
+    "dock_plugins",
+    rclcpp::ParameterValue(std::vector<std::string>{"dock_plugin", "dock_plugin2"}));
+  node->declare_parameter(
+    "dock_plugin.plugin",
+    rclcpp::ParameterValue(std::string{"opennav_docking::TestFailureDock"}));
+  node->declare_parameter(
+    "dock_plugin2.plugin",
+    rclcpp::ParameterValue(std::string{"opennav_docking::TestFailureDock"}));
+
+  node->on_configure(rclcpp_lifecycle::State());
+
+  // Empty dock_type with >1 plugin registered: findDockPlugin returns nullptr
+  auto empty_type_goal = std::make_shared<const DockRobot::Goal>();
+  EXPECT_THROW(
+    node->generateGoalDock(empty_type_goal), opennav_docking_core::DockNotValid);
+
+  // Unknown dock_type: findDockPlugin returns nullptr
+  auto unknown_goal = std::make_shared<DockRobot::Goal>();
+  unknown_goal->dock_type = "not_a_registered_dock_type";
+  EXPECT_THROW(
+    node->generateGoalDock(unknown_goal), opennav_docking_core::DockNotValid);
+
+  node->on_cleanup(rclcpp_lifecycle::State());
+  node->on_shutdown(rclcpp_lifecycle::State());
+  node.reset();
+}
+
 TEST(DockingServerTests, testDynamicParams)
 {
   auto node = std::make_shared<opennav_docking::DockingServer>();


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6354 |
| Primary OS tested on | Ubuntu 24.04.4 LTS (Noble) |
| Robotic platform tested on | Gazebo and hardware industrial cleaning robot |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Backport of #6355 to jazzy
* `generateGoalDock()` now throws `DockNotValid` when `findDockPlugin()` returns null.
* Added tests that produces the case that throws DockNotValid.
* Dangling pointer case in the main branch is not present in jazzy

## Description of documentation updates required from your changes

* None. No new parameters, no new plugins, no behavior change to document.

## Description of how this change was tested

* Added a unit test in `test_docking_server_unit.cpp` calling `generateGoalDock()` with a dock type
  that doesn't have a registered plugin.

---

## Future work that may be required in bullet points

* None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
