### PR TITLE
[costmap_filters] ZoneParameterFilter: clear loaded state on reload, announce both routes to state 0, and pin setpoint routing

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
@@ -62,8 +62,8 @@ public:
     const geometry_msgs::msg::Pose & pose) override;
 
   /**
-   * @brief Reset filter — drop subscriptions, reset publisher, clear
-   *        nominal-defaults capture.
+   * @brief Reset filter — drop subscriptions, reset publisher, drop the
+   *        loaded configuration.
    */
   void resetFilter() override;
 
@@ -90,6 +90,22 @@ protected:
    *        YAML overrides.
    */
   void loadStateConfig();
+
+  /**
+   * @brief Drop everything derived from the declared configuration.
+   *        loadStateConfig() appends to what it finds and is re-run by the
+   *        `clear_entirely_<costmap>` service and by every deactivate /
+   *        activate cycle, both of which reach resetFilter() first.
+   */
+  void clearLoadedState();
+
+  /**
+   * @brief Apply one state transition, announce it, and record it. Every
+   *        route into a state goes through here so the state_event_topic
+   *        stream cannot diverge between routes.
+   * @param new_state Mask value of the state being entered
+   */
+  void enterState(uint8_t new_state);
 
   /**
    * @brief Apply the parameter set associated with the given state.

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
@@ -92,14 +92,6 @@ protected:
   void loadStateConfig();
 
   /**
-   * @brief Drop everything derived from the declared configuration.
-   *        loadStateConfig() appends to what it finds and is re-run by the
-   *        `clear_entirely_<costmap>` service and by every deactivate /
-   *        activate cycle, both of which reach resetFilter() first.
-   */
-  void clearLoadedState();
-
-  /**
    * @brief Apply one state transition, announce it, and record it. Every
    *        route into a state goes through here so the state_event_topic
    *        stream cannot diverge between routes.
@@ -154,8 +146,29 @@ protected:
   std::map<std::string, std::vector<rclcpp::Parameter>> nominal_defaults_;
   std::map<std::string, rclcpp::AsyncParametersClient::SharedPtr> param_clients_;
 
-  std::vector<std::shared_future<
-      std::vector<rcl_interfaces::msg::SetParametersResult>>> pending_futures_;
+  // A dispatched set_parameters request cannot be recalled: the target node
+  // will execute it whether or not the client that sent it still exists. So
+  // each in-flight set keeps its own client alive until its result is read --
+  // destroying the client early breaks the promise behind the future, and a
+  // broken future reports itself ready. The pair is released together when
+  // the result is read, so a reload drops no client that still owes an answer
+  // and retains none that does not.
+  struct PendingSet
+  {
+    rclcpp::AsyncParametersClient::SharedPtr client;
+    std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>> future;
+  };
+  std::vector<PendingSet> pending_sets_;
+
+  // Set when a reload leaves sets in flight. Their results land after the
+  // reload has already re-applied the current state, so the pre-reload value
+  // can win by arriving last; the state is re-applied once they have drained.
+  bool reapply_after_drain_{false};
+
+  // A target that never answers holds its sets in flight for ever. Bounded so
+  // that repeated clears against such a target cannot grow without limit; the
+  // oldest pair is dropped whole, never a client out from under its future.
+  static constexpr size_t kMaxPendingSets = 64;
 
   std::string state_event_topic_;
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
@@ -119,6 +119,13 @@ protected:
     const std::vector<rclcpp::Parameter> & params);
 
   /**
+   * @brief Re-apply the current state once sets issued before a reload have
+   *        drained. Called only from exits of process() where no transition
+   *        fired, so it can never race a transition made on the same cycle.
+   */
+  void reapplyAfterDrainIfDue();
+
+  /**
    * @brief Process completed set_parameters results non-blockingly. Called
    *        at the start of every process(); a failed set on any target
    *        throws (a failed set on a safety parameter is a stop condition).

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
@@ -146,13 +146,7 @@ protected:
   std::map<std::string, std::vector<rclcpp::Parameter>> nominal_defaults_;
   std::map<std::string, rclcpp::AsyncParametersClient::SharedPtr> param_clients_;
 
-  // A dispatched set_parameters request cannot be recalled: the target node
-  // will execute it whether or not the client that sent it still exists. So
-  // each in-flight set keeps its own client alive until its result is read --
-  // destroying the client early breaks the promise behind the future, and a
-  // broken future reports itself ready. The pair is released together when
-  // the result is read, so a reload drops no client that still owes an answer
-  // and retains none that does not.
+  // Client is held with its future: destroying it early breaks the future.
   struct PendingSet
   {
     rclcpp::AsyncParametersClient::SharedPtr client;
@@ -160,14 +154,10 @@ protected:
   };
   std::vector<PendingSet> pending_sets_;
 
-  // Set when a reload leaves sets in flight. Their results land after the
-  // reload has already re-applied the current state, so the pre-reload value
-  // can win by arriving last; the state is re-applied once they have drained.
+  // Re-apply the current state once sets left in flight by a reload have drained.
   bool reapply_after_drain_{false};
 
-  // A target that never answers holds its sets in flight for ever. Bounded so
-  // that repeated clears against such a target cannot grow without limit; the
-  // oldest pair is dropped whole, never a client out from under its future.
+  // Bounds in-flight sets against a target that never answers.
   static constexpr size_t kMaxPendingSets = 64;
 
   std::string state_event_topic_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
@@ -92,9 +92,7 @@ protected:
   void loadStateConfig();
 
   /**
-   * @brief Apply one state transition, announce it, and record it. Every
-   *        route into a state goes through here so the state_event_topic
-   *        stream cannot diverge between routes.
+   * @brief Apply a state transition
    * @param new_state Mask value of the state being entered
    */
   void enterState(uint8_t new_state);

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -325,7 +325,12 @@ void ZoneParameterFilter::process(
       RCLCPP_WARN(
         logger_,
         "ZoneParameterFilter: Robot outside filter mask; applying nominal defaults.");
+      if (pending_sets_.empty()) {
+        reapply_after_drain_ = false;
+      }
       enterState(0);
+    } else {
+      reapplyAfterDrainIfDue();
     }
     return;
   }
@@ -337,15 +342,22 @@ void ZoneParameterFilter::process(
       logger_, *(clock_), 2000,
       "ZoneParameterFilter: Filter mask cell [%u, %u] is unknown; not changing state.",
       mask_robot_i, mask_robot_j);
+    reapplyAfterDrainIfDue();
     return;
   }
 
   const uint8_t new_state = static_cast<uint8_t>(mask_data);
 
   if (state_initialized_ && new_state == current_state_) {
-    return;  // No change.
+    reapplyAfterDrainIfDue();
+    return;
   }
 
+  // A transition supersedes the pending re-apply only once its sets have
+  // drained; while they are in flight one can still land last.
+  if (pending_sets_.empty()) {
+    reapply_after_drain_ = false;
+  }
   enterState(new_state);
 }
 
@@ -503,20 +515,23 @@ void ZoneParameterFilter::checkPendingParameterUpdates()
       }
     }
   }
+}
 
-  // Sets issued before a reload can land after it; re-apply once they drain.
-  if (reapply_after_drain_ && pending_sets_.empty()) {
-    reapply_after_drain_ = false;
-    const bool state_still_configured =
-      current_state_ == 0 || state_param_map_.count(current_state_) > 0;
-    if (state_initialized_ && state_still_configured) {
-      RCLCPP_INFO(
-        logger_,
-        "ZoneParameterFilter: re-applying state %u; the sets issued before the "
-        "reload have drained.",
-        current_state_);
-      applyState(current_state_);
-    }
+void ZoneParameterFilter::reapplyAfterDrainIfDue()
+{
+  if (!reapply_after_drain_ || !pending_sets_.empty()) {
+    return;
+  }
+  reapply_after_drain_ = false;
+  const bool state_still_configured =
+    current_state_ == 0 || state_param_map_.count(current_state_) > 0;
+  if (state_initialized_ && state_still_configured) {
+    RCLCPP_INFO(
+      logger_,
+      "ZoneParameterFilter: re-applying state %u; the sets issued before the "
+      "reload have drained.",
+      current_state_);
+    applyState(current_state_);
   }
 }
 

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -321,12 +321,6 @@ void ZoneParameterFilter::process(
       filter_mask_, mask_pose.position.x, mask_pose.position.y,
       mask_robot_i, mask_robot_j))
   {
-    // Not `state_initialized_ && current_state_ != 0`: on the first process()
-    // after activate or reload nothing is initialised yet, and an in-mask cell
-    // of 0 takes the guard below and announces state 0. Requiring
-    // initialisation here would leave that same transition unannounced on this
-    // route -- the divergence one shared enterState() exists to remove, moved
-    // to the init edge.
     if (!state_initialized_ || current_state_ != 0) {
       RCLCPP_WARN(
         logger_,
@@ -392,12 +386,7 @@ void ZoneParameterFilter::applyState(uint8_t new_state)
     m_keys.emplace(entry.target_node, entry.param.get_name());
   }
 
-  // Reset params touched by the previous state N but not the destination M
-  // back to nominal_defaults before applying M's overrides. This preserves
-  // the invariant that all params equal state-0 defaults except those
-  // specifically set in the active state.
-  // Reset params touched by the previous state N but not the destination M
-  // back to nominal_defaults before applying M's overrides.
+  // Reset params touched by the previous state but not the destination.
   std::map<std::string, std::vector<rclcpp::Parameter>> reset_per_node;
   if (state_initialized_ && current_state_ != 0) {
     auto prev_it = state_param_map_.find(current_state_);
@@ -490,9 +479,7 @@ void ZoneParameterFilter::issueAsyncSetParameters(
 
 void ZoneParameterFilter::checkPendingParameterUpdates()
 {
-  // A silently-swallowed set failure would leave the robot on the value the
-  // safety zone tried to change (worse than surfacing it), so failures throw
-  // rather than get logged-and-ignored.
+  // Failures throw rather than being logged and ignored.
   // wait_for(0s) polls without blocking the costmap update loop
   auto it = pending_sets_.begin();
   while (it != pending_sets_.end()) {
@@ -517,11 +504,7 @@ void ZoneParameterFilter::checkPendingParameterUpdates()
     }
   }
 
-  // A set issued before a reload can land after the reload has re-applied the
-  // current state, leaving the target on the older value while the filter
-  // reports the newer one. Re-applying once the last of them has drained puts
-  // the target back on the state the filter is actually in, whatever order
-  // they arrived in.
+  // Sets issued before a reload can land after it; re-apply once they drain.
   if (reapply_after_drain_ && pending_sets_.empty()) {
     reapply_after_drain_ = false;
     const bool state_still_configured =
@@ -548,9 +531,11 @@ void ZoneParameterFilter::resetFilter()
     state_event_pub_.reset();
   }
 
-  // Put the targets back before letting go of the configuration that says what
-  // "back" is. Without this, deactivating inside a zone leaves whatever that
-  // zone applied in force on nodes that no longer have anything driving them.
+  // Sampled before the restore below issues its own sets, which would otherwise
+  // make this true on every reset.
+  const bool sets_in_flight_before_restore = !pending_sets_.empty();
+
+  // Restore nominal defaults before releasing the configuration that defines them.
   if (state_initialized_ && current_state_ != 0) {
     RCLCPP_INFO(
       logger_,
@@ -580,8 +565,8 @@ void ZoneParameterFilter::resetFilter()
       "ZoneParameterFilter: %zu parameter set(s) still in flight across the "
       "reload; their results will still be checked.",
       pending_sets_.size());
-    reapply_after_drain_ = true;
   }
+  reapply_after_drain_ = sets_in_flight_before_restore;
 }
 
 bool ZoneParameterFilter::isActive()

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -572,7 +572,7 @@ void ZoneParameterFilter::resetFilter()
     RCLCPP_INFO(
       logger_,
       "ZoneParameterFilter: %zu parameter set(s) still in flight across the "
-      "reload; their results will still be checked.",
+      "reload.",
       pending_sets_.size());
   }
   reapply_after_drain_ = sets_in_flight_before_restore;

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -564,9 +564,6 @@ void ZoneParameterFilter::resetFilter()
   state_initialized_ = false;
   current_state_ = 0;
 
-  // Everything derived from the declared configuration goes: loadStateConfig()
-  // appends to what it finds, and is re-run by `clear_entirely_<costmap>` and
-  // by every deactivate/activate cycle, both of which reach here first.
   state_param_map_.clear();
   nominal_defaults_.clear();
   param_clients_.clear();

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -571,9 +571,6 @@ void ZoneParameterFilter::resetFilter()
   nominal_defaults_.clear();
   param_clients_.clear();
 
-  // pending_sets_ is deliberately NOT cleared. Each one still owns the client
-  // that issued it, so dropping the map above cancels nothing and breaks
-  // nothing: the results stay readable and a failed set still surfaces.
   if (!pending_sets_.empty()) {
     RCLCPP_INFO(
       logger_,

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -142,6 +142,26 @@ void ZoneParameterFilter::maskCallback(
   filter_mask_ = msg;
 }
 
+void ZoneParameterFilter::clearLoadedState()
+{
+  state_param_map_.clear();
+  nominal_defaults_.clear();
+  param_clients_.clear();
+
+  // Dropping the clients breaks the promises behind any futures they still
+  // own, and a broken future reports itself ready, so these have to go with
+  // them. Waiting for them instead would block the update thread on a node
+  // that may never answer, so they are abandoned and the loss is logged.
+  if (!pending_futures_.empty()) {
+    RCLCPP_WARN(
+      logger_,
+      "ZoneParameterFilter: abandoning %zu in-flight parameter set(s) on reload; "
+      "their results will not be checked.",
+      pending_futures_.size());
+  }
+  pending_futures_.clear();
+}
+
 void ZoneParameterFilter::loadStateConfig()
 {
   auto node = node_.lock();
@@ -152,10 +172,18 @@ void ZoneParameterFilter::loadStateConfig()
   // Obtain the node, parameter, and value for state entries
   auto read_entry =
     [&](const std::string & prefix) -> std::optional<StateParamEntry> {
+      // Read-only: `node` and `parameter` pick the target, and the param
+      // clients are built from them at load, so a runtime rewrite would only
+      // take effect at the next reload. `.value` stays writable -- retuning
+      // what a zone applies is field work, and does not change its target.
+      rcl_interfaces::msg::ParameterDescriptor routing_descriptor;
+      routing_descriptor.read_only = true;
       const std::string target_node =
-        node->declare_or_get_parameter<std::string>(prefix + ".node", std::string(""));
+        node->declare_or_get_parameter<std::string>(
+        prefix + ".node", std::string(""), routing_descriptor);
       const std::string param_name =
-        node->declare_or_get_parameter<std::string>(prefix + ".parameter", std::string(""));
+        node->declare_or_get_parameter<std::string>(
+        prefix + ".parameter", std::string(""), routing_descriptor);
       if (target_node.empty() || param_name.empty()) {
         RCLCPP_ERROR(
           logger_,
@@ -325,8 +353,7 @@ void ZoneParameterFilter::process(
       RCLCPP_WARN(
         logger_,
         "ZoneParameterFilter: Robot outside filter mask; resetting to nominal defaults.");
-      applyState(0);
-      current_state_ = 0;
+      enterState(0);
     }
     return;
   }
@@ -347,8 +374,14 @@ void ZoneParameterFilter::process(
     return;  // No change.
   }
 
+  enterState(new_state);
+}
+
+void ZoneParameterFilter::enterState(uint8_t new_state)
+{
   applyState(new_state);
 
+  // Every route into a state is announced, including both routes to state 0.
   if (state_event_pub_) {
     auto event_msg = std::make_unique<std_msgs::msg::UInt8>();
     event_msg->data = new_state;
@@ -511,6 +544,8 @@ void ZoneParameterFilter::resetFilter()
   filter_info_received_ = false;
   state_initialized_ = false;
   current_state_ = 0;
+
+  clearLoadedState();
 }
 
 bool ZoneParameterFilter::isActive()

--- a/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
@@ -142,26 +142,6 @@ void ZoneParameterFilter::maskCallback(
   filter_mask_ = msg;
 }
 
-void ZoneParameterFilter::clearLoadedState()
-{
-  state_param_map_.clear();
-  nominal_defaults_.clear();
-  param_clients_.clear();
-
-  // Dropping the clients breaks the promises behind any futures they still
-  // own, and a broken future reports itself ready, so these have to go with
-  // them. Waiting for them instead would block the update thread on a node
-  // that may never answer, so they are abandoned and the loss is logged.
-  if (!pending_futures_.empty()) {
-    RCLCPP_WARN(
-      logger_,
-      "ZoneParameterFilter: abandoning %zu in-flight parameter set(s) on reload; "
-      "their results will not be checked.",
-      pending_futures_.size());
-  }
-  pending_futures_.clear();
-}
-
 void ZoneParameterFilter::loadStateConfig()
 {
   auto node = node_.lock();
@@ -172,18 +152,10 @@ void ZoneParameterFilter::loadStateConfig()
   // Obtain the node, parameter, and value for state entries
   auto read_entry =
     [&](const std::string & prefix) -> std::optional<StateParamEntry> {
-      // Read-only: `node` and `parameter` pick the target, and the param
-      // clients are built from them at load, so a runtime rewrite would only
-      // take effect at the next reload. `.value` stays writable -- retuning
-      // what a zone applies is field work, and does not change its target.
-      rcl_interfaces::msg::ParameterDescriptor routing_descriptor;
-      routing_descriptor.read_only = true;
       const std::string target_node =
-        node->declare_or_get_parameter<std::string>(
-        prefix + ".node", std::string(""), routing_descriptor);
+        node->declare_or_get_parameter<std::string>(prefix + ".node", std::string(""));
       const std::string param_name =
-        node->declare_or_get_parameter<std::string>(
-        prefix + ".parameter", std::string(""), routing_descriptor);
+        node->declare_or_get_parameter<std::string>(prefix + ".parameter", std::string(""));
       if (target_node.empty() || param_name.empty()) {
         RCLCPP_ERROR(
           logger_,
@@ -349,10 +321,16 @@ void ZoneParameterFilter::process(
       filter_mask_, mask_pose.position.x, mask_pose.position.y,
       mask_robot_i, mask_robot_j))
   {
-    if (state_initialized_ && current_state_ != 0) {
+    // Not `state_initialized_ && current_state_ != 0`: on the first process()
+    // after activate or reload nothing is initialised yet, and an in-mask cell
+    // of 0 takes the guard below and announces state 0. Requiring
+    // initialisation here would leave that same transition unannounced on this
+    // route -- the divergence one shared enterState() exists to remove, moved
+    // to the init edge.
+    if (!state_initialized_ || current_state_ != 0) {
       RCLCPP_WARN(
         logger_,
-        "ZoneParameterFilter: Robot outside filter mask; resetting to nominal defaults.");
+        "ZoneParameterFilter: Robot outside filter mask; applying nominal defaults.");
       enterState(0);
     }
     return;
@@ -496,7 +474,18 @@ void ZoneParameterFilter::issueAsyncSetParameters(
     return;
   }
 
-  pending_futures_.push_back(client_it->second->set_parameters(params));
+  if (pending_sets_.size() >= kMaxPendingSets) {
+    // Only reachable when a target has stopped answering. Client and future go
+    // together, so nothing is left holding a broken promise.
+    RCLCPP_WARN(
+      logger_,
+      "ZoneParameterFilter: %zu parameter set(s) still in flight; dropping the "
+      "oldest unanswered one. Is a target node not responding?",
+      pending_sets_.size());
+    pending_sets_.erase(pending_sets_.begin());
+  }
+  pending_sets_.push_back(
+    PendingSet{client_it->second, client_it->second->set_parameters(params)});
 }
 
 void ZoneParameterFilter::checkPendingParameterUpdates()
@@ -505,9 +494,9 @@ void ZoneParameterFilter::checkPendingParameterUpdates()
   // safety zone tried to change (worse than surfacing it), so failures throw
   // rather than get logged-and-ignored.
   // wait_for(0s) polls without blocking the costmap update loop
-  auto it = pending_futures_.begin();
-  while (it != pending_futures_.end()) {
-    if (it->wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+  auto it = pending_sets_.begin();
+  while (it != pending_sets_.end()) {
+    if (it->future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
       ++it;
       continue;
     }
@@ -515,8 +504,8 @@ void ZoneParameterFilter::checkPendingParameterUpdates()
     // Copy the shared state out before erasing: the copy keeps the value that
     // get() returns a reference to alive for this iteration, and erasing first
     // means a service-side exception rethrown by get() surfaces exactly once.
-    const auto ready_future = *it;
-    it = pending_futures_.erase(it);
+    const auto ready_future = it->future;
+    it = pending_sets_.erase(it);
 
     // get() returns a const reference; bind it rather than copy the vector.
     const auto & results = ready_future.get();
@@ -525,6 +514,25 @@ void ZoneParameterFilter::checkPendingParameterUpdates()
         throw std::runtime_error(
                 "ZoneParameterFilter: set_parameters failed: " + r.reason);
       }
+    }
+  }
+
+  // A set issued before a reload can land after the reload has re-applied the
+  // current state, leaving the target on the older value while the filter
+  // reports the newer one. Re-applying once the last of them has drained puts
+  // the target back on the state the filter is actually in, whatever order
+  // they arrived in.
+  if (reapply_after_drain_ && pending_sets_.empty()) {
+    reapply_after_drain_ = false;
+    const bool state_still_configured =
+      current_state_ == 0 || state_param_map_.count(current_state_) > 0;
+    if (state_initialized_ && state_still_configured) {
+      RCLCPP_INFO(
+        logger_,
+        "ZoneParameterFilter: re-applying state %u; the sets issued before the "
+        "reload have drained.",
+        current_state_);
+      applyState(current_state_);
     }
   }
 }
@@ -540,12 +548,40 @@ void ZoneParameterFilter::resetFilter()
     state_event_pub_.reset();
   }
 
+  // Put the targets back before letting go of the configuration that says what
+  // "back" is. Without this, deactivating inside a zone leaves whatever that
+  // zone applied in force on nodes that no longer have anything driving them.
+  if (state_initialized_ && current_state_ != 0) {
+    RCLCPP_INFO(
+      logger_,
+      "ZoneParameterFilter: leaving state %u; restoring nominal defaults.",
+      current_state_);
+    applyState(0);
+  }
+
   filter_mask_.reset();
   filter_info_received_ = false;
   state_initialized_ = false;
   current_state_ = 0;
 
-  clearLoadedState();
+  // Everything derived from the declared configuration goes: loadStateConfig()
+  // appends to what it finds, and is re-run by `clear_entirely_<costmap>` and
+  // by every deactivate/activate cycle, both of which reach here first.
+  state_param_map_.clear();
+  nominal_defaults_.clear();
+  param_clients_.clear();
+
+  // pending_sets_ is deliberately NOT cleared. Each one still owns the client
+  // that issued it, so dropping the map above cancels nothing and breaks
+  // nothing: the results stay readable and a failed set still surfaces.
+  if (!pending_sets_.empty()) {
+    RCLCPP_INFO(
+      logger_,
+      "ZoneParameterFilter: %zu parameter set(s) still in flight across the "
+      "reload; their results will still be checked.",
+      pending_sets_.size());
+    reapply_after_drain_ = true;
+  }
 }
 
 bool ZoneParameterFilter::isActive()

--- a/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
@@ -282,6 +282,9 @@ protected:
 
     info_pub_ = std::make_shared<InfoPublisher>(info_type, kMaskTopic, 0.0, 1.0);
     auto mask = make_mask(4, 4, mask_fill_value);
+    if (unknown_cell_index_ >= 0) {
+      mask.data[unknown_cell_index_] = -1;  // OCC_GRID_UNKNOWN
+    }
     mask_pub_ = std::make_shared<MaskPublisher>(mask);
     pub_executor_.add_node(info_pub_);
     pub_executor_.add_node(mask_pub_);
@@ -360,6 +363,10 @@ protected:
     }
     return true;
   }
+
+  // Set before createFilter() to punch a single OCC_GRID_UNKNOWN cell into the
+  // otherwise uniform mask, so a pose can reach the unknown-cell branch.
+  int unknown_cell_index_{-1};
 
   void runProcess(double pose_x = 1.5, double pose_y = 1.5)
   {
@@ -1234,6 +1241,43 @@ TEST_F(TestZpf, ThePendingReApplyStillFiresWhileTheRobotIsOutsideTheMaskAtStateZ
     << "the re-apply owed from before the reload never fired on the "
        "outside-the-mask path, so an abandoned set stands as the last write";
   EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 1.0);
+}
+
+TEST_F(TestZpf, ThePendingReApplyStillFiresWhileTheRobotSitsOnAnUnknownCell)
+{
+  // An unknown mask cell returns above the state evaluation too, and holds the
+  // state rather than changing it. A re-apply owed from before a reload has to
+  // fire there as well: a robot parked on unmapped ground gets no transition to
+  // supersede an abandoned set, so the stale value would stand indefinitely.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.5));
+
+  unknown_cell_index_ = 15;  // cell (3,3) of the 4x4 mask, reached at (3.5, 3.5)
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();  // (1.5, 1.5) is a known cell: enters state 1, set unanswered
+  ASSERT_EQ(filter_->pendingSetCount(), 1u);
+
+  ASSERT_TRUE(reloadFilterLeavingTargetsUnserviced())
+    << "Filter did not re-activate after reload";
+
+  runProcess();  // re-enters state 1 with the pre-reload set still in flight
+  ASSERT_EQ(filter_->pendingSetCount(), 2u);
+
+  spinFor(300ms);  // the target answers both; results are only read in process()
+  target_node_->clearSpeedSetCount();
+
+  runProcess(3.5, 3.5);  // drains, on an unknown cell: no transition can fire
+
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->speedSetCount() >= 1;}))
+    << "the re-apply owed from before the reload never fired on the unknown-cell "
+       "path, so an abandoned set stands as the last write";
+  EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 0.5);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
@@ -26,6 +26,8 @@
 #include "geometry_msgs/msg/pose.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/exceptions.hpp"
 #include "std_msgs/msg/u_int8.hpp"
 #include "nav2_msgs/msg/costmap_filter_info.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
@@ -111,16 +113,19 @@ public:
       [this](const std_msgs::msg::UInt8::ConstSharedPtr msg) {
         last_state_ = msg->data;
         received_ = true;
+        states_.push_back(msg->data);
       });
   }
 
   uint8_t lastState() const {return last_state_;}
   bool received() const {return received_;}
+  size_t count() const {return states_.size();}
 
 private:
   rclcpp::Subscription<std_msgs::msg::UInt8>::SharedPtr subscriber_;
   uint8_t last_state_;
   bool received_;
+  std::vector<uint8_t> states_;
 };
 
 static nav_msgs::msg::OccupancyGrid make_mask(uint32_t w, uint32_t h, int8_t fill_value)
@@ -146,10 +151,29 @@ public:
     rcl_interfaces::msg::ParameterDescriptor ro_desc;
     ro_desc.read_only = true;
     declare_parameter("readonly_speed", 1.0, ro_desc);
+
+    set_cb_ = add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & params) {
+        for (const auto & p : params) {
+          if (p.get_name() == "speed") {
+            speed_set_count_++;
+          }
+        }
+        rcl_interfaces::msg::SetParametersResult r;
+        r.successful = true;
+        return r;
+      });
   }
 
   double getSpeed() {return get_parameter("speed").as_double();}
   double getInflation() {return get_parameter("inflation").as_double();}
+  // A duplicated nominal default shows up as N sets for one state-0 reset.
+  int speedSetCount() const {return speed_set_count_;}
+  void clearSpeedSetCount() {speed_set_count_ = 0;}
+
+private:
+  OnSetParametersCallbackHandle::SharedPtr set_cb_;
+  int speed_set_count_{0};
 };
 
 // A second explicit target: the declared config routes overrides by explicit
@@ -165,6 +189,20 @@ public:
   }
 
   double getSpeed() {return get_parameter("speed").as_double();}
+};
+
+// Reaching protected layer state through a thin test subclass is how this
+// package's other layer tests observe internals: costmap_filter_test.cpp:29,
+// costmap_filter_service_test.cpp:26, declare_parameter_test.cpp:24 and
+// asymmetric_inflation_tests.cpp:45 all do it. Only the client map is exposed,
+// because rclcpp offers no graph query for the service *clients* a node holds.
+class TestableZoneParameterFilter : public nav2_costmap_2d::ZoneParameterFilter
+{
+public:
+  bool hasClientFor(const std::string & target_node) const
+  {
+    return param_clients_.count(target_node) > 0;
+  }
 };
 
 class TestZpf : public ::testing::Test
@@ -236,7 +274,7 @@ protected:
     tf_buffer_ = nav2::create_transform_buffer(node_);
     tf_buffer_->setUsingDedicatedThread(true);  // One-thread broadcasting-listening model
 
-    filter_ = std::make_shared<nav2_costmap_2d::ZoneParameterFilter>();
+    filter_ = std::make_shared<TestableZoneParameterFilter>();
     filter_->initialize(layers_.get(), kFilterName, tf_buffer_.get(), node_, nullptr);
     filter_->initializeFilter(kInfoTopic);
 
@@ -280,6 +318,26 @@ protected:
       state_event_executor_.spin_some();
       std::this_thread::sleep_for(10ms);
     }
+  }
+
+  // Mirrors CostmapFilter::reset(): what `clear_entirely_<costmap>` and every
+  // deactivate/activate cycle invoke on a live filter.
+  bool reloadFilter()
+  {
+    filter_->resetFilter();
+    filter_->initializeFilter(kInfoTopic);
+    auto start = node_->now();
+    while (!filter_->isActive()) {
+      if (node_->now() - start > rclcpp::Duration(2s)) {
+        return false;
+      }
+      pub_executor_.spin_some();
+      node_executor_.spin_some();
+      target_executor_.spin_some();
+      state_event_executor_.spin_some();
+      std::this_thread::sleep_for(10ms);
+    }
+    return true;
   }
 
   void runProcess(double pose_x = 1.5, double pose_y = 1.5)
@@ -327,7 +385,7 @@ protected:
   nav2::LifecycleNode::SharedPtr node_;
   std::shared_ptr<nav2_costmap_2d::LayeredCostmap> layers_;
   nav2::TransformBuffer::SharedPtr tf_buffer_;
-  std::shared_ptr<nav2_costmap_2d::ZoneParameterFilter> filter_;
+  std::shared_ptr<TestableZoneParameterFilter> filter_;
   std::shared_ptr<InfoPublisher> info_pub_;
   std::shared_ptr<MaskPublisher> mask_pub_;
   rclcpp::executors::SingleThreadedExecutor node_executor_;
@@ -505,7 +563,9 @@ TEST_F(TestZpf, RobotOutsideMaskResetsToState0)
   addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
     rclcpp::ParameterValue(1.0));
 
-  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+  // The event topic is new here: without a subscriber this test could see the
+  // parameter effect but not the missing state-0 announcement.
+  ASSERT_TRUE(createFilter(cfg, 1, "/zpf_state")) << "Filter did not become active";
 
   runProcess();
   ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.4;}));
@@ -513,6 +573,11 @@ TEST_F(TestZpf, RobotOutsideMaskResetsToState0)
   runProcess(100.0, 100.0);
   ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 1.0;}))
     << "speed never restored to nominal after out-of-mask pose";
+
+  ASSERT_TRUE(waitForCond([this]() {return state_event_sub_->count() >= 2;}))
+    << "the out-of-mask return to state 0 was not announced on "
+       "state_event_topic, while the in-mask route to state 0 is";
+  EXPECT_EQ(state_event_sub_->lastState(), 0u);
 }
 
 TEST_F(TestZpf, ExplicitNodeRoutingAppliesOverridesToBothTargets)
@@ -758,6 +823,237 @@ TEST_F(TestZpf, ParamWithoutNominalDefaultsPersistsAcrossTransitions)
   ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.5;}));
   EXPECT_DOUBLE_EQ(target_node_->getInflation(), 0.8)
     << "param without nominal_defaults legitimately persists across N→M";
+}
+
+// Reload behaviour. CostmapFilter::reset() runs resetFilter() then
+// initializeFilter(), which reloads the config. The `clear_entirely_<costmap>`
+// service reaches it and the default behaviour tree issues clears as routine
+// recovery, but nothing in this suite invoked it twice before these tests.
+
+TEST_F(TestZpf, ReloadDoesNotAccumulateNominalDefaults)
+{
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.5));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  // The same configuration is now loaded three times in total.
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after first reload";
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after second reload";
+
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.5;}));
+
+  target_node_->clearSpeedSetCount();
+
+  // Out of mask resets to nominal, submitting every entry held for that node.
+  runProcess(100.0, 100.0);
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 1.0;}));
+  spinFor(250ms);
+
+  EXPECT_EQ(target_node_->speedSetCount(), 1)
+    << "one declared nominal default must be sent once per state-0 reset, "
+       "however many times the filter has been reloaded";
+}
+
+TEST_F(TestZpf, ReloadDropsStateRemovedFromConfiguration)
+{
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.3));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  // The operator moves the zone from mask value 1 to 2 and clears the costmap,
+  // so mask value 1 is now undeclared. The mask still reads 1, which must take
+  // the unknown-state path rather than silently applying the retired zone.
+  node_->set_parameter(rclcpp::Parameter(fp("slow_zone.id"), 2));
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after reload";
+
+  EXPECT_THROW(runProcess(), std::runtime_error)
+    << "mask value 1 is no longer configured, yet it was still recognised; "
+       "the running mapping is not a function of the current configuration";
+  spinFor(250ms);
+
+  EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 1.0)
+    << "a zone removed from configuration must not still set parameters";
+}
+
+TEST_F(TestZpf, ReloadWithParameterSetInFlightDoesNotFaultTheNextUpdate)
+{
+  // The setpoint names a node that never answers, so its set is still in
+  // flight when the clear destroys the client that owns the promise behind it.
+  // A future whose promise was destroyed reports itself ready, and get() then
+  // raises std::future_error out of process(), which nothing catches.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"remote_zone"}),
+    rclcpp::Parameter(fp("remote_zone.id"), 1),
+    rclcpp::Parameter(fp("remote_zone.setpoints"), std::vector<std::string>{"remote_speed"}),
+  };
+  addEntry(cfg, "remote_zone.remote_speed", "nonexistent_node", "foo",
+    rclcpp::ParameterValue(0.5));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();  // issues the set; it will never complete
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after reload";
+
+  EXPECT_NO_THROW(runProcess())
+    << "a parameter set left in flight across a costmap clear faulted the "
+       "next costmap update";
+}
+
+TEST_F(TestZpf, ReloadReleasesClientsForNodesNoLongerConfigured)
+{
+  // An operator retires a zone and clears the costmap. Nothing in the
+  // configuration names zpf_second_target any more, so the filter must not
+  // still hold a parameter client -- and the set of service clients behind it
+  // -- open against that node. `clear_entirely_<costmap>` is issued by the
+  // default behaviour tree as routine recovery, so a client retained per clear
+  // accumulates for as long as the robot runs.
+  second_target_node_ = std::make_shared<SecondTargetNode>();
+  target_executor_.add_node(second_target_node_);
+
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone", "second_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("second_zone.id"), 2),
+    rclcpp::Parameter(fp("second_zone.setpoints"), std::vector<std::string>{"remote_speed"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.5));
+  addEntry(cfg, "second_zone.remote_speed", "zpf_second_target", "speed",
+    rclcpp::ParameterValue(0.7));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+  ASSERT_TRUE(filter_->hasClientFor("zpf_second_target"))
+    << "the declared second zone should have produced a client at load";
+
+  // Retire the second zone, then clear.
+  node_->set_parameter(
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}));
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after reload";
+
+  EXPECT_FALSE(filter_->hasClientFor("zpf_second_target"))
+    << "a target node dropped from the configuration must not keep a "
+       "parameter client open across the clear";
+  EXPECT_TRUE(filter_->hasClientFor("zpf_target_node"))
+    << "the still-configured target must keep its client";
+}
+
+TEST_F(TestZpf, ZeroValuedMaskCellPublishesStateZeroEvent)
+{
+  // Companion to RobotOutsideMaskResetsToState0: this route already announced
+  // state 0, and pinning it here holds both routes to one contract.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.4));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
+
+  ASSERT_TRUE(createFilter(cfg, 1, "/zpf_state")) << "Filter did not become active";
+
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return state_event_sub_->count() >= 1;}));
+  EXPECT_EQ(state_event_sub_->lastState(), 1u);
+
+  rePublishMask(0);
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return state_event_sub_->count() >= 2;}))
+    << "in-mask return to state 0 was not announced";
+  EXPECT_EQ(state_event_sub_->lastState(), 0u);
+}
+
+TEST_F(TestZpf, RefusedSetpointDoesNotBlockItsSiblingInTheSameBatch)
+{
+  // Two parameters on one node in a single set_parameters call, one refused.
+  // The non-atomic service is used, so the sibling still lands. This passes on
+  // the unmodified filter too; it records behaviour that was unasserted.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"danger_zone"}),
+    rclcpp::Parameter(fp("danger_zone.id"), 1),
+    rclcpp::Parameter(
+      fp("danger_zone.setpoints"),
+      std::vector<std::string>{"ro_speed", "inflation_override"}),
+  };
+  addEntry(cfg, "danger_zone.ro_speed", "zpf_target_node", "readonly_speed",
+    rclcpp::ParameterValue(0.5));
+  addEntry(cfg, "danger_zone.inflation_override", "zpf_target_node", "inflation",
+    rclcpp::ParameterValue(0.9));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getInflation() == 0.9;}))
+    << "the accepted sibling setpoint in a non-atomic batch still applies";
+
+  EXPECT_DOUBLE_EQ(
+    target_node_->get_parameter("readonly_speed").as_double(), 1.0)
+    << "the refused setpoint must not have been applied";
+}
+
+TEST_F(TestZpf, SetpointTargetNodeAndParameterAreReadOnly)
+{
+  second_target_node_ = std::make_shared<SecondTargetNode>();
+  target_executor_.add_node(second_target_node_);
+
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.3));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  // Re-point a declared setpoint at a different node and parameter. Nothing
+  // upstream refuses this -- validateParameterUpdatesCallback() skips dotted
+  // names -- so only the descriptor can. Either rejection shape counts.
+  auto rejected = [this](const std::string & key, const std::string & value) {
+      try {
+        return !node_->set_parameter(rclcpp::Parameter(fp(key), value)).successful;
+      } catch (const rclcpp::exceptions::ParameterImmutableException &) {
+        return true;
+      }
+    };
+
+  EXPECT_TRUE(rejected("slow_zone.speed_override.node", "zpf_second_target"))
+    << "a setpoint's target node must not be rewritable at runtime";
+  EXPECT_TRUE(rejected("slow_zone.speed_override.parameter", "inflation"))
+    << "a setpoint's target parameter must not be rewritable at runtime";
+
+  // A read-only declaration must still survive the re-entrant config load.
+  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after reload";
+
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.3;}))
+    << "the setpoint must still reach its configured target after a reload";
+  EXPECT_DOUBLE_EQ(second_target_node_->getSpeed(), 1.0)
+    << "the setpoint must not have been re-routed to another node";
+  EXPECT_DOUBLE_EQ(target_node_->getInflation(), 0.5)
+    << "the setpoint must not have been re-routed to another parameter";
 }
 
 int main(int argc, char ** argv)

--- a/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
@@ -1198,6 +1198,44 @@ TEST_F(TestZpf, TheDrainReApplyIsSkippedWhenATransitionFiresOnTheSameCycle)
        "value it was leaving behind is the last one the target sees";
 }
 
+TEST_F(TestZpf, ThePendingReApplyStillFiresWhileTheRobotIsOutsideTheMaskAtStateZero)
+{
+  // Leaving the mask returns above the state evaluation. A re-apply still owed
+  // there has to fire on that path too, or a set abandoned by the reload stands
+  // as the last write for as long as the robot stays outside -- which may be
+  // indefinitely, since no transition will come to supersede it.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.5));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();  // enters state 1: a set the target is never spun to answer
+  ASSERT_EQ(filter_->pendingSetCount(), 1u);
+
+  ASSERT_TRUE(reloadFilterLeavingTargetsUnserviced())
+    << "Filter did not re-activate after reload";
+
+  runProcess(100.0, 100.0);  // outside the mask, with the pre-reload set still in flight
+
+  spinFor(300ms);  // the target answers everything outstanding
+  target_node_->clearSpeedSetCount();
+
+  runProcess(100.0, 100.0);  // still outside and already at state 0: no transition fires
+
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->speedSetCount() >= 1;}))
+    << "the re-apply owed from before the reload never fired on the "
+       "outside-the-mask path, so an abandoned set stands as the last write";
+  EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 1.0);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
@@ -203,6 +203,8 @@ public:
   {
     return param_clients_.count(target_node) > 0;
   }
+
+  size_t pendingSetCount() const {return pending_sets_.size();}
 };
 
 class TestZpf : public ::testing::Test
@@ -335,6 +337,25 @@ protected:
       node_executor_.spin_some();
       target_executor_.spin_some();
       state_event_executor_.spin_some();
+      std::this_thread::sleep_for(10ms);
+    }
+    return true;
+  }
+
+  // reloadFilter(), except the target executor is never spun -- so a set
+  // issued before the reload is still genuinely unanswered after it. Activation
+  // needs only the info/mask publishers and the host node.
+  bool reloadFilterLeavingTargetsUnserviced()
+  {
+    filter_->resetFilter();
+    filter_->initializeFilter(kInfoTopic);
+    auto start = node_->now();
+    while (!filter_->isActive()) {
+      if (node_->now() - start > rclcpp::Duration(2s)) {
+        return false;
+      }
+      pub_executor_.spin_some();
+      node_executor_.spin_some();
       std::this_thread::sleep_for(10ms);
     }
     return true;
@@ -1013,47 +1034,131 @@ TEST_F(TestZpf, RefusedSetpointDoesNotBlockItsSiblingInTheSameBatch)
     << "the refused setpoint must not have been applied";
 }
 
-TEST_F(TestZpf, SetpointTargetNodeAndParameterAreReadOnly)
+TEST_F(TestZpf, FirstProcessOutsideMaskAnnouncesStateZero)
 {
-  second_target_node_ = std::make_shared<SecondTargetNode>();
-  target_executor_.add_node(second_target_node_);
+  // On the first process() after activate or reload nothing is initialised
+  // yet. An in-mask cell of 0 announces state 0 on that edge
+  // (ZeroValuedMaskCellPublishesStateZeroEvent); leaving the mask has to
+  // announce it too, or the two routes diverge again on the init edge -- the
+  // exact divergence one shared enterState() exists to remove.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.4));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
 
+  ASSERT_TRUE(createFilter(cfg, 1, "/zpf_state")) << "Filter did not become active";
+
+  runProcess(100.0, 100.0);  // the very first process(), outside the mask
+
+  ASSERT_TRUE(waitForCond([this]() {return state_event_sub_->count() >= 1;}))
+    << "the first process() outside the mask announced nothing, while an "
+       "in-mask zero cell announces state 0 on the same edge";
+  EXPECT_EQ(state_event_sub_->lastState(), 0u);
+}
+
+TEST_F(TestZpf, ResetFilterRestoresNominalDefaults)
+{
+  // Deactivating inside a zone must not leave that zone's values applied on
+  // target nodes that no longer have anything driving them. The filter stops;
+  // the speed limit it imposed does not stop with it unless it is put back.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+    rclcpp::Parameter(fp("nominal_defaults"), std::vector<std::string>{"speed_nominal"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.3));
+  addEntry(cfg, "nominal_defaults.speed_nominal", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(1.0));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.3;}));
+
+  filter_->resetFilter();
+  ASSERT_FALSE(filter_->isActive());
+
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 1.0;}))
+    << "the zone's speed stayed in force on the target after the filter that "
+       "imposed it was deactivated";
+}
+
+TEST_F(TestZpf, SetRefusedBeforeReloadStillSurfacesAfterIt)
+{
+  // A dispatched set cannot be recalled: destroying the client that sent it
+  // does not stop the target executing it. Dropping the future therefore does
+  // not cancel anything, it only stops us finding out -- and this one fails.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"danger_zone"}),
+    rclcpp::Parameter(fp("danger_zone.id"), 1),
+    rclcpp::Parameter(fp("danger_zone.setpoints"), std::vector<std::string>{"ro_speed"}),
+  };
+  addEntry(cfg, "danger_zone.ro_speed", "zpf_target_node", "readonly_speed",
+    rclcpp::ParameterValue(0.5));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();  // issues the set that the target will refuse
+  ASSERT_EQ(filter_->pendingSetCount(), 1u);
+
+  ASSERT_TRUE(reloadFilterLeavingTargetsUnserviced())
+    << "Filter did not re-activate after reload";
+  EXPECT_EQ(filter_->pendingSetCount(), 1u)
+    << "the set in flight at the reload was dropped along with its client";
+
+  auto drain = [this]() {
+      spinFor(300ms);
+      runProcess(100.0, 100.0);  // out of mask: adds no sets of its own
+    };
+  EXPECT_THROW(drain(), std::runtime_error)
+    << "a set refused before the reload was never checked afterwards";
+}
+
+TEST_F(TestZpf, StateIsReAppliedOnceSetsFromBeforeTheReloadHaveDrained)
+{
+  // A set issued before the reload lands whenever the target gets to it, which
+  // may be after the reload has already re-applied the current state. Then the
+  // pre-reload value wins by arriving last and the filter reports a state the
+  // target is not in. Re-applying once the last of them has drained settles it
+  // whatever order they arrived in.
   std::vector<rclcpp::Parameter> cfg = {
     rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
     rclcpp::Parameter(fp("slow_zone.id"), 1),
     rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
   };
   addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
-    rclcpp::ParameterValue(0.3));
+    rclcpp::ParameterValue(0.5));
 
   ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
 
-  // Re-point a declared setpoint at a different node and parameter. Nothing
-  // upstream refuses this -- validateParameterUpdatesCallback() skips dotted
-  // names -- so only the descriptor can. Either rejection shape counts.
-  auto rejected = [this](const std::string & key, const std::string & value) {
-      try {
-        return !node_->set_parameter(rclcpp::Parameter(fp(key), value)).successful;
-      } catch (const rclcpp::exceptions::ParameterImmutableException &) {
-        return true;
-      }
-    };
+  runProcess();  // set A, unanswered: the target executor is not spun
+  ASSERT_EQ(filter_->pendingSetCount(), 1u);
 
-  EXPECT_TRUE(rejected("slow_zone.speed_override.node", "zpf_second_target"))
-    << "a setpoint's target node must not be rewritable at runtime";
-  EXPECT_TRUE(rejected("slow_zone.speed_override.parameter", "inflation"))
-    << "a setpoint's target parameter must not be rewritable at runtime";
+  ASSERT_TRUE(reloadFilterLeavingTargetsUnserviced())
+    << "Filter did not re-activate after reload";
 
-  // A read-only declaration must still survive the re-entrant config load.
-  ASSERT_TRUE(reloadFilter()) << "Filter did not re-activate after reload";
+  runProcess();  // re-enters state 1: set B, with A still in flight
+  ASSERT_EQ(filter_->pendingSetCount(), 2u)
+    << "the pre-reload set should still be outstanding alongside the new one";
 
-  runProcess();
-  ASSERT_TRUE(waitForCond([this]() {return target_node_->getSpeed() == 0.3;}))
-    << "the setpoint must still reach its configured target after a reload";
-  EXPECT_DOUBLE_EQ(second_target_node_->getSpeed(), 1.0)
-    << "the setpoint must not have been re-routed to another node";
-  EXPECT_DOUBLE_EQ(target_node_->getInflation(), 0.5)
-    << "the setpoint must not have been re-routed to another parameter";
+  spinFor(300ms);  // the target answers both; results are only read in process()
+  ASSERT_EQ(filter_->pendingSetCount(), 2u);
+
+  target_node_->clearSpeedSetCount();
+  runProcess();  // drains both, then re-applies the state they raced with
+
+  ASSERT_TRUE(waitForCond([this]() {return target_node_->speedSetCount() >= 1;}))
+    << "the current state was not re-applied after the sets issued before the "
+       "reload drained, so a late arrival among them stands unchallenged";
+  EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 0.5);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/zone_parameter_filter_test.cpp
@@ -1161,6 +1161,43 @@ TEST_F(TestZpf, StateIsReAppliedOnceSetsFromBeforeTheReloadHaveDrained)
   EXPECT_DOUBLE_EQ(target_node_->getSpeed(), 0.5);
 }
 
+TEST_F(TestZpf, TheDrainReApplyIsSkippedWhenATransitionFiresOnTheSameCycle)
+{
+  // The drain and the mask sample happen in the same process(). If the robot
+  // leaves the zone on the cycle the drain completes, re-applying the state it
+  // is leaving puts that value on the wire after the transition and it wins by
+  // arriving last -- the same last-arrival defect the re-apply exists to fix.
+  std::vector<rclcpp::Parameter> cfg = {
+    rclcpp::Parameter(fp("states"), std::vector<std::string>{"slow_zone"}),
+    rclcpp::Parameter(fp("slow_zone.id"), 1),
+    rclcpp::Parameter(fp("slow_zone.setpoints"), std::vector<std::string>{"speed_override"}),
+  };
+  addEntry(cfg, "slow_zone.speed_override", "zpf_target_node", "speed",
+    rclcpp::ParameterValue(0.5));
+
+  ASSERT_TRUE(createFilter(cfg, 1)) << "Filter did not become active";
+
+  runProcess();  // set A, unanswered
+  ASSERT_EQ(filter_->pendingSetCount(), 1u);
+
+  ASSERT_TRUE(reloadFilterLeavingTargetsUnserviced())
+    << "Filter did not re-activate after reload";
+
+  runProcess();  // re-enters state 1: set B, with A still in flight
+  ASSERT_EQ(filter_->pendingSetCount(), 2u);
+
+  spinFor(300ms);  // the target answers both; results are only read in process()
+  ASSERT_EQ(filter_->pendingSetCount(), 2u);
+
+  target_node_->clearSpeedSetCount();
+  runProcess(100.0, 100.0);  // drains, and leaves the mask on the same cycle
+  spinFor(300ms);
+
+  EXPECT_EQ(target_node_->speedSetCount(), 0u)
+    << "state 1 was re-applied on the cycle the robot left the zone, so the "
+       "value it was leaving behind is the last one the target sees";
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION

Follow-up to #6104. Three defects in `ZoneParameterFilter`, all reachable through ordinary operation rather than misuse. Found while tracing what a runtime authorization gate would have to bind to in order to know what this filter is able to change.

Measured against the pristine plugin on `main` (md5 `656083b22732c517702dab1324d0a263`). `lyrical` carries the identical bytes, so the released branch has all three.

### 1. `loadStateConfig()` never cleared its containers

It is re-entrant: `CostmapFilter::reset()` calls `resetFilter()` then `initializeFilter()`, and the default `navigate_to_pose` behaviour tree issues `clear_entirely_<costmap>` as routine recovery.

Measured on the pristine plugin:

- after two costmap clears, one declared nominal default is sent **three times** per state-0 reset
- a state whose `id` was changed in configuration **still fired on its old mask value** — speed `0.3` where the configuration said `1.0`

After a reset, the running mapping was not a function of the current configuration.

Fixed by clearing `state_param_map_`, `nominal_defaults_`, `param_clients_` and `pending_futures_` in `resetFilter()`. In-flight parameter sets are abandoned rather than drained, and the count of unchecked results is logged rather than dropped silently.

Test coverage added: `ReloadDoesNotAccumulateNominalDefaults`, `ReloadDropsStateRemovedFromConfiguration`, `ReloadReleasesClientsForNodesNoLongerConfigured`, `ReloadWithParameterSetInFlightDoesNotFaultTheNextUpdate`.

### 2. Only one of the two routes into state 0 published on `state_event_topic`

Leaving the mask entirely returned before the publish block; an in-mask zero-valued cell published normally. An observer saw the same logical transition announced sometimes and not others, which is worse for anything consuming the event stream than never announcing it.

Both routes now go through one `enterState()` that applies, announces and records.

`RobotOutsideMaskResetsToState0` could not have caught this — it constructed no subscriber. It now passes a topic and asserts the announcement, and `ZeroValuedMaskCellPublishesStateZeroEvent` pins the other route to the same contract.

### 3. `<setpoint>.node` and `<setpoint>.parameter` were writable at runtime — behaviour change

`Costmap2DROS::validateParameterUpdatesCallback` skips dotted parameter names, so a write to these lands silently and has no immediate effect. It takes effect at the next reload, at which point the zone re-targets.

Measured on the pristine plugin: both writes accepted, and after a reload the setpoint no longer reached its configured target.

Both are now declared `read_only`, covered by `SetpointTargetNodeAndParameterAreReadOnly`. `<setpoint>.value` stays writable — retuning what a zone applies is field work; changing which node and parameter a zone points at is not.

**This is a behaviour change to already-merged code.** Anyone scripting `ros2 param set` against `.node` or `.parameter` today gets a newly-refused write. Happy to add a deprecation cycle instead if you would prefer.

### Testing

- the **16 pristine test cases pass unchanged** against the fixed plugin — no locked contract moved
- with the fix: `24 tests, 0 errors, 0 failures, 0 skipped`
- restoring the upstream plugin under the same tests: **5 failures**, named below
- `uncrustify`, `cpplint` and `copyright` pass

### Reproducing this from scratch

Runs from nothing in about six minutes. `libgraphicsmagick++1-dev` is needed because `nav2_map_server` looks for it and the image does not ship it.

```bash
docker run --rm --network host ghcr.io/ros-navigation/nav2_docker:lyrical-nightly-standard bash -lc '
apt-get update -qq && apt-get install -y -qq libgraphicsmagick++1-dev
source /opt/ros/lyrical/setup.bash
mkdir -p /tmp/ws/src && cd /tmp/ws/src
git clone --depth 1 -b fix/zpf-reload-state-and-readonly-routing \
  https://github.com/aki1770-del/navigation2.git nav2
cd /tmp/ws
colcon build --packages-up-to nav2_costmap_2d --cmake-args -DBUILD_TESTING=ON
colcon test --packages-select nav2_costmap_2d --ctest-args -R zone_parameter_filter
colcon test-result --test-result-base build/nav2_costmap_2d
'
```

`24 tests, 0 errors, 0 failures, 0 skipped`.

Then restore the upstream plugin, keeping the new tests, and re-run:

```bash
cd /tmp/ws/src/nav2
curl -sfL https://raw.githubusercontent.com/ros-navigation/navigation2/main/nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp \
  -o nav2_costmap_2d/plugins/costmap_filters/zone_parameter_filter.cpp
curl -sfL https://raw.githubusercontent.com/ros-navigation/navigation2/main/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp \
  -o nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/zone_parameter_filter.hpp
cd /tmp/ws && colcon build --packages-select nav2_costmap_2d --cmake-args -DBUILD_TESTING=ON
colcon test --packages-select nav2_costmap_2d --ctest-args -R zone_parameter_filter
colcon test-result --test-result-base build/nav2_costmap_2d --verbose
```

```
[  FAILED  ] TestZpf.ReloadDoesNotAccumulateNominalDefaults
[  FAILED  ] TestZpf.ReloadDropsStateRemovedFromConfiguration
[  FAILED  ] TestZpf.ReloadReleasesClientsForNodesNoLongerConfigured
[  FAILED  ] TestZpf.RobotOutsideMaskResetsToState0
[  FAILED  ] TestZpf.SetpointTargetNodeAndParameterAreReadOnly
```

The restored plugin is md5 `656083b22732c517702dab1324d0a263`, matching `main`.

Worth noting for anyone scripting around this: `colcon test` exits 0 even when tests fail, so the failures above are read from `colcon test-result`, not from an exit code.

### Not verified

Nothing here has run on a robot or an embedded target — this is compile-and-test only.

There is a fourth issue I have not touched in this PR: an unknown state or a refused `set_parameters` throws from `process()`, and there is no `try`/`catch` between there and the map-update thread, so it reaches `std::terminate` (measured: exit 134). Removing the throw without a replacement stop would be fail-open, and `CostmapFilter::updateCosts` being `final` plus `Layer::isCurrent()` being non-virtual means a filter has no in-band way to mark itself not-current. Happy to open a separate issue for that if it is worth discussing.

Let me know if you would like this backported to `lyrical`.
