### PR TITLE
Looking up transform only once when transforming paths

### DIFF
--- a/nav2_util/src/path_utils.cpp
+++ b/nav2_util/src/path_utils.cpp
@@ -20,6 +20,7 @@
 
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_ros_common/tf2_factories.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 namespace nav2_util
 {
 
@@ -100,22 +101,31 @@ bool transformPathInTargetFrame(
   transformed_path.header.stamp = input_path.header.stamp;
   transformed_path.poses.reserve(input_path.poses.size());
 
+  if (input_path.poses.empty()) {
+    return true;
+  }
+
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    transform = tf_buffer.lookupTransform(
+      target_frame, input_path.header.frame_id,
+      tf2_ros::fromMsg(input_path.header.stamp),
+      tf2::durationFromSec(transform_timeout));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "Failed to transform path from '%s' to '%s': %s",
+      input_path.header.frame_id.c_str(), target_frame.c_str(), ex.what());
+    return false;
+  }
+
   for (const auto & input_pose : input_path.poses) {
     geometry_msgs::msg::PoseStamped source_pose, transformed_pose;
     source_pose.header.frame_id = input_path.header.frame_id;
     source_pose.header.stamp = input_path.header.stamp;
     source_pose.pose = input_pose.pose;
 
-    if (!nav2_util::transformPoseInTargetFrame(
-          source_pose, transformed_pose, tf_buffer, target_frame, transform_timeout))
-    {
-      RCLCPP_ERROR(
-        logger,
-        "Failed to transform path from '%s' to '%s'.",
-        input_path.header.frame_id.c_str(), target_frame.c_str());
-      return false;
-    }
-
+    tf2::doTransform(source_pose, transformed_pose, transform);
     transformed_pose.pose.position.z = 0.0;
     transformed_path.poses.push_back(std::move(transformed_pose));
   }


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [(add tickets here #1)](https://github.com/ros-navigation/navigation2/issues/6316) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Only local tests |
| Does this PR contain AI generated software? | No|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Looks up the transform between origin and target frame only once instead of doing it for each pose in the path.

## Description of documentation updates required from your changes

## Description of how this change was tested
I Only ran the local tests.

---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
