### PR TITLE
Backport of #6359 and #6367 to jazzy

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -383,17 +383,6 @@ bool FollowingServer::approachObject(
       return false;
     }
 
-    // If the object is behind the robot, we reverse the control
-    geometry_msgs::msg::PoseStamped robot_pose;
-    if (!nav2_util::getCurrentPose(
-        robot_pose, *tf2_buffer_, target_pose.header.frame_id, params_->base_frame,
-        params_->transform_tolerance,
-        iteration_start_time_))
-    {
-      RCLCPP_WARN(get_logger(), "Failed to get current robot pose");
-      return false;
-    }
-
     // Compute and publish controls
     auto command = std::make_unique<geometry_msgs::msg::TwistStamped>();
     command->header.stamp = now();

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -412,10 +412,18 @@ bool FollowingServer::rotateToObject(
 {
   const double dt = 1.0 / params_->controller_frequency;
 
+  // object_pose is still default-constructed (empty frame_id) if no detection has
+  // ever arrived for this goal, fall back to the fixed frame and let the robot search.
+  const std::string reference_frame =
+    object_pose.header.frame_id.empty() ? params_->fixed_frame : object_pose.header.frame_id;
+
+  // Refresh start time before transforming.
+  iteration_start_time_ = this->now();
+
   // Compute initial robot heading
   geometry_msgs::msg::PoseStamped robot_pose;
   if (!nav2_util::getCurrentPose(
-      robot_pose, *tf2_buffer_, object_pose.header.frame_id, params_->base_frame,
+      robot_pose, *tf2_buffer_, reference_frame, params_->base_frame,
       params_->transform_tolerance,
       iteration_start_time_))
   {
@@ -454,7 +462,7 @@ bool FollowingServer::rotateToObject(
 
       // Get current robot pose
       if (!nav2_util::getCurrentPose(
-          robot_pose, *tf2_buffer_, object_pose.header.frame_id, params_->base_frame,
+          robot_pose, *tf2_buffer_, reference_frame, params_->base_frame,
           params_->transform_tolerance,
           iteration_start_time_))
       {


### PR DESCRIPTION
The automatic backport of #6359 (#6365) failed and was closed: at the time Mergify ran it, `opennav_following` didn't exist on `jazzy` yet — #6347 merged about a minute later. #6367 wasn't backported either. So `jazzy` currently has the package with both issues still present.

This carries over both commits:

- **#6359** — `rotateToObject()` aborting instead of searching, when no detection has ever arrived for the goal (empty `frame_id` on the TF lookup, plus a stale `iteration_start_time_` after the blocking detection wait).
- **#6367** — removes the unused `robot_pose` lookup in `approachObject()`.

Cherry-picked with `-x`; no conflicts.

## Testing

Built against Jazzy (`opennav_docking_core`, `opennav_docking`, `opennav_following`) — clean. `ament_uncrustify` and `ament_cpplint` clean.

The #6359 half was also verified in Gazebo on this exact Jazzy code before #6347 merged, using a workspace with the backport branch applied: without the fix the goal aborts ~120 ms after "Rotating to find object again" without commanding any rotation; with it the robot rotates and searches until `rotate_to_object_timeout`, failing with `903 / "Timed out rotating to object"`. Odometry showed 0° vs 37.1° of rotation. That's the same testing reported in #6347.
