### PR TITLE
opennav_following: remove unused robot pose lookup in approachObject()

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -382,17 +382,6 @@ bool FollowingServer::approachObject(
       return false;
     }
 
-    // If the object is behind the robot, we reverse the control
-    geometry_msgs::msg::PoseStamped robot_pose;
-    if (!nav2_util::getCurrentPose(
-        robot_pose, *tf2_buffer_, target_pose.header.frame_id, params_->base_frame,
-        params_->transform_tolerance,
-        iteration_start_time_))
-    {
-      RCLCPP_WARN(get_logger(), "Failed to get current robot pose");
-      return false;
-    }
-
     // Compute and publish controls
     auto command = std::make_unique<geometry_msgs::msg::TwistStamped>();
     command->header.stamp = now();


### PR DESCRIPTION
Follow-up to the discussion in #6359 — @nirwester spotted that `robot_pose` is fetched and never used in `approachObject()`.

The comment above it says "If the object is behind the robot, we reverse the control", but nothing reverses anything: `computeVelocityCommand()` is called with `backward` hardcoded to `false`, and `robot_pose` is never read after being filled in.

It doesn't work as an implicit TF validation either, which was the other possible justification. `target_pose` is transformed into `base_frame` immediately above, so this resolves to a `base_frame` → `base_frame` lookup — identity. It would yield a zero pose even if something did read it, and it succeeds regardless of the state of the rest of the TF tree.

This removes the block only. Whether the reversing behaviour the comment describes should actually be implemented (the `backward` argument does exist on `computeVelocityCommand()`) seemed like a separate question for the maintainers.
