### PR TITLE
Refactor nav2_route tests to use condition polling instead of timed waits

### DIFF
--- a/nav2_route/test/test_collision_operation.cpp
+++ b/nav2_route/test/test_collision_operation.cpp
@@ -13,8 +13,10 @@
 // limitations under the License. Reserved.
 
 #include <math.h>
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -193,10 +195,19 @@ TEST(TestCollisionMonitor, test_costmap_apis)
   publisher.on_activate();
   publisher.publishCostmap();
 
-  // Give it a moment to receive the costmap
-  rclcpp::Rate r(10);
-  r.sleep();
-  monitor.getCostmapWrapper();  // Since would otherwise be called in `perform`
+  // Poll until the costmap is received rather than waiting a fixed time
+  const auto start_time = std::chrono::steady_clock::now();
+  while (true) {
+    try {
+      monitor.getCostmapWrapper();  // Since would otherwise be called in `perform`
+      break;
+    } catch (const nav2_core::OperationFailed &) {
+      ASSERT_LT(
+        std::chrono::steady_clock::now() - start_time,
+        std::chrono::seconds(10));
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
 
   Coordinates start, end;
   start.x = 1.0;

--- a/nav2_route/test/test_edge_scorers.cpp
+++ b/nav2_route/test/test_edge_scorers.cpp
@@ -13,8 +13,10 @@
 // limitations under the License. Reserved.
 
 #include <math.h>
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -265,9 +267,15 @@ TEST(EdgeScorersTest, test_costmap_scoring)
   publisher.on_activate();
   publisher.publishCostmap();
 
-  // Give it a moment to receive the costmap
-  rclcpp::Rate r(10);
-  r.sleep();
+  // Poll until the costmap is received rather than waiting a fixed time:
+  // scoring fails while no costmap has been received, succeeds afterwards
+  const auto start_time = std::chrono::steady_clock::now();
+  while (!scorer.score(&edge, route_request, edge_type, traversal_cost)) {
+    ASSERT_LT(
+      std::chrono::steady_clock::now() - start_time,
+      std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   n1.coords.x = 5.0;
   n1.coords.y = 8.0;
@@ -379,13 +387,20 @@ TEST(EdgeScorersTest, test_costmap_scoring_alt_profile)
   publisher.on_activate();
   publisher.publishCostmap();
 
-  // Give it a moment to receive the costmap
-  rclcpp::Rate r(1);
-  r.sleep();
-
   const geometry_msgs::msg::PoseStamped start_pose, goal_pose;
   RouteRequest route_request;
   EdgeType edge_type = EdgeType::NONE;
+
+  // Poll until the costmap is received rather than waiting a fixed time:
+  // scoring fails while no costmap has been received, succeeds afterwards
+  float poll_cost = -1;
+  const auto start_time = std::chrono::steady_clock::now();
+  while (!scorer.score(&edge, route_request, edge_type, poll_cost)) {
+    ASSERT_LT(
+      std::chrono::steady_clock::now() - start_time,
+      std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   // Off map
   n1.coords.x = -1.0;

--- a/nav2_route/test/test_operations.cpp
+++ b/nav2_route/test/test_operations.cpp
@@ -13,8 +13,10 @@
 // limitations under the License. Reserved.
 
 #include <math.h>
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -154,8 +156,15 @@ TEST(OperationsManagerTest, test_processing_speed_on_status)
   EXPECT_EQ(result.operations_triggered.size(), 2u);
   EXPECT_EQ(result.operations_triggered[0], std::string("AdjustSpeedLimit"));
   EXPECT_EQ(result.operations_triggered[1], std::string("ReroutingService"));
-  rclcpp::Rate r(10);
-  r.sleep();
+
+  // Poll until the speed limit message arrives rather than waiting a fixed time
+  const auto start_time = std::chrono::steady_clock::now();
+  while (!got_msg) {
+    ASSERT_LT(
+      std::chrono::steady_clock::now() - start_time,
+      std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   // Check values are correct
   EXPECT_TRUE(got_msg);

--- a/nav2_route/test/test_path_converter.cpp
+++ b/nav2_route/test/test_path_converter.cpp
@@ -13,8 +13,10 @@
 // limitations under the License. Reserved.
 
 #include <math.h>
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -76,8 +78,14 @@ TEST(PathConverterTest, test_path_converter_api)
   EXPECT_NEAR(path.poses.back().pose.position.x, 20.0, 0.01);
   EXPECT_NEAR(path.poses.back().pose.position.y, 20.0, 0.01);
 
-  rclcpp::Rate r(10);
-  r.sleep();
+  // Poll until the published path arrives rather than waiting a fixed time
+  const auto start_time = std::chrono::steady_clock::now();
+  while (path_msg.poses.empty()) {
+    ASSERT_LT(
+      std::chrono::steady_clock::now() - start_time,
+      std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
   // Checks the same as returned and actually was published
   EXPECT_EQ(path_msg.poses.size(), path.poses.size());


### PR DESCRIPTION
## Refactoring / test reliability

Follow-up to the test-flakiness discussion in #6163.

### Problem

In [#6163](https://github.com/ros-navigation/navigation2/issues/6163), Innomer measured locally on FastRTPS that `nav2_route` tests fail **2 out of 12 runs** (`nav2_theta_star_planner` 2/8), and pointed out several test cases use *timer-based waits* to "ensure subscription/message updates". fishOmlette confirmed:

> timer based waits are sensitive to the testing workspace. Switching to condition based polling (like checking getCostmap() dynamically) is definitely the best approach to make these tests deterministic. ... we should absolutely refactor those timers next

This PR implements that for `nav2_route`, which nobody has picked up so far.

### Changes

All replaced sleeps are pure *synchronization* waits; each is replaced by a bounded poll loop (10s deadline, 10ms interval) on an observable condition, so tests proceed as soon as state is actually ready and fail with a clear timeout instead of passing/failing depending on machine load:

| File | Wait | Condition polled instead |
|---|---|---|
| `test_edge_scorers.cpp` (2 sites) | fixed sleep after publishing costmap | `scorer.score()` succeeds — scoring deterministically fails while no costmap was received |
| `test_collision_operation.cpp` | fixed sleep after publishing costmap | `getCostmapWrapper()` stops throwing `nav2_core::OperationFailed` |
| `test_path_converter.cpp` | fixed sleep hoping the published path arrives | subscription received a non-empty path |
| `test_operations.cpp` | fixed sleep hoping the speed-limit msg arrives | `got_msg` flag set by the subscription callback |

### Intentionally left unchanged

Some remaining sleeps are *semantic*, not synchronization — they rely on real wall time passing:

- `test_operations.cpp`: elapsed-time measurement of edge traversal (`abs_time_taken`)
- `test_collision_operation.cpp`: collision-monitor throttle window between `perform()` calls
- `test_route_server.cpp`: preemption timing between action goals
- `test_graph_loader/test_graph_saver`: TF waits already partially synchronized via `spin_all`; a `canTransform`-based refactor would fit better into a dedicated TF-test follow-up

### Testing

- All four affected test binaries: `--gtest_repeat=20` (and 10x re-run) under default FastRTPS — the RMW where the flakiness was originally measured — **0 failures**
- Full `nav2_route` unit suite passes (23/23 targets)
- `cpplint`, `cppcheck` clean on touched files; no source (non-test) files modified
