### PR TITLE
Make follow_object reinit-lock handling exception-safe

### DIFF
--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -179,9 +179,6 @@ bool FollowingServer::checkAndWarnIfPreempted(
 
 void FollowingServer::followObject()
 {
-  // unique_lock rather than lock_guard: ownership is temporarily released below
-  // while creating the pose subscription, and must stay exception-safe so the
-  // destructor never unlocks a mutex this thread does not own.
   std::unique_lock<std::mutex> lock_reinit(param_handler_->getMutex());
   action_start_time_ = this->now();
   nav2::Rate loop_rate(this, params_->controller_frequency);
@@ -219,8 +216,6 @@ void FollowingServer::followObject()
         following_action_server_->terminate_all(result);
         return;
       } else {
-        // Temporarily release the reinit lock while creating the subscription:
-        // if creation throws, the unique_lock destructor safely skips unlocking
         lock_reinit.unlock();
         RCLCPP_INFO(get_logger(), "Subscribing to pose topic: %s", pose_topic.c_str());
         dynamic_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(

--- a/nav2_following/opennav_following/src/following_server.cpp
+++ b/nav2_following/opennav_following/src/following_server.cpp
@@ -179,7 +179,10 @@ bool FollowingServer::checkAndWarnIfPreempted(
 
 void FollowingServer::followObject()
 {
-  std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());
+  // unique_lock rather than lock_guard: ownership is temporarily released below
+  // while creating the pose subscription, and must stay exception-safe so the
+  // destructor never unlocks a mutex this thread does not own.
+  std::unique_lock<std::mutex> lock_reinit(param_handler_->getMutex());
   action_start_time_ = this->now();
   nav2::Rate loop_rate(this, params_->controller_frequency);
 
@@ -216,7 +219,9 @@ void FollowingServer::followObject()
         following_action_server_->terminate_all(result);
         return;
       } else {
-        param_handler_->getMutex().unlock();
+        // Temporarily release the reinit lock while creating the subscription:
+        // if creation throws, the unique_lock destructor safely skips unlocking
+        lock_reinit.unlock();
         RCLCPP_INFO(get_logger(), "Subscribing to pose topic: %s", pose_topic.c_str());
         dynamic_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
           pose_topic,
@@ -224,7 +229,7 @@ void FollowingServer::followObject()
             detected_dynamic_pose_ = *pose;
           },
           nav2::qos::StandardTopicQoS(1));  // Only want the most recent pose
-        param_handler_->getMutex().lock();
+        lock_reinit.lock();
       }
     } else {
       RCLCPP_INFO(get_logger(), "Following frame: %s instead of pose", target_frame.c_str());


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | N/A (defensive hardening found by code inspection) |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Unit tests only (no hardware platform) |
| Does this PR contain AI generated software? | Yes; AI was used for code formatting/layout of the changes |
| Was this PR description generated by AI software? | Yes; AI was used to translate the description content into English |

---

## Description of contribution in a few bullet points

* `FollowingServer::followObject()` holds the parameter-handler reinit mutex through a `std::lock_guard` for the whole action, but temporarily releases it around `create_subscription()` with raw `unlock()` / `lock()` calls
* If `create_subscription()` throws — e.g. when a goal supplies an invalid pose topic name, which is user input — the manual re-lock is skipped and the `lock_guard` destructor then unlocks a mutex this thread no longer owns, which is undefined behavior and can abort the process, turning a recoverable invalid-goal error into a crash
* This PR switches to `std::unique_lock<std::mutex>` and uses its ownership-aware `unlock()` / `lock()`; the destructor only unlocks when ownership is held, so every exit path (including exceptions from subscription creation) stays correct
* No behavior change in the normal path; lock hold windows are identical

## Description of documentation updates required from your changes

* None required — internal robustness fix with no API, parameter, or documented-behavior changes

## Description of how this change was tested

* All existing `opennav_following` unit tests pass; Codecov reports the changed lines fully covered
* Exception path exercised by the existing tests covering `follow_object` goals with invalid inputs

---

## Future work that may be required in bullet points

* None foreseen

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.

Signed-off-by: lawliet <lawliet206@163.com>