### PR TITLE
Cancel all action goals on BT goal response timeout

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -410,7 +410,7 @@ protected:
   {
     RCLCPP_WARN(
       node_->get_logger(),
-      "Timed out while waiting for action server to acknowledge goal request for %s, canceling",
+      "Timed out while waiting for action server to acknowledge goal request for %s, canceling all goals for",
       action_name_.c_str());
     auto future_cancel = action_client_->async_cancel_all_goals();
     if (callback_group_executor_.spin_until_future_complete(
@@ -418,7 +418,7 @@ protected:
     {
       RCLCPP_WARN(
         node_->get_logger(),
-        "Timed out while waiting for action server to cancel goals for %s",
+        "Timed out while waiting for action server to cancel all goals for %s",
         action_name_.c_str());
     }
     future_goal_handle_.reset();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -294,13 +294,7 @@ public:
           if (elapsed < server_timeout_) {
             return BT::NodeStatus::RUNNING;
           }
-          // if server has taken more time than the specified timeout value return FAILURE
-          RCLCPP_WARN(
-            node_->get_logger(),
-            "Timed out while waiting for action server to acknowledge goal request for %s",
-            action_name_.c_str());
-          future_goal_handle_.reset();
-          on_timeout();
+          handle_goal_response_timeout();
           return BT::NodeStatus::FAILURE;
         }
       }
@@ -326,12 +320,7 @@ public:
             if (elapsed < server_timeout_) {
               return BT::NodeStatus::RUNNING;
             }
-            RCLCPP_WARN(
-              node_->get_logger(),
-              "Timed out while waiting for action server to acknowledge goal request for %s",
-              action_name_.c_str());
-            future_goal_handle_.reset();
-            on_timeout();
+            handle_goal_response_timeout();
             return BT::NodeStatus::FAILURE;
           }
         }
@@ -415,6 +404,28 @@ public:
 
 protected:
   /**
+   * @brief Handle a timeout while waiting for a goal response
+   */
+  void handle_goal_response_timeout()
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Timed out while waiting for action server to acknowledge goal request for %s, canceling",
+      action_name_.c_str());
+    auto future_cancel = action_client_->async_cancel_all_goals();
+    if (callback_group_executor_.spin_until_future_complete(
+        future_cancel, cancel_timeout_) != rclcpp::FutureReturnCode::SUCCESS)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Timed out while waiting for action server to cancel goals for %s",
+        action_name_.c_str());
+    }
+    future_goal_handle_.reset();
+    on_timeout();
+  }
+
+  /**
    * @brief Function to check if current goal should be cancelled
    * @return bool True if current goal should be cancelled, false otherwise
    */
@@ -489,7 +500,6 @@ protected:
 
     // server has already timed out, no need to sleep
     if (remaining <= std::chrono::milliseconds(0)) {
-      future_goal_handle_.reset();
       return false;
     }
 
@@ -548,7 +558,7 @@ protected:
   // new action goal is sent or canceled
   std::chrono::milliseconds server_timeout_;
 
-  // The timeout value when cancelling actions during halt
+  // The timeout value when cancelling actions
   std::chrono::milliseconds cancel_timeout_;
 
   // The timeout value for BT loop execution

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -410,7 +410,8 @@ protected:
   {
     RCLCPP_WARN(
       node_->get_logger(),
-      "Timed out while waiting for action server to acknowledge goal request for %s, canceling all goals for",
+      "Timed out waiting for action server to acknowledge goal request for %s, "
+      "canceling all goals",
       action_name_.c_str());
     auto future_cancel = action_client_->async_cancel_all_goals();
     if (callback_group_executor_.spin_until_future_complete(

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <set>
@@ -66,6 +67,16 @@ public:
     goal_response_ = goal_response;
   }
 
+  unsigned int getAcceptedGoalCount() const
+  {
+    return accepted_goal_count_.load();
+  }
+
+  unsigned int getCancelRequestCount() const
+  {
+    return cancel_request_count_.load();
+  }
+
 protected:
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID &,
@@ -81,12 +92,14 @@ protected:
   rclcpp_action::CancelResponse handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>>)
   {
+    cancel_request_count_++;
     return rclcpp_action::CancelResponse::ACCEPT;
   }
 
   void handle_accepted(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>> handle)
   {
+    accepted_goal_count_++;
     // this needs to return quickly to avoid blocking the executor, so spin up a new thread
     std::thread{std::bind(&FibonacciActionServer::execute, this, _1), handle}.detach();
   }
@@ -130,6 +143,8 @@ protected:
   std::chrono::milliseconds sleep_duration_;
   std::chrono::nanoseconds server_loop_rate_;
   rclcpp_action::GoalResponse goal_response_{rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE};
+  std::atomic_uint accepted_goal_count_{0};
+  std::atomic_uint cancel_request_count_{0};
 };
 
 class FibonacciAction : public nav2_behavior_tree::BtActionNode<test_msgs::action::Fibonacci>
@@ -144,6 +159,15 @@ public:
   void on_tick() override
   {
     getInput("order", goal_.order);
+  }
+
+  void on_wait_for_result(
+    std::shared_ptr<const test_msgs::action::Fibonacci::Feedback>) override
+  {
+    if (config().blackboard->get<bool>("goal_updated")) {
+      goal_updated_ = true;
+      config().blackboard->set("goal_updated", false);
+    }
   }
 
   BT::NodeStatus on_success() override
@@ -200,12 +224,14 @@ public:
     // Put items on the blackboard
     config_->blackboard->set("node", node_);
     config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
+    config_->blackboard->set<std::chrono::milliseconds>("cancel_timeout", 50ms);
     config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
     config_->blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout", 1000ms);
     config_->blackboard->set("initial_pose_received", false);
     config_->blackboard->set("on_cancelled_triggered", false);
     config_->blackboard->set("on_goal_rejected_triggered", false);
     config_->blackboard->set("on_send_goal_failure_triggered", false);
+    config_->blackboard->set("goal_updated", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -431,6 +457,108 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   // since the server timeout was smaller than the action server goal handling duration
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::SUCCESS);
+}
+
+TEST_F(BTActionNodeTestFixture, test_updated_goal_timeout_cancels_all_goals)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <Fibonacci order="1000000" />
+        </BehaviorTree>
+      </root>)";
+
+  config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  config_->blackboard->set<std::chrono::milliseconds>("cancel_timeout", 150ms);
+  config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
+  config_->blackboard->set("goal_updated", false);
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  action_server_->setHandleGoalSleepDuration(1ms);
+  action_server_->setServerLoopRate(10ms);
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::RUNNING);
+
+  const auto first_goal_deadline = std::chrono::steady_clock::now() + 100ms;
+  while (action_server_->getAcceptedGoalCount() < 1u &&
+    std::chrono::steady_clock::now() < first_goal_deadline)
+  {
+    std::this_thread::sleep_for(1ms);
+  }
+  ASSERT_EQ(action_server_->getAcceptedGoalCount(), 1u);
+
+  // Delay the replacement goal response past the BT action client's timeout.
+  action_server_->setHandleGoalSleepDuration(100ms);
+  config_->blackboard->set("goal_updated", true);
+
+  BT::NodeStatus result = BT::NodeStatus::RUNNING;
+  rclcpp::WallRate loop_rate(10ms);
+  while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
+    result = tree_->tickOnce();
+    loop_rate.sleep();
+  }
+
+  EXPECT_EQ(result, BT::NodeStatus::FAILURE);
+
+  const auto cancel_deadline = std::chrono::steady_clock::now() + 200ms;
+  while (action_server_->getCancelRequestCount() < 2u &&
+    std::chrono::steady_clock::now() < cancel_deadline)
+  {
+    std::this_thread::sleep_for(1ms);
+  }
+
+  EXPECT_EQ(action_server_->getAcceptedGoalCount(), 2u);
+  EXPECT_EQ(action_server_->getCancelRequestCount(), 2u);
+}
+
+TEST_F(BTActionNodeTestFixture, test_updated_goal_immediate_timeout_cancels_all_goals)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <Fibonacci order="1000000" />
+        </BehaviorTree>
+      </root>)";
+
+  config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  config_->blackboard->set<std::chrono::milliseconds>("cancel_timeout", 150ms);
+  // Make max_timeout_ larger than server_timeout_ so the updated goal times out in the
+  // immediate goal-response check.
+  config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 100ms);
+  config_->blackboard->set("goal_updated", false);
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  action_server_->setHandleGoalSleepDuration(1ms);
+  action_server_->setServerLoopRate(10ms);
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::RUNNING);
+
+  const auto first_goal_deadline = std::chrono::steady_clock::now() + 100ms;
+  while (action_server_->getAcceptedGoalCount() < 1u &&
+    std::chrono::steady_clock::now() < first_goal_deadline)
+  {
+    std::this_thread::sleep_for(1ms);
+  }
+  ASSERT_EQ(action_server_->getAcceptedGoalCount(), 1u);
+
+  action_server_->setHandleGoalSleepDuration(100ms);
+  config_->blackboard->set("goal_updated", true);
+
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
+
+  const auto cancel_deadline = std::chrono::steady_clock::now() + 200ms;
+  while (action_server_->getCancelRequestCount() < 2u &&
+    std::chrono::steady_clock::now() < cancel_deadline)
+  {
+    std::this_thread::sleep_for(1ms);
+  }
+
+  EXPECT_EQ(action_server_->getAcceptedGoalCount(), 2u);
+  EXPECT_EQ(action_server_->getCancelRequestCount(), 2u);
 }
 
 TEST_F(BTActionNodeTestFixture, test_goal_rejected)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6370 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Ubuntu) |
| Does this PR contain AI generated software? | Yes, used for integration tests and some cleanup |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Currently, if for any reason setting a goal times out (the first time or subsequent times with updates), the BT action doesn't try to cancel it.
The proposed change cancels all pending goals in this eventuality.

## Description of documentation updates required from your changes

Not sure if this should be documented anywhere else too.

## Description of how this change was tested

Only unit tests, I'll ask the issuer to test too.

## Known limitations

The proposed solution has these limitations:
- It would cancel goals from other clients too, if any, which might be undesired
- It would cancel pending goals only if the cancel request arrives before the goal request
- Cancelation is synchronous and blocks the BT up to cancelation_time -> Assuming the server is unresponsive, should we send it without waiting again for a response?

However, in a normal system with properly configured timeouts, acks should not fail; this cancelation is just handling an already faulty system.

Unfortunately, specific goals can't be canceled until they get ackd.
A different approach could cancel the already acked active goal and the already sent goal once it gets acked; but it wouldn't cancel it should it never get acked (ex because the BT exits).

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
