### PR TITLE
Guard getPoseAtDistance against undefined projection at zero distance

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -650,12 +650,7 @@ geometry_msgs::msg::PoseStamped FollowingServer::getPoseAtDistance(
   double dx = pose.pose.position.x - robot_pose.pose.position.x;
   double dy = pose.pose.position.y - robot_pose.pose.position.y;
   const double dist = std::hypot(dx, dy);
-  if (dist == 0.0) {
-    // The robot is exactly at the tracked pose: the backwards projection is
-    // undefined and would produce NaNs downstream, return the pose unchanged.
-    RCLCPP_WARN(
-      get_logger(),
-      "Robot is already at the tracked object pose, skipping distance projection");
+  if (dist < 1e-6) {
     return pose;
   }
   geometry_msgs::msg::PoseStamped forward_pose = pose;

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -650,6 +650,14 @@ geometry_msgs::msg::PoseStamped FollowingServer::getPoseAtDistance(
   double dx = pose.pose.position.x - robot_pose.pose.position.x;
   double dy = pose.pose.position.y - robot_pose.pose.position.y;
   const double dist = std::hypot(dx, dy);
+  if (dist == 0.0) {
+    // The robot is exactly at the tracked pose: the backwards projection is
+    // undefined and would produce NaNs downstream, return the pose unchanged.
+    RCLCPP_WARN(
+      get_logger(),
+      "Robot is already at the tracked object pose, skipping distance projection");
+    return pose;
+  }
   geometry_msgs::msg::PoseStamped forward_pose = pose;
   forward_pose.pose.position.x -= distance * (dx / dist);
   forward_pose.pose.position.y -= distance * (dy / dist);

--- a/nav2_following/opennav_following/test/test_following_server_unit.cpp
+++ b/nav2_following/opennav_following/test/test_following_server_unit.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <cmath>
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -190,6 +191,17 @@ TEST(FollowingServerTests, GetPoseAtDistance)
   auto new_pose = node->getPoseAtDistance(pose, 0.2);
   EXPECT_NEAR(new_pose.pose.position.x, 0.8585, 0.01);
   EXPECT_NEAR(new_pose.pose.position.y, -0.8585, 0.01);
+
+  // Robot exactly at the tracked pose: the backwards projection is undefined
+  // and must not propagate NaNs downstream
+  geometry_msgs::msg::PoseStamped at_robot;
+  at_robot.header.stamp = node->now();
+  at_robot.header.frame_id = "my_frame";
+  auto zero_dist = node->getPoseAtDistance(at_robot, 0.5);
+  EXPECT_TRUE(std::isfinite(zero_dist.pose.position.x));
+  EXPECT_TRUE(std::isfinite(zero_dist.pose.position.y));
+  EXPECT_EQ(zero_dist.pose.position.x, 0.0);
+  EXPECT_EQ(zero_dist.pose.position.y, 0.0);
 
   node->on_cleanup(rclcpp_lifecycle::State());
   node->on_shutdown(rclcpp_lifecycle::State());


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | N/A (bug found by code inspection) |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Unit tests only (no hardware platform) |
| Does this PR contain AI generated software? | Yes; AI was used for code formatting/layout of the changes |
| Was this PR description generated by AI software? | Yes; AI was used to translate the description content into English |

---

## Description of contribution in a few bullet points

* `FollowingServer::getPoseAtDistance()` projects a point at a given distance from the tracked object pose back towards the robot using `distance * (dx / dist)` where `dist = std::hypot(dx, dy)`
* When the robot pose coincides exactly with the tracked object pose (`dist == 0`) this divides by zero and produces NaN coordinates that propagate into the target pose handed to `controller_->computeVelocityCommand()`, resulting in an invalid command for that control cycle
* Although an edge case, it is reachable (e.g. detections reporting the robot position itself), and NaNs are never valid output for a control pipeline
* This PR returns the tracked pose unchanged when `dist == 0`, consistent with the existing fallback path used when the current robot pose cannot be obtained

## Description of documentation updates required from your changes

* None required — bug fix with no API, parameter, or documented-behavior changes

## Description of how this change was tested

* Extended the existing `GetPoseAtDistance` unit test with a zero-distance scenario asserting the returned coordinates stay finite and equal to the input pose
* All existing `opennav_following` unit tests still pass

---

## Future work that may be required in bullet points

* None foreseen

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.

Signed-off-by: lawliet <lawliet206@163.com>