### PR TITLE
feat(costmap): add FenceLayer plugin for dynamic operational zone (#6348)

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(layers SHARED
   plugins/range_sensor_layer.cpp
   plugins/denoise_layer.cpp
   plugins/plugin_container_layer.cpp
+  plugins/fence_layer.cpp
 )
 target_include_directories(layers
   PUBLIC

--- a/nav2_costmap_2d/costmap_plugins.xml
+++ b/nav2_costmap_2d/costmap_plugins.xml
@@ -27,6 +27,9 @@
     <class type="nav2_costmap_2d::PluginContainerLayer" base_class_type="nav2_costmap_2d::Layer">
       <description>Plugin to group different layers within the same costmap</description>
     </class>
+    <class type="nav2_costmap_2d::FenceLayer" base_class_type="nav2_costmap_2d::Layer">
+      <description>Dynamically resizes costmap bounds to match an operational polygon zone, marking cells outside as lethal.</description>
+    </class>
   </library>
 
   <library path="filters">

--- a/nav2_costmap_2d/include/nav2_costmap_2d/fence_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/fence_layer.hpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, LonelyGuy-SE1
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_COSTMAP_2D__FENCE_LAYER_HPP_
+#define NAV2_COSTMAP_2D__FENCE_LAYER_HPP_
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+#include "nav2_costmap_2d/costmap_layer.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+
+namespace nav2_costmap_2d
+{
+
+class FenceLayerTester;
+
+class FenceLayer : public CostmapLayer
+{
+public:
+  FenceLayer();
+  virtual ~FenceLayer();
+
+  void onInitialize() override;
+  void activate() override;
+  void deactivate() override;
+  void reset() override;
+  bool isClearable() override {return false;}
+  void updateBounds(
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
+  void updateCosts(
+    Costmap2D & master_grid,
+    int min_i, int min_j, int max_i, int max_j) override;
+  void matchSize() override;
+
+  friend class FenceLayerTester;
+
+private:
+  // Subscription callback (runs on executor thread, outside updateMap lock)
+  void polygonCallback(const geometry_msgs::msg::PolygonStamped::ConstSharedPtr & msg);
+
+  // Deferred processing (runs inside updateMap lock via updateBounds)
+  void processFence();
+
+  // Pre-rasterize the fence mask into internal costmap
+  void rasterizeMask();
+
+  // Point-in-polygon test (ray casting)
+  bool isPointInPolygon(double x, double y) const;
+
+  // Dynamic parameter callbacks
+  rcl_interfaces::msg::SetParametersResult validateParameterUpdatesCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
+  void updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters);
+
+  // Members
+  std::string global_frame_;
+  nav2::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_sub_;
+
+  // Buffered polygon (set in callback, consumed in updateBounds)
+  std::mutex polygon_buffer_mutex_;
+  geometry_msgs::msg::PolygonStamped::ConstSharedPtr polygon_buffer_;
+  std::atomic<bool> polygon_updated_{false};
+
+  // Processed polygon state (only accessed under updateMap lock)
+  std::vector<double> polygon_x_;
+  std::vector<double> polygon_y_;
+  bool has_received_polygon_{false};
+
+  // Pre-rasterized mask: true = outside fence (lethal), false = inside (untouched)
+  // Stored as flat vector indexed by [j * fence_size_x_ + i]
+  std::vector<bool> outside_fence_;
+  unsigned int fence_size_x_{0};
+  unsigned int fence_size_y_{0};
+  double fence_origin_x_{0.0};
+  double fence_origin_y_{0.0};
+  double fence_resolution_{0.0};
+
+  // Parameter callbacks
+  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr
+    post_set_params_handler_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
+    on_set_params_handler_;
+};
+
+}  // namespace nav2_costmap_2d
+
+#endif  // NAV2_COSTMAP_2D__FENCE_LAYER_HPP_

--- a/nav2_costmap_2d/plugins/fence_layer.cpp
+++ b/nav2_costmap_2d/plugins/fence_layer.cpp
@@ -1,0 +1,365 @@
+// Copyright (c) 2026, LonelyGuy-SE1
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_costmap_2d/fence_layer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pluginlib/class_list_macros.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+PLUGINLIB_EXPORT_CLASS(nav2_costmap_2d::FenceLayer, nav2_costmap_2d::Layer)
+
+using nav2_costmap_2d::LETHAL_OBSTACLE;
+using nav2_costmap_2d::NO_INFORMATION;
+using nav2_costmap_2d::FREE_SPACE;
+
+namespace nav2_costmap_2d
+{
+
+FenceLayer::FenceLayer()
+{
+}
+
+FenceLayer::~FenceLayer()
+{
+}
+
+void FenceLayer::onInitialize()
+{
+  auto node = node_.lock();
+  if (!node) {
+    throw std::runtime_error{"Failed to lock node"};
+  }
+
+  enabled_ = node->declare_or_get_parameter(name_ + ".enabled", true);
+  global_frame_ = layered_costmap_->getGlobalFrameID();
+
+  std::string polygon_topic = node->declare_or_get_parameter(
+    name_ + ".polygon_topic", std::string("operational_zone"));
+  polygon_topic = joinWithParentNamespace(polygon_topic);
+
+  polygon_sub_ = node->create_subscription<geometry_msgs::msg::PolygonStamped>(
+    polygon_topic,
+    std::bind(&FenceLayer::polygonCallback, this, std::placeholders::_1),
+    nav2::qos::StandardTopicQoS());
+
+  matchSize();
+  setCurrent(true);
+
+  RCLCPP_INFO(logger_, "FenceLayer initialized, subscribing to [%s]", polygon_topic.c_str());
+}
+
+void FenceLayer::polygonCallback(
+  const geometry_msgs::msg::PolygonStamped::ConstSharedPtr & msg)
+{
+  if (!msg || msg->polygon.points.size() < 3) {
+    RCLCPP_WARN(logger_, "FenceLayer: Polygon has < 3 points, ignoring");
+    return;
+  }
+
+  // Transform polygon to global_frame_ if needed
+  geometry_msgs::msg::PolygonStamped transformed;
+  if (!msg->header.frame_id.empty() && msg->header.frame_id != global_frame_) {
+    if (!tf_) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 1000,
+        "FenceLayer: Cannot transform polygon, tf_ is null");
+      return;
+    }
+    try {
+      auto transform = tf_->lookupTransform(
+        global_frame_, msg->header.frame_id, tf2::TimePointZero,
+        tf2::durationFromSec(0.1));
+      tf2::doTransform(*msg, transformed, transform);
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 1000,
+        "FenceLayer: Failed to transform polygon: %s", ex.what());
+      return;
+    }
+  } else {
+    transformed = *msg;
+  }
+
+  // Buffer the polygon (consumed in updateBounds under updateMap lock)
+  {
+    std::lock_guard<std::mutex> lock(polygon_buffer_mutex_);
+    polygon_buffer_ = std::make_shared<const geometry_msgs::msg::PolygonStamped>(transformed);
+  }
+  polygon_updated_.store(true);
+  setCurrent(false);
+}
+
+void FenceLayer::processFence()
+{
+  geometry_msgs::msg::PolygonStamped::ConstSharedPtr poly;
+  {
+    std::lock_guard<std::mutex> lock(polygon_buffer_mutex_);
+    poly = polygon_buffer_;
+    polygon_buffer_ = nullptr;
+  }
+
+  if (!poly) {
+    return;
+  }
+
+  // Extract polygon points
+  polygon_x_.clear();
+  polygon_y_.clear();
+  for (const auto & pt : poly->polygon.points) {
+    polygon_x_.push_back(pt.x);
+    polygon_y_.push_back(pt.y);
+  }
+  has_received_polygon_ = true;
+
+  // Compute bounding box
+  double min_x = *std::min_element(polygon_x_.begin(), polygon_x_.end());
+  double min_y = *std::min_element(polygon_y_.begin(), polygon_y_.end());
+  double max_x = *std::max_element(polygon_x_.begin(), polygon_x_.end());
+  double max_y = *std::max_element(polygon_y_.begin(), polygon_y_.end());
+
+  // Pad by circumscribed radius (rounded up to cell boundary)
+  Costmap2D * master = layered_costmap_->getCostmap();
+  double resolution = master->getResolution();
+  double circ_r = layered_costmap_->getCircumscribedRadius();
+  double padding = std::ceil(circ_r / resolution) * resolution;
+
+  min_x -= padding;
+  min_y -= padding;
+  max_x += padding;
+  max_y += padding;
+
+  // Compute new grid dimensions
+  unsigned int new_size_x = static_cast<unsigned int>(std::ceil((max_x - min_x) / resolution));
+  unsigned int new_size_y = static_cast<unsigned int>(std::ceil((max_y - min_y) / resolution));
+
+  // Check if layered costmap needs resizing
+  if (new_size_x != master->getSizeInCellsX() ||
+    new_size_y != master->getSizeInCellsY() ||
+    std::abs(master->getOriginX() - min_x) >= 1e-6 ||
+    std::abs(master->getOriginY() - min_y) >= 1e-6)
+  {
+    RCLCPP_INFO(
+      logger_,
+      "FenceLayer: Resizing costmap to %u X %u, origin (%.2f, %.2f)",
+      new_size_x, new_size_y, min_x, min_y);
+
+    layered_costmap_->resizeMap(
+      new_size_x, new_size_y, resolution,
+      min_x, min_y,
+      true);  // size_locked=true
+  }
+
+  fence_size_x_ = new_size_x;
+  fence_size_y_ = new_size_y;
+  fence_origin_x_ = min_x;
+  fence_origin_y_ = min_y;
+  fence_resolution_ = resolution;
+
+  // Pre-rasterize the fence mask
+  rasterizeMask();
+}
+
+void FenceLayer::rasterizeMask()
+{
+  outside_fence_.assign(fence_size_x_ * fence_size_y_, false);
+
+  for (unsigned int j = 0; j < fence_size_y_; ++j) {
+    for (unsigned int i = 0; i < fence_size_x_; ++i) {
+      double wx = fence_origin_x_ + (i + 0.5) * fence_resolution_;
+      double wy = fence_origin_y_ + (j + 0.5) * fence_resolution_;
+      outside_fence_[j * fence_size_x_ + i] = !isPointInPolygon(wx, wy);
+    }
+  }
+}
+
+bool FenceLayer::isPointInPolygon(double x, double y) const
+{
+  int n = static_cast<int>(polygon_x_.size());
+  if (n < 3) {
+    return false;
+  }
+
+  bool inside = false;
+  for (int i = 0, j = n - 1; i < n; j = i++) {
+    if (((polygon_y_[i] > y) != (polygon_y_[j] > y)) &&
+      (x < (polygon_x_[j] - polygon_x_[i]) * (y - polygon_y_[i]) /
+      (polygon_y_[j] - polygon_y_[i]) + polygon_x_[i]))
+    {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+void FenceLayer::updateBounds(
+  double robot_x, double robot_y, double robot_yaw,
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  (void)robot_x;
+  (void)robot_y;
+  (void)robot_yaw;
+
+  if (!enabled_) {
+    return;
+  }
+
+  // Check if new polygon is available
+  if (polygon_updated_.load()) {
+    processFence();  // Runs under updateMap's lock — safe to call resizeMap
+    polygon_updated_.store(false);
+    setCurrent(true);
+  }
+
+  if (!has_received_polygon_) {
+    return;
+  }
+
+  useExtraBounds(min_x, min_y, max_x, max_y);
+
+  // Report entire costmap as needing update (we rewrite all cells)
+  Costmap2D * master = layered_costmap_->getCostmap();
+  double wx, wy;
+  master->mapToWorld(0, 0, wx, wy);
+  *min_x = std::min(wx, *min_x);
+  *min_y = std::min(wy, *min_y);
+  master->mapToWorld(master->getSizeInCellsX(), master->getSizeInCellsY(), wx, wy);
+  *max_x = std::max(wx, *max_x);
+  *max_y = std::max(wy, *max_y);
+}
+
+void FenceLayer::updateCosts(
+  Costmap2D & master_grid,
+  int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_ || !has_received_polygon_) {
+    return;
+  }
+
+  unsigned char * master = master_grid.getCharMap();
+  unsigned int span = master_grid.getSizeInCellsX();
+
+  for (int j = min_j; j < max_j; ++j) {
+    for (int i = min_i; i < max_i; ++i) {
+      // Bounds check against pre-rasterized mask
+      if (i < 0 || i >= static_cast<int>(fence_size_x_) ||
+        j < 0 || j >= static_cast<int>(fence_size_y_))
+      {
+        continue;
+      }
+
+      if (outside_fence_[j * fence_size_x_ + i]) {
+        master[j * span + i] = LETHAL_OBSTACLE;
+      }
+      // Inside fence: do NOT touch. Let other layers handle costs.
+    }
+  }
+}
+
+void FenceLayer::activate()
+{
+  auto node = node_.lock();
+  if (!node) {
+    return;
+  }
+
+  post_set_params_handler_ = node->add_post_set_parameters_callback(
+    std::bind(&FenceLayer::updateParametersCallback, this, std::placeholders::_1));
+  on_set_params_handler_ = node->add_on_set_parameters_callback(
+    std::bind(&FenceLayer::validateParameterUpdatesCallback, this, std::placeholders::_1));
+}
+
+void FenceLayer::deactivate()
+{
+  auto node = node_.lock();
+  if (!node) {
+    return;
+  }
+  if (post_set_params_handler_) {
+    node->remove_post_set_parameters_callback(post_set_params_handler_.get());
+    post_set_params_handler_.reset();
+  }
+  if (on_set_params_handler_) {
+    node->remove_on_set_parameters_callback(on_set_params_handler_.get());
+    on_set_params_handler_.reset();
+  }
+}
+
+void FenceLayer::reset()
+{
+  has_received_polygon_ = false;
+  polygon_updated_.store(false);
+  polygon_x_.clear();
+  polygon_y_.clear();
+  outside_fence_.clear();
+  fence_size_x_ = 0;
+  fence_size_y_ = 0;
+  fence_origin_x_ = 0.0;
+  fence_origin_y_ = 0.0;
+  fence_resolution_ = 0.0;
+
+  {
+    std::lock_guard<std::mutex> lock(polygon_buffer_mutex_);
+    polygon_buffer_ = nullptr;
+  }
+
+  // Reset internal costmap
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
+  resetMaps();
+  setCurrent(true);
+}
+
+void FenceLayer::matchSize()
+{
+  if (!layered_costmap_) {
+    return;
+  }
+  CostmapLayer::matchSize();
+}
+
+rcl_interfaces::msg::SetParametersResult
+FenceLayer::validateParameterUpdatesCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  for (const auto & param : parameters) {
+    if (param.get_name() == name_ + ".enabled") {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        result.successful = false;
+        result.reason = "enabled must be a boolean";
+        return result;
+      }
+    }
+  }
+  return result;
+}
+
+void FenceLayer::updateParametersCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  for (const auto & param : parameters) {
+    if (param.get_name() == name_ + ".enabled") {
+      enabled_ = param.as_bool();
+    }
+  }
+}
+
+}  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/test/unit/CMakeLists.txt
+++ b/nav2_costmap_2d/test/unit/CMakeLists.txt
@@ -95,3 +95,9 @@ target_link_libraries(asymmetric_inflation_layer_test
   nav2_costmap_2d_core
   layers
 )
+
+nav2_add_gtest(fence_layer_test fence_layer_test.cpp)
+target_link_libraries(fence_layer_test
+  nav2_costmap_2d_core
+  layers
+)

--- a/nav2_costmap_2d/test/unit/fence_layer_test.cpp
+++ b/nav2_costmap_2d/test/unit/fence_layer_test.cpp
@@ -1,0 +1,524 @@
+// Copyright (c) 2026, LonelyGuy-SE1
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+#include "geometry_msgs/msg/point32.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+#include "nav2_costmap_2d/fence_layer.hpp"
+#include "nav2_costmap_2d/footprint.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_ros_common/tf2_factories.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+using namespace std::chrono_literals;
+
+namespace nav2_costmap_2d
+{
+
+class TestLifecycleNode : public nav2::LifecycleNode
+{
+public:
+  explicit TestLifecycleNode(const std::string & name)
+  : nav2::LifecycleNode(name)
+  {
+  }
+
+  nav2::CallbackReturn on_configure(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+
+  nav2::CallbackReturn on_activate(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+
+  nav2::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+
+  nav2::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+
+  nav2::CallbackReturn onShutdown(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+
+  nav2::CallbackReturn onError(const rclcpp_lifecycle::State &)
+  {
+    return nav2::CallbackReturn::SUCCESS;
+  }
+};
+
+class FenceLayerTester
+{
+public:
+  static void setPolygonDirect(
+    FenceLayer & layer,
+    const std::vector<double> & x,
+    const std::vector<double> & y)
+  {
+    layer.polygon_x_ = x;
+    layer.polygon_y_ = y;
+    layer.has_received_polygon_ = true;
+  }
+
+  static bool isPointInPolygon(const FenceLayer & layer, double x, double y)
+  {
+    return layer.isPointInPolygon(x, y);
+  }
+
+  static void triggerPolygonCallback(
+    FenceLayer & layer,
+    const geometry_msgs::msg::PolygonStamped::ConstSharedPtr & msg)
+  {
+    layer.polygonCallback(msg);
+  }
+
+  static bool hasReceivedPolygon(const FenceLayer & layer)
+  {
+    return layer.has_received_polygon_;
+  }
+
+  static bool isPolygonUpdated(const FenceLayer & layer)
+  {
+    return layer.polygon_updated_.load();
+  }
+
+  static const std::vector<bool> & getOutsideMask(const FenceLayer & layer)
+  {
+    return layer.outside_fence_;
+  }
+
+  static void getFenceDimensions(
+    const FenceLayer & layer,
+    unsigned int & size_x, unsigned int & size_y,
+    double & origin_x, double & origin_y, double & resolution)
+  {
+    size_x = layer.fence_size_x_;
+    size_y = layer.fence_size_y_;
+    origin_x = layer.fence_origin_x_;
+    origin_y = layer.fence_origin_y_;
+    resolution = layer.fence_resolution_;
+  }
+};
+
+class FenceLayerTest : public ::testing::Test
+{
+public:
+  FenceLayerTest()
+  : layers_("map", false, false)
+  {
+  }
+
+  void SetUp() override
+  {
+    node_ = std::make_shared<TestLifecycleNode>("fence_layer_test_node");
+    tf_ = std::make_shared<nav2::TransformBuffer>(node_->get_clock());
+    tf_->setUsingDedicatedThread(true);
+
+    fence_layer_ = std::make_shared<FenceLayer>();
+    fence_layer_->initialize(
+      &layers_, "fence_layer", tf_.get(), node_, nullptr);
+    layers_.addPlugin(std::shared_ptr<Layer>(fence_layer_));
+
+    // Initialize layered costmap with default size (20x20 cells at 0.1m, origin (0, 0))
+    layers_.resizeMap(20, 20, 0.1, 0.0, 0.0);
+  }
+
+  void TearDown() override
+  {
+    fence_layer_->deactivate();
+    fence_layer_.reset();
+    tf_.reset();
+    node_.reset();
+  }
+
+  geometry_msgs::msg::PolygonStamped createSquarePolygon(
+    double min_x, double min_y, double max_x, double max_y,
+    const std::string & frame_id = "map")
+  {
+    geometry_msgs::msg::PolygonStamped poly;
+    poly.header.frame_id = frame_id;
+    poly.header.stamp = node_->now();
+
+    geometry_msgs::msg::Point32 p1, p2, p3, p4;
+    p1.x = min_x; p1.y = min_y;
+    p2.x = max_x; p2.y = min_y;
+    p3.x = max_x; p3.y = max_y;
+    p4.x = min_x; p4.y = max_y;
+
+    poly.polygon.points = {p1, p2, p3, p4};
+    return poly;
+  }
+
+  void updateBoundsAndCosts()
+  {
+    layers_.updateMap(0.0, 0.0, 0.0);
+  }
+
+protected:
+  std::shared_ptr<TestLifecycleNode> node_;
+  std::shared_ptr<nav2::TransformBuffer> tf_;
+  LayeredCostmap layers_;
+  std::shared_ptr<FenceLayer> fence_layer_;
+};
+
+// 1. Ray casting on convex polygon
+TEST_F(FenceLayerTest, testPointInPolygonConvex)
+{
+  FenceLayer layer;
+  // Square from (0,0) to (10,10)
+  std::vector<double> px = {0.0, 10.0, 10.0, 0.0};
+  std::vector<double> py = {0.0, 0.0, 10.0, 10.0};
+  FenceLayerTester::setPolygonDirect(layer, px, py);
+
+  // Center
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 5.0, 5.0));
+  // Near corners inside
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 1.0, 1.0));
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 9.0, 9.0));
+
+  // Outside points
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, -1.0, 5.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 11.0, 5.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 5.0, -1.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 5.0, 11.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 15.0, 15.0));
+}
+
+// 2. Ray casting on concave polygon (U-shape)
+TEST_F(FenceLayerTest, testPointInPolygonConcave)
+{
+  FenceLayer layer;
+  // U-shape polygon
+  // (0,0) -> (10,0) -> (10,10) -> (7,10) -> (7,3) -> (3,3) -> (3,10) -> (0,10)
+  std::vector<double> px = {0.0, 10.0, 10.0, 7.0, 7.0, 3.0, 3.0, 0.0};
+  std::vector<double> py = {0.0, 0.0, 10.0, 10.0, 3.0, 3.0, 10.0, 10.0};
+  FenceLayerTester::setPolygonDirect(layer, px, py);
+
+  // Bottom bar (inside)
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 5.0, 1.5));
+  // Left arm (inside)
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 1.5, 6.0));
+  // Right arm (inside)
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 8.5, 6.0));
+
+  // Cavity in middle of U (outside)
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 5.0, 6.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 5.0, 9.0));
+
+  // Far outside
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, -5.0, 5.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 15.0, 5.0));
+}
+
+// 3. Points on or near polygon edge
+TEST_F(FenceLayerTest, testPointInPolygonOnEdge)
+{
+  FenceLayer layer;
+  std::vector<double> px = {0.0, 10.0, 10.0, 0.0};
+  std::vector<double> py = {0.0, 0.0, 10.0, 10.0};
+  FenceLayerTester::setPolygonDirect(layer, px, py);
+
+  // Slightly inside vs slightly outside
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 0.01, 5.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, -0.01, 5.0));
+  EXPECT_TRUE(FenceLayerTester::isPointInPolygon(layer, 9.99, 5.0));
+  EXPECT_FALSE(FenceLayerTester::isPointInPolygon(layer, 10.01, 5.0));
+}
+
+// 4. Costmap resizes to polygon bounding box + circumscribed radius padding
+TEST_F(FenceLayerTest, testPolygonResize)
+{
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(2.0, 3.0, 8.0, 9.0));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  EXPECT_FALSE(fence_layer_->isCurrent());
+  EXPECT_TRUE(FenceLayerTester::isPolygonUpdated(*fence_layer_));
+
+  updateBoundsAndCosts();
+
+  EXPECT_TRUE(fence_layer_->isCurrent());
+  EXPECT_TRUE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+
+  Costmap2D * master = layers_.getCostmap();
+  double circ_r = layers_.getCircumscribedRadius();
+  double res = master->getResolution();
+  double padding = std::ceil(circ_r / res) * res;
+
+  EXPECT_NEAR(master->getOriginX(), 2.0 - padding, 1e-5);
+  EXPECT_NEAR(master->getOriginY(), 3.0 - padding, 1e-5);
+
+  unsigned int expected_cells_x = static_cast<unsigned int>(
+    std::ceil((8.0 + padding - (2.0 - padding)) / res));
+  unsigned int expected_cells_y = static_cast<unsigned int>(
+    std::ceil((9.0 + padding - (3.0 - padding)) / res));
+
+  EXPECT_EQ(master->getSizeInCellsX(), expected_cells_x);
+  EXPECT_EQ(master->getSizeInCellsY(), expected_cells_y);
+}
+
+// 5. All cells outside polygon are LETHAL_OBSTACLE
+TEST_F(FenceLayerTest, testLethalOutside)
+{
+  // Polygon from (1.0, 1.0) to (4.0, 4.0)
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(1.0, 1.0, 4.0, 4.0));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+
+  Costmap2D * master = layers_.getCostmap();
+  for (unsigned int j = 0; j < master->getSizeInCellsY(); ++j) {
+    for (unsigned int i = 0; i < master->getSizeInCellsX(); ++i) {
+      double wx, wy;
+      master->mapToWorld(i, j, wx, wy);
+      bool inside = (wx > 1.0) && (wx < 4.0) && (wy > 1.0) && (wy < 4.0);
+      if (!inside) {
+        EXPECT_EQ(master->getCost(i, j), LETHAL_OBSTACLE)
+          << "Cell (" << i << ", " << j << ") at world (" << wx << ", " << wy <<
+          ") should be LETHAL";
+      }
+    }
+  }
+}
+
+// 6. Cells inside polygon retain their original cost (not overwritten)
+TEST_F(FenceLayerTest, testInsidePreserved)
+{
+  // Set master costmap default to FREE_SPACE (or a specific value)
+  Costmap2D * master = layers_.getCostmap();
+  master->setDefaultValue(FREE_SPACE);
+
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(1.0, 1.0, 4.0, 4.0));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+
+  // For a cell strictly inside (e.g. wx=2.5, wy=2.5)
+  unsigned int mx, my;
+  ASSERT_TRUE(master->worldToMap(2.5, 2.5, mx, my));
+  EXPECT_EQ(master->getCost(mx, my), FREE_SPACE);
+}
+
+// 7. New polygon arrives, costmap resizes and mask updates
+TEST_F(FenceLayerTest, testPolygonUpdate)
+{
+  // First polygon: [1.0, 1.0] to [3.0, 3.0]
+  auto poly_msg1 = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(1.0, 1.0, 3.0, 3.0));
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg1);
+  updateBoundsAndCosts();
+
+  Costmap2D * master = layers_.getCostmap();
+  unsigned int mx, my;
+  ASSERT_TRUE(master->worldToMap(2.0, 2.0, mx, my));
+  EXPECT_NE(master->getCost(mx, my), LETHAL_OBSTACLE);
+
+  // Second polygon shifted: [5.0, 5.0] to [10.0, 10.0]
+  auto poly_msg2 = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(5.0, 5.0, 10.0, 10.0));
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg2);
+  updateBoundsAndCosts();
+
+  // (2.0, 2.0) is now outside the costmap or outside the new fence
+  if (master->worldToMap(2.0, 2.0, mx, my)) {
+    EXPECT_EQ(master->getCost(mx, my), LETHAL_OBSTACLE);
+  }
+  // (7.0, 7.0) is inside the new polygon
+  ASSERT_TRUE(master->worldToMap(7.0, 7.0, mx, my));
+  EXPECT_NE(master->getCost(mx, my), LETHAL_OBSTACLE);
+}
+
+// 8. Layer is a no-op before first polygon arrives
+TEST_F(FenceLayerTest, testNoPolygon)
+{
+  EXPECT_TRUE(fence_layer_->isCurrent());
+  EXPECT_FALSE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+
+  double min_x = 1e6, min_y = 1e6, max_x = -1e6, max_y = -1e6;
+  fence_layer_->updateBounds(0.0, 0.0, 0.0, &min_x, &min_y, &max_x, &max_y);
+  // Bounds should not have been updated since no polygon received
+  EXPECT_EQ(min_x, 1e6);
+  EXPECT_EQ(max_x, -1e6);
+}
+
+// 9. Layer does nothing when enabled: false
+TEST_F(FenceLayerTest, testDisabled)
+{
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(1.0, 1.0, 4.0, 4.0));
+
+  // Disable layer via dynamic parameter
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("fence_layer.enabled", false)
+  };
+  fence_layer_->activate();
+  auto res = node_->set_parameters(params);
+  EXPECT_TRUE(res[0].successful);
+  EXPECT_FALSE(fence_layer_->isEnabled());
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+
+  double min_x = 1e6, min_y = 1e6, max_x = -1e6, max_y = -1e6;
+  fence_layer_->updateBounds(0.0, 0.0, 0.0, &min_x, &min_y, &max_x, &max_y);
+  EXPECT_EQ(min_x, 1e6);
+}
+
+// 10. Polygon in non-global frame is transformed correctly
+TEST_F(FenceLayerTest, testTfTransform)
+{
+  // Broadcast transform from "odom" to "map": translation x=5.0, y=5.0
+  geometry_msgs::msg::TransformStamped tf_msg;
+  tf_msg.header.stamp = node_->now();
+  tf_msg.header.frame_id = "map";
+  tf_msg.child_frame_id = "odom";
+  tf_msg.transform.translation.x = 5.0;
+  tf_msg.transform.translation.y = 5.0;
+  tf_msg.transform.translation.z = 0.0;
+  tf_msg.transform.rotation.w = 1.0;
+
+  tf_->setTransform(tf_msg, "test_authority", false);
+
+  // Polygon in "odom" frame: [0, 0] to [2, 2] -> transformed to "map": [5, 5] to [7, 7]
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(0.0, 0.0, 2.0, 2.0, "odom"));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+
+  Costmap2D * master = layers_.getCostmap();
+  unsigned int mx, my;
+  // (6.0, 6.0) in "map" should be inside
+  ASSERT_TRUE(master->worldToMap(6.0, 6.0, mx, my));
+  EXPECT_NE(master->getCost(mx, my), LETHAL_OBSTACLE);
+
+  // (1.0, 1.0) in "map" should be outside
+  if (master->worldToMap(1.0, 1.0, mx, my)) {
+    EXPECT_EQ(master->getCost(mx, my), LETHAL_OBSTACLE);
+  }
+}
+
+// 11. Grid extends beyond polygon by at least circumscribed radius
+TEST_F(FenceLayerTest, testPaddingCircumscribedRadius)
+{
+  layers_.setFootprint(nav2_costmap_2d::makeFootprintFromRadius(0.55));
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(0.0, 0.0, 10.0, 10.0));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+
+  Costmap2D * master = layers_.getCostmap();
+  double expected_padding = std::ceil(0.55 / master->getResolution()) * master->getResolution();
+
+  EXPECT_LE(master->getOriginX(), 0.0 - expected_padding);
+  EXPECT_LE(master->getOriginY(), 0.0 - expected_padding);
+}
+
+// 12. Polygon with 3 points works correctly
+TEST_F(FenceLayerTest, testSmallPolygon)
+{
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "map";
+  geometry_msgs::msg::Point32 p1, p2, p3;
+  p1.x = 0.0; p1.y = 0.0;
+  p2.x = 4.0; p2.y = 0.0;
+  p3.x = 2.0; p3.y = 4.0;
+  poly.polygon.points = {p1, p2, p3};
+
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(poly);
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+
+  EXPECT_TRUE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+
+  Costmap2D * master = layers_.getCostmap();
+  unsigned int mx, my;
+  // Centroid (2.0, 1.33) is inside triangle
+  ASSERT_TRUE(master->worldToMap(2.0, 1.33, mx, my));
+  EXPECT_NE(master->getCost(mx, my), LETHAL_OBSTACLE);
+
+  // (0.5, 3.0) is outside triangle
+  ASSERT_TRUE(master->worldToMap(0.5, 3.0, mx, my));
+  EXPECT_EQ(master->getCost(mx, my), LETHAL_OBSTACLE);
+}
+
+// 13. Polygon with < 3 points is rejected
+TEST_F(FenceLayerTest, testInvalidPolygon)
+{
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "map";
+  geometry_msgs::msg::Point32 p1, p2;
+  p1.x = 0.0; p1.y = 0.0;
+  p2.x = 4.0; p2.y = 0.0;
+  poly.polygon.points = {p1, p2};
+
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(poly);
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+
+  EXPECT_FALSE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+  EXPECT_FALSE(FenceLayerTester::isPolygonUpdated(*fence_layer_));
+}
+
+// 14. Reset layer
+TEST_F(FenceLayerTest, testReset)
+{
+  auto poly_msg = std::make_shared<geometry_msgs::msg::PolygonStamped>(
+    createSquarePolygon(1.0, 1.0, 4.0, 4.0));
+
+  FenceLayerTester::triggerPolygonCallback(*fence_layer_, poly_msg);
+  updateBoundsAndCosts();
+  EXPECT_TRUE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+
+  fence_layer_->reset();
+  EXPECT_FALSE(FenceLayerTester::hasReceivedPolygon(*fence_layer_));
+  EXPECT_TRUE(fence_layer_->isCurrent());
+}
+
+// 15. isClearable returns false
+TEST_F(FenceLayerTest, testIsClearable)
+{
+  EXPECT_FALSE(fence_layer_->isClearable());
+}
+
+}  // namespace nav2_costmap_2d
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
## Basic Info

| Info | Value |
| ------ | ----------- |
| Ticket(s) this addresses | #6348 |
| Primary OS tested on | Ubuntu (Docker, ROS Rolling) |
| Robotic platform tested on | Loopback simulation (tb3_loopback_simulation) |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Added a new `FenceLayer` costmap plugin (`CostmapLayer` subclass) that dynamically resizes the global costmap to match a user-defined operational zone polygon, marking all cells outside as `LETHAL_OBSTACLE`.
- Subscribes to a configurable `PolygonStamped` topic (default: `operational_zone`) for runtime zone updates — no custom service messages required.
- Pre-rasterizes an outside-fence boolean mask once per polygon change, so `updateCosts()` does flat array lookups instead of per-cycle ray-casting.
- Transforms incoming polygons to the global frame via `tf2` when the polygon is published in a different frame.
- Pads the costmap by the circumscribed robot radius (rounded to cell boundaries) so the full footprint never clips the fence edge.
- Defers `resizeMap()` to `updateBounds()` (under the `updateMap` lock) using an atomic + mutex double-buffer pattern to avoid race conditions between the subscription callback and the costmap update thread.
- Registered plugin in `costmap_plugins.xml`, added to `CMakeLists.txt`.

## Description of documentation updates required from your changes

- New plugin documentation page for `FenceLayer` on `docs.nav2.org` under Configuration → Costmap Plugins.
- Document the `enabled` (bool) and `polygon_topic` (string) parameters.
- Document the `PolygonStamped` topic interface for setting/updating the fence at runtime.

## Description of how this change was tested

- 15 Google Test unit tests all passing, covering:
  - Cells outside fence → `LETHAL_OBSTACLE`
  - Cells inside fence → preserved (not overwritten)
  - Dynamic polygon update triggers costmap resize
  - No-op before first polygon arrives
  - Disabled layer via dynamic parameter
  - TF transformation from non-global frame
  - Circumscribed radius padding verification
  - Triangle (3-point) polygon
  - Invalid polygon (< 3 points) rejection
  - `reset()` clears all state
  - `isClearable()` returns `false`
- Visually verified via RViz2 in the `tb3_loopback_simulation` environment.

---

## Future work that may be required in bullet points

- Support for multiple concurrent fence zones (vector of polygons)
- Optional configurable cost value for outside-fence cells (instead of hardcoded `LETHAL_OBSTACLE`)
- Convex hull optimization for faster point-in-polygon on simple zones
- Integration example in `nav2_bringup` params / launch files

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.