### PR TITLE
Revert "MPPI: holonomic velocity limits constrained by ellipse instead of rectangle"

### DIFF
--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -86,12 +86,6 @@ Three built-in motion models are provided:
  | plugin               | string | Required: `"mppi::AckermannMotionModel"`                                                                    |
  | min_turning_r        | double | Default 0.2. Minimum turning radius in metres                                                               |
 
-#### Omni Motion Model
- | Parameter                        | Type   | Definition                                                                                                  |
- | -------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
- | plugin                           | string | Required: `"mppi::OmniMotionModel"`                                                                         |
- | use_elliptical_velocity_limits   | bool   | Default true. Bound `(vx, vy)` by the ellipse spanned by the per-axis limits rather than by each limit independently.  |
-
 #### Constraint Critic
  | Parameter             | Type   | Definition                                                                                                  |
  | ---------------       | ------ | ----------------------------------------------------------------------------------------------------------- |
@@ -229,11 +223,6 @@ controller_server:
       # ackermann:
       #   plugin: "mppi::AckermannMotionModel"
       #   min_turning_r: 0.2
-      # To use holonomic steering instead:
-      # motion_model: "omni"
-      # omni:
-      #   plugin: "mppi::OmniMotionModel"
-      #   use_elliptical_velocity_limits: true
       critics: ["ConstraintCritic", "CostCritic", "GoalCritic", "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic", "PathAngleCritic", "PreferForwardCritic"]
       ConstraintCritic:
         enabled: true

--- a/nav2_mppi_controller/benchmark/optimizer_benchmark.cpp
+++ b/nav2_mppi_controller/benchmark/optimizer_benchmark.cpp
@@ -178,15 +178,6 @@ static void BM_ObstaclesCriticPointFootprint(benchmark::State & state)
   prepareAndRunBenchmark(consider_footprint, motion_model, critics, state);
 }
 
-static void BM_ConstraintCritic(benchmark::State & state)
-{
-  bool consider_footprint = true;
-  std::string motion_model = "Omni";
-  std::vector<std::string> critics = {{"ConstraintCritic"}};
-
-  prepareAndRunBenchmark(consider_footprint, motion_model, critics, state);
-}
-
 static void BM_TwilringCritic(benchmark::State & state)
 {
   bool consider_footprint = true;
@@ -225,7 +216,6 @@ BENCHMARK(BM_PathAngleCritic)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_PathFollowCritic)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_ObstaclesCritic)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_ObstaclesCriticPointFootprint)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_ConstraintCritic)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_TwilringCritic)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/motion_models.hpp
@@ -18,7 +18,6 @@
 
 #include <Eigen/Dense>
 
-#include <cmath>
 #include <cstdint>
 #include <string>
 #include <algorithm>
@@ -342,19 +341,6 @@ public:
   OmniMotionModel() = default;
 
   /**
-   * @brief Initialize motion model.
-   * @param param_handler Pointer to the shared parameters handler
-   * @param plugin_name   Namespaced name of this plugin instance
-   */
-  void initialize(
-    ParametersHandler * param_handler,
-    const std::string & plugin_name) override
-  {
-    auto getParam = param_handler->getParamGetter(plugin_name);
-    getParam(use_elliptical_velocity_limits_, "use_elliptical_velocity_limits", true);
-  }
-
-  /**
    * @brief Whether the motion model is holonomic, using Y axis
    * @return Bool If holonomic
    */
@@ -362,79 +348,6 @@ public:
   {
     return true;
   }
-
-  /**
-   * @brief Whether (vx, vy) is bounded by the ellipse spanned by the per-axis limits rather
-   *        than by each limit independently
-   * @return Bool If the elliptical velocity envelope is enforced
-   */
-  bool useEllipticalVelocityLimits() const {return use_elliptical_velocity_limits_;}
-
-  /**
-   * @brief Returns a scale factor, projecting any infeasible velocity back onto the
-   *        elliptical velocity space
-   *
-   * The envelope is the ellipse inscribed by the per-axis limits,
-   *     (vx / vx_max)² + (vy / vy_max)² <= 1     driving forward, vx >= 0
-   *     (vx / vx_min)² + (vy / vy_max)² <= 1     driving in reverse, vx < 0
-   *
-   * @param vx Longitudinal velocities
-   * @param vy Lateral velocities
-   * @return Scale factors in (0, 1]
-   */
-  template<typename Derived>
-  typename Derived::PlainObject getVelocityScalingFactor(
-    const Eigen::ArrayBase<Derived> & vx, const Eigen::ArrayBase<Derived> & vy) const
-  {
-    // Protect the inverse of v_max² against division by zero.
-    const float vx_min_abs = std::fabs(control_constraints_.vx_min);
-    const float inv_vx_max_sq = control_constraints_.vx_max > 1e-6f ?
-      1.0f / (control_constraints_.vx_max * control_constraints_.vx_max) : 1e12f;
-    const float inv_vx_min_sq = vx_min_abs > 1e-6f ?
-      1.0f / (vx_min_abs * vx_min_abs) : 1e12f;
-    const float inv_vy_max_sq = control_constraints_.vy > 1e-6f ?
-      1.0f / (control_constraints_.vy * control_constraints_.vy) : 1e12f;
-
-
-    const float inv_vx_sq_range = inv_vx_max_sq - inv_vx_min_sq;
-
-    // 1/sqrt[(vx/vx_max)² + (vy/vy_max)²] for vx >= 0
-    // 1/sqrt[(vx/vx_min)² + (vy/vy_max)²] for vx < 0
-    // clamped at 1 so that feasible velocities are left alone
-    return (
-      (inv_vx_min_sq + inv_vx_sq_range * (vx >= 0.0f).template cast<float>()) * vx.square() +
-      inv_vy_max_sq * vy.square()
-    ).max(1.0f).sqrt().inverse();
-  }
-
-  /**
-   * @brief Apply hard vehicle constraints to a control sequence
-   * @param control_sequence Control sequence to apply constraints to
-   */
-  void applyConstraints(models::ControlSequence & control_sequence) override
-  {
-    if (!use_elliptical_velocity_limits_) {
-      return;
-    }
-
-    // An axis whose limit is zero cannot be commanded at all, so zero it before scaling
-    if (control_constraints_.vy <= 1e-6f) {
-      control_sequence.vy.setZero();
-    }
-    if (std::fabs(control_constraints_.vx_min) <= 1e-6f) {
-      control_sequence.vx = control_sequence.vx.max(0.0f);
-    }
-
-    // Constrain (vx, vy) onto the velocity ellipse
-    const Eigen::ArrayXf scaling_factor =
-      getVelocityScalingFactor(control_sequence.vx, control_sequence.vy);
-
-    control_sequence.vx *= scaling_factor;
-    control_sequence.vy *= scaling_factor;
-  }
-
-private:
-  bool use_elliptical_velocity_limits_{true};
 };
 
 }  // namespace mppi

--- a/nav2_mppi_controller/src/critics/constraint_critic.cpp
+++ b/nav2_mppi_controller/src/critics/constraint_critic.cpp
@@ -54,26 +54,13 @@ void ConstraintCritic::score(CriticData & data)
   }
 
   // Omnidirectional motion model
+  // Axis wise violation check
   auto omni = dynamic_cast<OmniMotionModel *>(data.motion_model.get());
   if (omni != nullptr) {
     auto & vx = data.state.vx;
     auto & vy = data.state.vy;
 
-    if (omni->useEllipticalVelocityLimits()) {
-      const Eigen::ArrayXXf scaling_factor = omni->getVelocityScalingFactor(vx, vy);
-      const auto violation = (vx.square() + vy.square()).sqrt() * (1.0f - scaling_factor);
-
-      if (power_ > 1u) {
-        data.costs += (((violation * data.model_dt).rowwise().sum().eval()) *
-          weight_).pow(power_).eval();
-      } else {
-        data.costs += (((violation * data.model_dt).rowwise().sum().eval()) * weight_).eval();
-      }
-      return;
-    }
-
-    // Axis wise violation check
-    if (power_ > 1u) {
+    if(power_ > 1u) {
       data.costs += (((((vx - vx_max_).max(0.0f) + (vx_min_ - vx).max(0.0f) +
         (vy.abs() - vy_max_).max(0.0f)) * data.model_dt).rowwise().sum().eval()) *
         weight_).pow(power_).eval();

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -421,10 +421,6 @@ void Optimizer::applyControlSequenceConstraints()
   float wz_last = static_cast<float>(state_.speed.angular.z);
   float vy_last = isHolonomic() ? static_cast<float>(state_.speed.linear.y) : 0.0f;
 
-  // Direction-preserving accel limiting only applies when the elliptical envelope is in use
-  auto * omni = dynamic_cast<OmniMotionModel *>(motion_model_.get());
-  const bool use_elliptical_limits = omni && omni->useEllipticalVelocityLimits();
-
   // When shifting, vx(0) is "now" and not sent. Pin it so vx(1), the sent command,
   // is exactly one constraint step from current speed when shift_control_sequence
   if (s.shift_control_sequence) {
@@ -445,54 +441,22 @@ void Optimizer::applyControlSequenceConstraints()
       max_delta_wz = s.model_dt * s.constraints.az_max;
     }
 
-    // Apply translational constraints to control sequence
     float & vx_curr = control_sequence_.vx(i);
     vx_curr = utils::clamp(s.constraints.vx_min, s.constraints.vx_max, vx_curr);
-
-    if (isHolonomic()) {
-      float & vy_curr = control_sequence_.vy(i);
-      vy_curr = utils::clamp(-s.constraints.vy, s.constraints.vy, vy_curr);
-
-      if (use_elliptical_limits) {
-        const float dvx = vx_curr - vx_last;
-        const float dvy = vy_curr - vy_last;
-
-        // Apply per-axis accel limits while preserving direction of requested
-        // translational velocity, matching the elliptical velocity envelope
-        float alpha = 1.0f;
-        if (dvx > max_delta_vx) {
-          alpha = std::min(alpha, max_delta_vx / dvx);
-        } else if (dvx < min_delta_vx) {
-          alpha = std::min(alpha, min_delta_vx / dvx);
-        }
-
-        if (dvy > max_delta_vy) {
-          alpha = std::min(alpha, max_delta_vy / dvy);
-        } else if (dvy < min_delta_vy) {
-          alpha = std::min(alpha, min_delta_vy / dvy);
-        }
-
-        vx_curr = vx_last + alpha * dvx;
-        vy_curr = vy_last + alpha * dvy;
-      } else {
-        // Per-axis velocity limits requested, so bound each axis independently too
-        vx_curr = utils::clampVelocityByAccel(vx_last, vx_curr, min_delta_vx, max_delta_vx);
-        vy_curr = utils::clampVelocityByAccel(vy_last, vy_curr, min_delta_vy, max_delta_vy);
-      }
-
-      vy_last = vy_curr;
-    } else {
-      // Non-holonomic case -> either Ackermann or Diff Drive
-      vx_curr = utils::clampVelocityByAccel(vx_last, vx_curr, min_delta_vx, max_delta_vx);
-    }
-
+    vx_curr = utils::clampVelocityByAccel(vx_last, vx_curr, min_delta_vx, max_delta_vx);
     vx_last = vx_curr;
 
-    // Apply rotational constraints to control sequence
     float & wz_curr = control_sequence_.wz(i);
     wz_curr = utils::clamp(-s.constraints.wz, s.constraints.wz, wz_curr);
     wz_curr = utils::clampVelocityByAccel(wz_last, wz_curr, -max_delta_wz, max_delta_wz);
     wz_last = wz_curr;
+
+    if (isHolonomic()) {
+      float & vy_curr = control_sequence_.vy(i);
+      vy_curr = utils::clamp(-s.constraints.vy, s.constraints.vy, vy_curr);
+      vy_curr = utils::clampVelocityByAccel(vy_last, vy_curr, min_delta_vy, max_delta_vy);
+      vy_last = vy_curr;
+    }
   }
 
   // Apply again to ensure accel constraints don't violate specialty limits

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -156,13 +156,7 @@ TEST(CriticTests, ConstraintsCritic)
   critic = ConstraintCritic();
   critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
 
-  // The omni branch takes its limits from the motion model, not from the critic's own copies,
-  // so that an active speed limit is respected. Give the model the same limits the critic reads.
-  models::ControlConstraints omni_constraints
-  {0.5f, -0.35f, 0.3f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  auto omni_model = std::make_shared<OmniMotionModel>();
-  omni_model->setConstraints(omni_constraints, model_dt, 0.0f, 0.0f, 0.0f, false);
-  data.motion_model = omni_model;
+  data.motion_model = std::make_shared<OmniMotionModel>();
 
   // reset state
   state.vx.setConstant(0.0f);
@@ -192,127 +186,20 @@ TEST(CriticTests, ConstraintsCritic)
   state.vy.row(999).setConstant(-0.5f);
   critic.score(data);
   EXPECT_GT(costs.sum(), 0);
-  // 4.0 weight * 0.1 model_dt * 0.401 error introduced * 30 timesteps = 4.81
-  EXPECT_NEAR(costs(999), 4.81, 0.01);
-  costs.setZero();
-
-  // A velocity within both per-axis limits but outside the ellipse is still penalized
-  state.vx.setConstant(0.0f);
-  state.vy.setConstant(0.0f);
-  state.vx.row(999).setConstant(0.5f);
-  state.vy.row(999).setConstant(0.3f);
-  critic.score(data);
-  // 4.0 weight * 0.1 model_dt * (0.583 * (1 - 1/sqrt(2))) * 30 timesteps = 2.05
-  EXPECT_NEAR(costs(999), 2.05, 0.01);
-  costs.setZero();
-
-  // ... and scaling that corner back onto the ellipse makes it free
-  state.vx.row(999).setConstant(0.5f / std::sqrt(2.0f));
-  state.vy.row(999).setConstant(0.3f / std::sqrt(2.0f));
-  critic.score(data);
-  EXPECT_NEAR(costs.sum(), 0, 1e-4);
+  // vx-violation 4.0 weight * 0.1 model_dt * 0.1 error introduced * 30 timesteps = 1.2
+  // vy-violation 4.0 weight * 0.1 model_dt * 0.2 error introduced * 30 timesteps = 2.4
+  // total-violation = 1.2 + 2.4
+  EXPECT_NEAR(costs(999), 3.6, 0.01);
   costs.setZero();
 
   // Test with different cost power
-  state.vx.row(999).setConstant(0.6f);
-  state.vy.row(999).setConstant(-0.5f);
   node->set_parameter(rclcpp::Parameter("critic.cost_power", 2));
   critic = ConstraintCritic();
   critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
   critic.score(data);
   EXPECT_GT(costs.sum(), 0);
-  // 4.81^2 = 23.12
-  EXPECT_NEAR(costs(999), 23.12, 0.02);
-  costs.setZero();
-
-  // A limit of zero means the axis cannot be commanded, so a non-zero velocity on it stays a
-  // violation rather than dropping out of the ellipse and becoming free
-  node->set_parameter(rclcpp::Parameter("critic.cost_power", 1));
-  critic = ConstraintCritic();
-  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
-
-  omni_constraints.vy = 0.0f;
-  omni_model->setConstraints(omni_constraints, model_dt, 0.0f, 0.0f, 0.0f, false);
-  state.vx.setConstant(0.0f);
-  state.vy.setConstant(0.0f);
-  state.vy.row(999).setConstant(0.2f);
-  critic.score(data);
-  EXPECT_GT(costs(999), 0.0f);
-  costs.setZero();
-
-  // ... while a feasible longitudinal command under the same limits is not penalized
-  state.vy.setConstant(0.0f);
-  state.vx.row(999).setConstant(0.4f);
-  critic.score(data);
-  EXPECT_NEAR(costs.sum(), 0, 1e-4);
-  costs.setZero();
-
-  // Same for vx_min = 0.0, which disallows reversing
-  omni_constraints.vy = 0.3f;
-  omni_constraints.vx_min = 0.0f;
-  omni_model->setConstraints(omni_constraints, model_dt, 0.0f, 0.0f, 0.0f, false);
-  state.vx.setConstant(0.0f);
-  state.vx.row(999).setConstant(-0.2f);
-  critic.score(data);
-  EXPECT_GT(costs(999), 0.0f);
-  costs.setZero();
-}
-
-TEST(CriticTests, ConstraintsCriticPerAxisFallback)
-{
-  // With use_elliptical_velocity_limits false, the omni branch scores each axis independently,
-  // exactly as it did before the elliptical envelope was introduced.
-  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
-  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
-    "dummy_costmap", "", true);
-  std::string name = "test";
-  ParametersHandler param_handler(node, name);
-  rclcpp_lifecycle::State lstate;
-  costmap_ros->on_configure(lstate);
-
-  models::State state;
-  state.vx = Eigen::ArrayXXf::Zero(1000, 30);
-  state.vy = Eigen::ArrayXXf::Zero(1000, 30);
-  state.wz = Eigen::ArrayXXf::Zero(1000, 30);
-  models::ControlSequence control_sequence;
-  models::Trajectories generated_trajectories;
-  models::Path path;
-  geometry_msgs::msg::Pose goal;
-  Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
-  float model_dt = 0.1;
-  CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
-    false, nullptr, nullptr, std::nullopt, std::nullopt, {}};
-
-  models::ControlConstraints constraints
-  {0.5f, -0.35f, 0.3f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  auto omni_model = std::make_shared<OmniMotionModel>();
-  node->declare_parameter(
-    std::string(node->get_name()) + ".omni.use_elliptical_velocity_limits", false);
-  omni_model->initialize(&param_handler, std::string(node->get_name()) + ".omni");
-  omni_model->setConstraints(constraints, model_dt, 0.0f, 0.0f, 0.0f, false);
-  ASSERT_FALSE(omni_model->useEllipticalVelocityLimits());
-  data.motion_model = omni_model;
-
-  node->declare_parameter("mppi.vy_max", 0.3);
-  ConstraintCritic critic;
-  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
-
-  // The rectangle's corner is free under the per-axis check, which is the behavior being
-  // preserved for users who opt out
-  state.vx.row(999).setConstant(0.5f);
-  state.vy.row(999).setConstant(0.3f);
-  critic.score(data);
-  EXPECT_NEAR(costs.sum(), 0, 1e-6);
-  costs.setZero();
-
-  // Exceeding a single axis is penalized by that axis' overshoot alone
-  state.vx.setConstant(0.0f);
-  state.vy.setConstant(0.0f);
-  state.vy.row(999).setConstant(0.5f);
-  critic.score(data);
-  // 4.0 weight * 0.1 model_dt * 0.2 error introduced * 30 timesteps = 2.4
-  EXPECT_NEAR(costs(999), 2.4, 0.01);
+  // 3.6^2 = 12.96
+  EXPECT_NEAR(costs(999), 12.96, 0.01);
   costs.setZero();
 }
 

--- a/nav2_mppi_controller/test/motion_model_tests.cpp
+++ b/nav2_mppi_controller/test/motion_model_tests.cpp
@@ -98,129 +98,21 @@ TEST(MotionModelTests, OmniTest)
   EXPECT_TRUE(state.vy.isApprox(state.cvy));  // holonomic
   EXPECT_TRUE(state.wz.isApprox(state.cwz));
 
-  // Check that Omni Drive is properly holonomic
-  EXPECT_EQ(model->isHolonomic(), true);
-
-  // Check it cleanly destructs
-  model.reset();
-}
-
-TEST(MotionModelTests, OmniEllipticalConstraintsTest)
-{
-  models::ControlSequence control_sequence;
-  control_sequence.reset(6);  // populates with zeros
-  auto model = std::make_unique<OmniMotionModel>();
-  models::ControlConstraints constraints{0.5f, -0.35f, 0.3f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  model->setConstraints(constraints, 0.1f, 0.0f, 0.0f, 0.0f, false);
-
-  // Velocities inside the ellipse, and exactly on either semi-axis, are left untouched.
-  // The last two are outside the ellipse, thus pulled onto the ellipse.
-  control_sequence.vx << 0.25f, 0.5f, 0.0f, -0.2f, 0.5f, -0.35f;
-  control_sequence.vy << 0.15f, 0.0f, -0.3f, -0.1f, 0.3f, 0.3f;
-
-  control_sequence.wz.setLinSpaced(6, -1.0f, 1.0f);
-  const Eigen::ArrayXf wz_initial = control_sequence.wz;
-
-  model->applyConstraints(control_sequence);
-
-  EXPECT_NEAR(control_sequence.vx(0), 0.25f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(0), 0.15f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(1), 0.5f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(1), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(2), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(2), -0.3f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(3), -0.2f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(3), -0.1f, 1e-6);
-
-  // Scaled radially by 1/sqrt(2), so the direction of travel is preserved
-  EXPECT_NEAR(control_sequence.vx(4), 0.5f / std::sqrt(2.0f), 1e-6);
-  EXPECT_NEAR(control_sequence.vy(4), 0.3f / std::sqrt(2.0f), 1e-6);
-  EXPECT_NEAR(control_sequence.vx(5), -0.35f / std::sqrt(2.0f), 1e-6);
-  EXPECT_NEAR(control_sequence.vy(5), 0.3f / std::sqrt(2.0f), 1e-6);
-
-  // The projected corners now sit on the ellipse, and below both per-axis limits
-  for (unsigned int i = 4; i != 6; i++) {
-    const float vx_limit = control_sequence.vx(i) >= 0.0f ? 0.5f : 0.35f;
-    const float radius = std::hypot(control_sequence.vx(i) / vx_limit,
-        control_sequence.vy(i) / 0.3f);
-    EXPECT_NEAR(radius, 1.0f, 1e-5);
-    EXPECT_LT(std::fabs(control_sequence.vx(i)), vx_limit);
-    EXPECT_LT(std::fabs(control_sequence.vy(i)), 0.3f);
+  // Check that application of constraints are empty for Omni Drive
+  for (unsigned int i = 0; i != control_sequence.vx.rows(); i++) {
+    control_sequence.vx(i) = i * i * i;
+    control_sequence.vy(i) = i * i * i;
+    control_sequence.wz(i) = i * i * i;
   }
 
-  // Angular velocity is not touched by the holonomic envelope
-  EXPECT_TRUE(control_sequence.wz.isApprox(wz_initial));
-
-  // Check it cleanly destructs
-  model.reset();
-}
-
-TEST(MotionModelTests, OmniZeroLimitConstraintsTest)
-{
-  // The axis with limit 0 cannot be commanded at all.
-  // The other feasible axis must still reach its own limit.
-  models::ControlSequence control_sequence;
-  control_sequence.reset(3);  // populates with zeros
-  auto model = std::make_unique<OmniMotionModel>();
-
-  // vy_max = 0.0: no lateral motion allowed
-  models::ControlConstraints no_strafe{0.5f, -0.35f, 0.0f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  model->setConstraints(no_strafe, 0.1f, 0.0f, 0.0f, 0.0f, false);
-
-  control_sequence.vx << 0.4f, -0.3f, 0.5f;
-  control_sequence.vy << 0.2f, -0.2f, 0.0f;
+  models::ControlSequence initial_control_sequence = control_sequence;
   model->applyConstraints(control_sequence);
+  EXPECT_TRUE(initial_control_sequence.vx.isApprox(control_sequence.vx));
+  EXPECT_TRUE(initial_control_sequence.vy.isApprox(control_sequence.vy));
+  EXPECT_TRUE(initial_control_sequence.wz.isApprox(control_sequence.wz));
 
-  EXPECT_NEAR(control_sequence.vy(0), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(1), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(2), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(0), 0.4f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(1), -0.3f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(2), 0.5f, 1e-6);
-
-  // vx_min = 0.0: no reversing allowed
-  models::ControlConstraints no_reverse{0.5f, 0.0f, 0.3f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  model->setConstraints(no_reverse, 0.1f, 0.0f, 0.0f, 0.0f, false);
-
-  control_sequence.vx << 0.4f, -0.3f, 0.0f;
-  control_sequence.vy << 0.0f, 0.0f, 0.3f;
-  model->applyConstraints(control_sequence);
-
-  EXPECT_NEAR(control_sequence.vx(0), 0.4f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(1), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(2), 0.0f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(2), 0.3f, 1e-6);
-
-  // Check it cleanly destructs
-  model.reset();
-}
-
-TEST(MotionModelTests, OmniPerAxisLimitsTest)
-{
-  // With use_elliptical_velocity_limits false only per-axis clamps are applied
-  models::ControlSequence control_sequence;
-  control_sequence.reset(2);  // populates with zeros
-  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
-  std::string name = "test";
-  ParametersHandler param_handler(node, name);
-  auto model = std::make_unique<OmniMotionModel>();
-
-  node->declare_parameter(name + ".omni.use_elliptical_velocity_limits", false);
-  model->initialize(&param_handler, name + ".omni");
-  EXPECT_FALSE(model->useEllipticalVelocityLimits());
-
-  models::ControlConstraints constraints{0.5f, -0.35f, 0.3f, 1.9f, 3.0f, -3.0f, -3.0f, 3.0f, 3.5f};
-  model->setConstraints(constraints, 0.1f, 0.0f, 0.0f, 0.0f, false);
-
-  // The rectangle's corner passes through untouched
-  control_sequence.vx << 0.5f, -0.35f;
-  control_sequence.vy << 0.3f, 0.3f;
-  model->applyConstraints(control_sequence);
-
-  EXPECT_NEAR(control_sequence.vx(0), 0.5f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(0), 0.3f, 1e-6);
-  EXPECT_NEAR(control_sequence.vx(1), -0.35f, 1e-6);
-  EXPECT_NEAR(control_sequence.vy(1), 0.3f, 1e-6);
+  // Check that Omni Drive is properly holonomic
+  EXPECT_EQ(model->isHolonomic(), true);
 
   // Check it cleanly destructs
   model.reset();

--- a/nav2_mppi_controller/test/optimizer_unit_tests.cpp
+++ b/nav2_mppi_controller/test/optimizer_unit_tests.cpp
@@ -589,35 +589,20 @@ TEST(OptimizerTests, applyControlSequenceConstraintsTests)
   auto & sequence = optimizer_tester.grabControlSequence();
   auto & state = optimizer_tester.grabState();
 
-  // Test boundary of limits, on the vx semi-axis of the holonomic velocity ellipse
+  // Test boundary of limits
   // Set state speed to match so acceleration constraints are satisfied
   state.speed.linear.x = 1.0;
-  state.speed.linear.y = 0.0;
+  state.speed.linear.y = 0.75;
   state.speed.angular.z = 2.0;
   sequence.vx = Eigen::ArrayXf::Ones(50);
-  sequence.vy = Eigen::ArrayXf::Zero(50);
+  sequence.vy = 0.75 * Eigen::ArrayXf::Ones(50);
   sequence.wz = 2.0 * Eigen::ArrayXf::Ones(50);
   optimizer_tester.applyControlSequenceConstraintsWrapper();
   EXPECT_TRUE(sequence.vx.isApproxToConstant(1.0f));
-  EXPECT_TRUE(sequence.vy.isApproxToConstant(0.0f));
+  EXPECT_TRUE(sequence.vy.isApproxToConstant(0.75f));
   EXPECT_TRUE(sequence.wz.isApproxToConstant(2.0f));
 
-  // Test boundary of limits on a diagonal, where the ellipse binds before the per-axis limits
-  const float diagonal_scale = 1.0f / std::sqrt(2.0f);
-  state.speed.linear.x = 1.0 * diagonal_scale;
-  state.speed.linear.y = 0.75 * diagonal_scale;
-  state.speed.angular.z = 2.0;
-  sequence.vx = 1.0 * diagonal_scale * Eigen::ArrayXf::Ones(50);
-  sequence.vy = 0.75 * diagonal_scale * Eigen::ArrayXf::Ones(50);
-  sequence.wz = 2.0 * Eigen::ArrayXf::Ones(50);
-  optimizer_tester.applyControlSequenceConstraintsWrapper();
-  EXPECT_TRUE(sequence.vx.isApproxToConstant(1.0f * diagonal_scale));
-  EXPECT_TRUE(sequence.vy.isApproxToConstant(0.75f * diagonal_scale));
-  EXPECT_TRUE(sequence.wz.isApproxToConstant(2.0f));
-
-  // Test breaking limits sets to the maximum along the commanded direction of travel. Equal
-  // vx and vy demand puts that at vx = 0.6, vy = 0.6: on the ellipse, and within both
-  // per-axis limits. The sequence ramps there under the acceleration limits, so check the tail.
+  // Test breaking limits sets to maximum
   state.speed.linear.x = 1.0;
   state.speed.linear.y = 0.75;
   state.speed.angular.z = 2.0;
@@ -625,11 +610,9 @@ TEST(OptimizerTests, applyControlSequenceConstraintsTests)
   sequence.vy = 5.0 * Eigen::ArrayXf::Ones(50);
   sequence.wz = 5.0 * Eigen::ArrayXf::Ones(50);
   optimizer_tester.applyControlSequenceConstraintsWrapper();
-  EXPECT_NEAR(sequence.vx(49), 0.6f, 1e-3);
-  EXPECT_NEAR(sequence.vy(49), 0.6f, 1e-3);
-  EXPECT_NEAR(sequence.wz(49), 2.0f, 1e-3);
-  EXPECT_TRUE((sequence.vx <= 1.0f + 1e-6f).all());
-  EXPECT_TRUE((sequence.vy <= 0.75f + 1e-6f).all());
+  EXPECT_TRUE(sequence.vx.isApproxToConstant(1.0f));
+  EXPECT_TRUE(sequence.vy.isApproxToConstant(0.75f));
+  EXPECT_TRUE(sequence.wz.isApproxToConstant(2.0f));
 
   // Test breaking limits sets to minimum
   state.speed.linear.x = -1.0;
@@ -639,109 +622,9 @@ TEST(OptimizerTests, applyControlSequenceConstraintsTests)
   sequence.vy = -5.0 * Eigen::ArrayXf::Ones(50);
   sequence.wz = -5.0 * Eigen::ArrayXf::Ones(50);
   optimizer_tester.applyControlSequenceConstraintsWrapper();
-  EXPECT_NEAR(sequence.vx(49), -0.6f, 1e-3);
-  EXPECT_NEAR(sequence.vy(49), -0.6f, 1e-3);
-  EXPECT_NEAR(sequence.wz(49), -2.0f, 1e-3);
-  EXPECT_TRUE((sequence.vx >= -1.0f - 1e-6f).all());
-  EXPECT_TRUE((sequence.vy >= -0.75f - 1e-6f).all());
-
-  // Test that acceleration limits and elliptical velocity limits are respected simultaneously
-  state.speed.linear.x = -0.2959;
-  state.speed.linear.y = -0.7164;
-  state.speed.angular.z = 0.0;
-  sequence.vx.setConstant(-0.404f);
-  sequence.vy.setConstant(-0.687f);
-  sequence.wz.setConstant(0.0f);
-  optimizer_tester.applyControlSequenceConstraintsWrapper();
-
-  float prev_vx = static_cast<float>(state.speed.linear.x);
-  float prev_vy = static_cast<float>(state.speed.linear.y);
-  auto & constraints = optimizer_tester.getControlConstraints();
-  auto & settings = optimizer_tester.grabSettings();
-  for (unsigned int i = 0; i < 50; ++i) {
-    float vx = sequence.vx(i);
-    float vy = sequence.vy(i);
-    float ellipse_val = (vx * vx) / (1.0f * 1.0f) + (vy * vy) / (0.75f * 0.75f);
-    EXPECT_LE(ellipse_val, 1.0f + 1e-5f);
-
-    float dt = (i == 0) ? settings.controller_period : settings.model_dt;
-    float max_dvx = dt * constraints.ax_max;
-    float min_dvx = dt * constraints.ax_min;
-    float max_dvy = dt * constraints.ay_max;
-    float min_dvy = dt * constraints.ay_min;
-
-    float dvx = vx - prev_vx;
-    float dvy = vy - prev_vy;
-    EXPECT_LE(dvx, max_dvx + 1e-5f);
-    EXPECT_GE(dvx, min_dvx - 1e-5f);
-    EXPECT_LE(dvy, max_dvy + 1e-5f);
-    EXPECT_GE(dvy, min_dvy - 1e-5f);
-
-    prev_vx = vx;
-    prev_vy = vy;
-  }
-}
-
-TEST(OptimizerTests, applyControlSequenceConstraintsPerAxisTests)
-{
-  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
-  OptimizerTester optimizer_tester;
-  node->declare_parameter("controller_frequency", rclcpp::ParameterValue(30.0));
-  node->declare_parameter("mppic.batch_size", rclcpp::ParameterValue(1000));
-  node->declare_parameter("mppic.time_steps", rclcpp::ParameterValue(50));
-  node->declare_parameter("mppic.vx_max", rclcpp::ParameterValue(1.0));
-  node->declare_parameter("mppic.vx_min", rclcpp::ParameterValue(-1.0));
-  node->declare_parameter("mppic.vy_max", rclcpp::ParameterValue(0.75));
-  node->declare_parameter("mppic.wz_max", rclcpp::ParameterValue(2.0));
-  node->declare_parameter(
-    "mppic.diff_drive.plugin", rclcpp::ParameterValue("mppi::DiffDriveMotionModel"));
-  node->declare_parameter(
-    "mppic.omni.plugin", rclcpp::ParameterValue("mppi::OmniMotionModel"));
-  node->declare_parameter(
-    "mppic.omni.use_elliptical_velocity_limits", rclcpp::ParameterValue(false));
-  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
-    "dummy_costmap", "", true);
-  std::string name = "test";
-  ParametersHandler param_handler(node, name);
-  rclcpp_lifecycle::State lstate;
-  costmap_ros->on_configure(lstate);
-  auto tf_buffer = nav2::create_transform_buffer(node);
-  optimizer_tester.initialize(node, "mppic", costmap_ros, tf_buffer, &param_handler);
-
-  // Opting out of the elliptical envelope must keep the axes independent, both for the
-  // velocity limits and for the acceleration limits
-  optimizer_tester.resetMotionModel();
-  optimizer_tester.testSetOmniModel();
-  auto & sequence = optimizer_tester.grabControlSequence();
-  auto & state = optimizer_tester.grabState();
-
-  // Demanding more than possible on both axes saturates each at its own limit, rather than
-  // being projected back onto the ellipse (which would give vx = vy = 0.6)
-  state.speed.linear.x = 0.0;
-  state.speed.linear.y = 0.0;
-  state.speed.angular.z = 0.0;
-  sequence.vx = 5.0 * Eigen::ArrayXf::Ones(50);
-  sequence.vy = 5.0 * Eigen::ArrayXf::Ones(50);
-  sequence.wz = 5.0 * Eigen::ArrayXf::Ones(50);
-  optimizer_tester.applyControlSequenceConstraintsWrapper();
-  EXPECT_NEAR(sequence.vx(49), 1.0f, 1e-3);
-  EXPECT_NEAR(sequence.vy(49), 0.75f, 1e-3);
-  EXPECT_NEAR(sequence.wz(49), 2.0f, 1e-3);
-
-  // Each axis is limited by its own acceleration limit, so an axis that is already at its
-  // demand is not slowed down by the other axis needing to ramp up
-  auto & constraints = optimizer_tester.getControlConstraints();
-  auto & settings = optimizer_tester.grabSettings();
-  state.speed.linear.x = 0.5;
-  state.speed.linear.y = 0.0;
-  state.speed.angular.z = 0.0;
-  sequence.vx.setConstant(0.5f);
-  sequence.vy.setConstant(0.75f);
-  sequence.wz.setZero();
-  optimizer_tester.applyControlSequenceConstraintsWrapper();
-  EXPECT_TRUE(sequence.vx.isApproxToConstant(0.5f));
-  EXPECT_NEAR(sequence.vy(0), settings.controller_period * constraints.ay_max, 1e-5);
-  EXPECT_NEAR(sequence.vy(49), 0.75f, 1e-3);
+  EXPECT_TRUE(sequence.vx.isApproxToConstant(-1.0f));
+  EXPECT_TRUE(sequence.vy.isApproxToConstant(-0.75f));
+  EXPECT_TRUE(sequence.wz.isApproxToConstant(-2.0f));
 }
 
 TEST(OptimizerTests, updateStateVelocitiesTests)


### PR DESCRIPTION
Reverts ros-navigation/navigation2#6344