### PR TITLE
Fix pose topic subscription leak when following ends via static object timeout

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -133,6 +133,7 @@ FollowingServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   vel_publisher_.reset();
   filtered_dynamic_pose_pub_.reset();
   odom_sub_.reset();
+  dynamic_pose_sub_.reset();
   return nav2::CallbackReturn::SUCCESS;
 }
 
@@ -273,6 +274,7 @@ void FollowingServer::followObject()
               result->num_retries = num_retries_;
               publishZeroVelocity();
               following_action_server_->succeeded_current(result);
+              dynamic_pose_sub_.reset();
               return;
             }
           }

--- a/nav2_following/opennav_following/test/test_following_server_unit.cpp
+++ b/nav2_following/opennav_following/test/test_following_server_unit.cpp
@@ -46,6 +46,9 @@ public:
 
   virtual bool approachObject(geometry_msgs::msg::PoseStamped &, const std::string &)
   {
+    // Mirror the production behavior of updating the iteration timestamp,
+    // used e.g. by the following feedback computation.
+    iteration_start_time_ = this->now();
     std::string exception;
     this->get_parameter("exception_to_throw", exception);
     if (exception == "TransformException") {
@@ -167,6 +170,61 @@ TEST(FollowingServerTests, ErrorExceptions)
 
   // Set follow_action_called to true to simulate robot following object
   node->set_parameter(rclcpp::Parameter("follow_action_called", true));
+
+  node->on_deactivate(rclcpp_lifecycle::State());
+  node->on_cleanup(rclcpp_lifecycle::State());
+  node->on_shutdown(rclcpp_lifecycle::State());
+  node.reset();
+}
+
+TEST(FollowingServerTests, SubscriptionReleasedOnStaticTimeout)
+{
+  auto node = std::make_shared<FollowingServerShim>();
+  auto node_thread = nav2::NodeThread(node);
+  auto node2 = std::make_shared<rclcpp::Node>("client_node_static_timeout");
+
+  auto pub = node2->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "dynamic_pose", rclcpp::QoS(1));
+
+  node->on_configure(rclcpp_lifecycle::State());
+  node->on_activate(rclcpp_lifecycle::State());
+
+  // Short static timeout so that the action ends through the
+  // "object has been static" success path
+  node->set_parameter(rclcpp::Parameter("static_object_timeout", 0.3));
+
+  geometry_msgs::msg::PoseStamped detected_pose;
+  detected_pose.header.stamp = node->now();
+
+  auto client = rclcpp_action::create_client<FollowObject>(node2, "follow_object");
+  ASSERT_TRUE(client->wait_for_action_server(1s));
+  auto goal_msg = FollowObject::Goal();
+  goal_msg.pose_topic = "dynamic_pose";
+  auto future_goal_handle = client->async_send_goal(goal_msg);
+  pub->publish(detected_pose);
+
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node2, future_goal_handle, 2s),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto future_result = client->async_get_result(future_goal_handle.get());
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node2, future_result, 10s),
+    rclcpp::FutureReturnCode::SUCCESS);
+  EXPECT_EQ(
+    future_result.get().code, rclcpp_action::ResultCode::SUCCEEDED);
+
+  // The pose topic subscription must be released once the action is over,
+  // just like on every other terminal exit path of this action
+  auto start = std::chrono::steady_clock::now();
+  bool released = false;
+  while (std::chrono::steady_clock::now() - start < 2s) {
+    if (node2->count_subscribers("dynamic_pose") == 0) {
+      released = true;
+      break;
+    }
+    std::this_thread::sleep_for(50ms);
+  }
+  EXPECT_TRUE(released);
 
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | N/A (bug found by code inspection) |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Unit tests only (no hardware platform) |
| Does this PR contain AI generated software? | Yes; AI was used for code formatting/layout of the changes |
| Was this PR description generated by AI software? | Yes; AI was used to translate the description content into English |

---

## Description of contribution in a few bullet points

* `opennav_following` creates a subscription to the requested pose topic (`dynamic_pose_sub_`) when a `follow_object` goal starts. Every terminal exit path released this subscription except one: ending through the *static object timeout -> succeeded* branch
* While following has ended, the server therefore stays subscribed to the pose topic and keeps receiving messages until the next goal starts or the node shuts down
* Additionally, `on_cleanup()` released every other managed resource but not this subscription
* This PR releases the subscription on the static object timeout success branch, and also releases it in `on_cleanup()` alongside `odom_sub_`

## Description of documentation updates required from your changes

* None required — bug fix with no API, parameter, or documented-behavior changes

## Description of how this change was tested

* Added a `SubscriptionReleasedOnStaticTimeout` unit test: sends a `follow_object` goal with a pose topic, lets it end through the static object timeout success path (short `static_object_timeout`, shimmed `approachObject`), then asserts the action result is `SUCCEEDED` and the subscriber count for the topic drops back to zero
* All existing `opennav_following` unit tests still pass

---

## Future work that may be required in bullet points

* Possibly audit other lifecycle servers for similar subscription-release asymmetries between terminal paths and `on_cleanup()`

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.

Signed-off-by: lawliet <lawliet206@163.com>