### PR TITLE
Fix direction-dependent traversal cost in theta* planner

### DIFF
--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -33,17 +33,25 @@ The parameters were set to - `w_euc_cost: 1.0`, `w_traversal_cost: 5.0` and the 
 
 **euc_cost(a,b)** - euclidean distance between the node type 'a' and type 'b'
 
-**costmap_cost(a,b)** - the costmap traversal cost (ranges from 0 - 252, 255 = unknown value) between the node type 'a' and type 'b'
+**costmap_cost(a)** - the costmap traversal cost of the cell at node 'a' (ranges from 0 - 252; an unknown cell is charged as 253)
 
 ### Cost function
 ```
-g(neigh) = g(curr) + w_euc_cost*euc_cost(curr, neigh) + w_traversal_cost*(costmap_cost(curr,neigh)/LETHAL_COST)^2
+g(neigh) = g(curr) + [w_euc_cost + w_traversal_cost*(costmap_cost(neigh)/MAX_NON_OBSTACLE_COST)^2] * euc_cost(curr, neigh)
 h(neigh) = w_heuristic_cost * euc_cost(neigh, goal)
 f(neigh) = g(neigh) + h(neigh)
 ```
-Because of how the program works when the 'neigh' init_rclcpp is to be expanded, depending
+Because of how the program works when the 'neigh' node is to be expanded, depending
 on the result of the LOS check, (if the LOS check returns true) the value of g(neigh) might change to `g(par) +
-w1*euc_cost(par, neigh) + w2*(costmap(par,neigh)/LETHAL_COST)^2`
+[w_euc_cost + w_traversal_cost*mean_over_cells((costmap_cost/MAX_NON_OBSTACLE_COST)^2)] * euc_cost(par, neigh)`,
+where the mean is taken over the cells the Bresenham trace from 'par' to 'neigh' visits, each
+weighted by the length of the step across it. It is a sampled average rather than an exact
+integral: a cell the line clips but the trace steps past is not charged.
+
+Both terms are charged per unit distance rather than once per step taken, so neither depends on
+the direction of travel relative to the grid axes. The line-of-sight traversal cost is a
+Bresenham-sampled average normalised to the length of the chord, which over a region of uniform
+cost equals the cost density times that length exactly.
 
 ## Parameters
 The parameters of the planner are :
@@ -65,7 +73,7 @@ planner_server:
 ## Usage Notes
 
 ### Tuning the Parameters
-Before starting off, do note that the costmap_cost(curr,neigh) component after being operated (ie before being multiplied to its parameter and being substituted in g(init_rclcpp)) varies from 0 to 1.
+Before starting off, do note that the costmap_cost(curr,neigh) component after being operated (ie before being multiplied to its parameter and being substituted in g(neigh)) varies from 0 to 1.
 
 This planner uses the costs associated with each cell from the `global_costmap` as a measure of the point's proximity to the obstacles. Providing a gentle potential field that covers the entirety of the region (thus leading to only small pocket like regions of cost = 0) is recommended in order to achieve paths that pass through the middle of the spaces. A good starting point could be to set the `inflation_layer`'s parameters as - `cost_scaling_factor: 10.0`, `inflation_radius: 5.5` and then decrease the value of `cost_scaling_factor` to achieve the said potential field.
 

--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -48,6 +48,9 @@ where the mean is taken over the cells the Bresenham trace from 'par' to 'neigh'
 weighted by the length of the step across it. It is a sampled average rather than an exact
 integral: a cell the line clips but the trace steps past is not charged.
 
+Free space (a costmap cost of 0) carries no traversal cost at all, so the length of a path is
+charged solely through the euclidean term.
+
 Both terms are charged per unit distance rather than once per step taken, so neither depends on
 the direction of travel relative to the grid axes. The line-of-sight traversal cost is a
 Bresenham-sampled average normalised to the length of the chord, which over a region of uniform

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -203,13 +203,13 @@ protected:
     }
   }
 
-  /*
-   * @brief this function scales the costmap cost by shifting the origin to 25 and then multiply
-   *           the actual costmap cost by 0.9 to keep the output in the range of [25, 255)
+  /**
+   * @brief the traversal cost density of a cell, in raw costmap units
+   * @return the cost density thus obtained
    */
   inline double getCost(const int & cx, const int & cy) const
   {
-    return 26 + 0.9 * costmap_->getCost(cx, cy);
+    return costmap_->getCost(cx, cy);
   }
 
   /**

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -182,9 +182,11 @@ protected:
   /**
    * @brief it is an overloaded function to ease the cost calculations while performing the LOS check
    * @param cost denotes the total straight line traversal cost; it adds the traversal cost for the node (cx, cy) at every instance; it is also being returned
-   * @return false if the traversal cost is greater than the MAX_NON_OBSTACLE_COST and true otherwise
+   * @param step_length the length of the step taken across this cell, in cell widths; the cell's
+   *          traversal cost is charged in proportion to it
+   * @return true if the cell may be traversed, false otherwise
    */
-  bool isSafe(const int & cx, const int & cy, double & cost) const
+  bool isSafe(const int & cx, const int & cy, double & cost, const double & step_length) const
   {
     double curr_cost = getCost(cx, cy);
     if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && params_->allow_unknown) ||
@@ -194,7 +196,7 @@ protected:
         curr_cost = OCCUPIED_COST - 1;
       }
       cost += params_->w_traversal_cost * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
-        MAX_NON_OBSTACLE_COST;
+        MAX_NON_OBSTACLE_COST * step_length;
       return true;
     } else {
       return false;

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -188,13 +188,10 @@ protected:
    */
   bool isSafe(const int & cx, const int & cy, double & cost, const double & step_length) const
   {
-    double curr_cost = getCost(cx, cy);
+    const double curr_cost = getCost(cx, cy);
     if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && params_->allow_unknown) ||
       curr_cost <= MAX_NON_OBSTACLE_COST)
     {
-      if (costmap_->getCost(cx, cy) == UNKNOWN_COST) {
-        curr_cost = OCCUPIED_COST - 1;
-      }
       cost += params_->w_traversal_cost * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
         MAX_NON_OBSTACLE_COST * step_length;
       return true;
@@ -205,11 +202,14 @@ protected:
 
   /**
    * @brief the traversal cost density of a cell, in raw costmap units
+   *           unknown cells are charged as near-obstacle, so that traversing them is discouraged
+   *           wherever allow_unknown permits it at all
    * @return the cost density thus obtained
    */
   inline double getCost(const int & cx, const int & cy) const
   {
-    return costmap_->getCost(cx, cy);
+    const unsigned char cost = costmap_->getCost(cx, cy);
+    return cost == UNKNOWN_COST ? OCCUPIED_COST - 1 : cost;
   }
 
   /**

--- a/nav2_theta_star_planner/src/parameter_handler.cpp
+++ b/nav2_theta_star_planner/src/parameter_handler.cpp
@@ -19,6 +19,8 @@
 #include <vector>
 #include <utility>
 
+#include <cmath>
+
 #include "nav2_theta_star_planner/parameter_handler.hpp"
 #include "nav2_core/controller_exceptions.hpp"
 
@@ -27,6 +29,23 @@ namespace nav2_theta_star_planner
 
 using nav2::declare_parameter_if_not_declared;
 using rcl_interfaces::msg::ParameterType;
+
+namespace
+{
+/**
+ * @brief Reject a weight that is not a positive finite number, warning and substituting a default
+ */
+void applyPositiveFiniteDefault(
+  const rclcpp::Logger & logger, const std::string & name, double & value, const double fallback)
+{
+  if (!std::isfinite(value) || value <= 0.0) {
+    RCLCPP_WARN(
+      logger, "Your value for - %s was %f, it must be a positive finite number, "
+      "and is now set to %f", name.c_str(), value, fallback);
+    value = fallback;
+  }
+}
+}  // namespace
 
 ParameterHandler::ParameterHandler(
   const nav2::LifecycleNode::SharedPtr & node,
@@ -45,8 +64,11 @@ ParameterHandler::ParameterHandler(
     plugin_name_ + ".allow_unknown", true);
   params_.w_euc_cost = node->declare_or_get_parameter(
     plugin_name_ + ".w_euc_cost", 1.0);
+  applyPositiveFiniteDefault(logger_, plugin_name_ + ".w_euc_cost", params_.w_euc_cost, 1.0);
   params_.w_traversal_cost = node->declare_or_get_parameter(
     plugin_name_ + ".w_traversal_cost", 2.0);
+  applyPositiveFiniteDefault(
+    logger_, plugin_name_ + ".w_traversal_cost", params_.w_traversal_cost, 2.0);
   params_.w_heuristic_cost = params_.w_euc_cost < 1.0 ? params_.w_euc_cost : 1.0;
   params_.terminal_checking_interval = node->declare_or_get_parameter(
     plugin_name_ + ".terminal_checking_interval", 5000);
@@ -66,10 +88,10 @@ rcl_interfaces::msg::SetParametersResult ParameterHandler::validateParameterUpda
       continue;
     }
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      if (parameter.as_double() <= 0.0) {
+      if (!std::isfinite(parameter.as_double()) || parameter.as_double() <= 0.0) {
         RCLCPP_WARN(
         logger_, "The value of parameter '%s' is incorrectly set to %f, "
-        "it should be >0. Ignoring parameter update.",
+        "it should be a positive finite number. Ignoring parameter update.",
         param_name.c_str(), parameter.as_double());
         result.successful = false;
       }
@@ -109,6 +131,9 @@ ParameterHandler::updateParametersCallback(
     } else if (param_type == ParameterType::PARAMETER_DOUBLE) {
       if (param_name == plugin_name_ + ".w_euc_cost") {
         params_.w_euc_cost = parameter.as_double();
+        // w_heuristic_cost is derived from w_euc_cost and must be recomputed with it, or the
+        // heuristic stops matching the cost function and can exceed the true remaining cost.
+        params_.w_heuristic_cost = params_.w_euc_cost < 1.0 ? params_.w_euc_cost : 1.0;
       } else if (param_name == plugin_name_ + ".w_traversal_cost") {
         params_.w_traversal_cost = parameter.as_double();
       }

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -125,8 +125,9 @@ void ThetaStar::setNeighbors(const tree_node * curr_data)
       continue;
     }
 
-    g_cost = curr_data->g + getEuclideanCost(curr_data->x, curr_data->y, mx, my) +
-      getTraversalCost(mx, my);
+    // Charged per unit distance. moves[0..3] are axial, moves[4..7] diagonal.
+    const double step_length = i < 4 ? 1.0 : M_SQRT2;
+    g_cost = curr_data->g + (params_->w_euc_cost + getTraversalCost(mx, my)) * step_length;
 
     m_id = getIndex(mx, my);
 
@@ -185,13 +186,17 @@ bool ThetaStar::losCheck(
   int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
   int dy = abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
   int cx = x0, cy = y0, e = dx - dy;
+  double stepped_length = 0.0;
 
   while (cx != x1 || cy != y1) {
-    if (!isSafe(cx, cy, sl_cost)) {
+    const int e2 = 2 * e;
+    const bool diagonal = e2 > -dy && e2 <= dx;
+    const double step_length = diagonal ? M_SQRT2 : 1.0;
+    if (!isSafe(cx, cy, sl_cost, step_length)) {
       return false;
     }
-    int e2 = 2 * e;
-    if (e2 > -dy && e2 <= dx) {
+    stepped_length += step_length;
+    if (diagonal) {
       if (!isSafe(cx + sx, cy) || !isSafe(cx, cy + sy)) {
         return false;
       }
@@ -205,6 +210,13 @@ bool ThetaStar::losCheck(
       cy += sy;
       e += dx;
     }
+  }
+
+  // The steps sum to the staircase length rather than the length of the line, so normalise the
+  // total to the chord. The result is a Bresenham-sampled average of the cost density over the
+  // chord, exact where the density is uniform.
+  if (stepped_length > 0.0) {
+    sl_cost *= std::hypot(dx, dy) / stepped_length;
   }
 
   return true;

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -13,6 +13,8 @@
 //  limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <vector>
 #include "rclcpp/rclcpp.hpp"
@@ -38,6 +40,8 @@ public:
   }
 
   bool uwithinLimits(const int & cx, const int & cy) {return withinLimits(cx, cy);}
+
+  double ugetTraversalCost(const int & cx, const int & cy) {return getTraversalCost(cx, cy);}
 
   bool uisGoal(const tree_node & this_node) {return isGoal(this_node);}
 
@@ -257,6 +261,245 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
     life_node->get_node_base_interface(),
     results);
   EXPECT_EQ(life_node->get_parameter("test.w_euc_cost").as_double(), 1.0);
+}
+
+/// The traversal cost is charged per unit distance, so two straight lines of equal metric length
+/// accrue equal cost whatever their bearing. Charging once per Bresenham step regardless of
+/// whether the step is axial or diagonal makes a 45-degree line about 29% cheaper per metre.
+TEST(ThetaStarTest, test_los_cost_is_direction_independent) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarDirectionTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  /// A uniform costmap: every cell has the same cost density, so the cost of a line is exactly
+  /// proportional to its length and any residual bearing dependence is the defect under test.
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(120, 120, 1.0, 0.0, 0.0, 100);
+  params->w_traversal_cost = 2.0;
+
+  const int line_length = 100;
+  double axial_cost = 0.0, diagonal_cost = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 5 + line_length, 5, axial_cost));
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 5 + line_length, 5 + line_length, diagonal_cost));
+
+  EXPECT_NEAR(
+    axial_cost / line_length,
+    diagonal_cost / std::hypot(line_length, line_length),
+    1e-9);
+
+  /// Axial and 45-degree are the two bearings at which the Bresenham staircase happens to be the
+  /// same length as the line, so an off-axis bearing is needed to detect a charge that follows the
+  /// staircase rather than the line.
+  double oblique_cost = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 5 + line_length, 5 + line_length / 2, oblique_cost));
+  EXPECT_NEAR(
+    axial_cost / line_length,
+    oblique_cost / std::hypot(line_length, line_length / 2),
+    1e-9);
+
+  delete planner_->costmap_;
+}
+
+/// Each expansion step is charged by its metric length, so on a uniform costmap the planner
+/// reaches an off-axis goal by a straight path rather than one bowed towards the grid diagonals.
+TEST(ThetaStarTest, test_path_does_not_bow_on_uniform_costmap) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarBowTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(200, 200, 1.0, 0.0, 0.0, 100);
+  params->w_euc_cost = 1.0;
+  params->w_traversal_cost = 2.0;
+  params->w_heuristic_cost = 1.0;
+  params->how_many_corners = 8;
+
+  /// An off-grid bearing, so neither the axial nor the diagonal step is favoured outright.
+  geometry_msgs::msg::PoseStamped start, goal;
+  start.pose.position.x = 10;
+  start.pose.position.y = 10;
+  start.pose.orientation.w = 1.0;
+  goal.pose.position.x = 190;
+  goal.pose.position.y = 120;
+  goal.pose.orientation.w = 1.0;
+  planner_->setStartAndGoal(start, goal);
+
+  std::vector<coordsW> path;
+  ASSERT_TRUE(planner_->runAlgo(path));
+  ASSERT_GE(static_cast<int>(path.size()), 2);
+
+  double length = 0.0;
+  for (size_t i = 1; i < path.size(); i++) {
+    length += std::hypot(path[i].x - path[i - 1].x, path[i].y - path[i - 1].y);
+  }
+  const double chord = std::hypot(
+    path.back().x - path.front().x, path.back().y - path.front().y);
+  /// A path bowed towards the diagonals is measurably longer than its own chord.
+  EXPECT_LT(length / chord, 1.001);
+
+  delete planner_->costmap_;
+}
+
+/// w_euc_cost is the only thing charging for path length, so a non-positive value makes every
+/// path through free space cost the same and the planner returns arbitrary ones. The dynamic
+/// reconfigure path already rejects non-positive doubles; the load path must agree.
+/// w_heuristic_cost is derived from w_euc_cost and has to track it, including on reconfigure,
+/// or the heuristic can exceed the true remaining cost and the search stops being admissible.
+TEST(ThetaStarPlanner, test_w_euc_cost_validation) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarEucValidationNode");
+  auto plugin_name = std::string("test");
+  node->declare_parameter(plugin_name + ".w_euc_cost", rclcpp::ParameterValue(0.0));
+
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+
+  /// A non-positive w_euc_cost loaded from config is overridden rather than accepted.
+  EXPECT_GT(params->w_euc_cost, 0.0);
+  EXPECT_GT(params->w_heuristic_cost, 0.0);
+
+  /// and the heuristic weight tracks w_euc_cost when it changes at runtime.
+  auto result = node->set_parameters(
+    {rclcpp::Parameter(plugin_name + ".w_euc_cost", 0.5)});
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0].successful);
+  EXPECT_DOUBLE_EQ(params->w_euc_cost, 0.5);
+  EXPECT_DOUBLE_EQ(params->w_heuristic_cost, 0.5);
+
+  /// A non-positive value is still refused on reconfigure.
+  auto bad = node->set_parameters(
+    {rclcpp::Parameter(plugin_name + ".w_euc_cost", 0.0)});
+  ASSERT_EQ(bad.size(), 1u);
+  EXPECT_FALSE(bad[0].successful);
+  EXPECT_DOUBLE_EQ(params->w_euc_cost, 0.5);
+
+  /// A non-finite value passes a bare "<= 0.0" test, so it must be refused explicitly.
+  auto nan_result = node->set_parameters(
+    {rclcpp::Parameter(plugin_name + ".w_euc_cost", std::nan(""))});
+  ASSERT_EQ(nan_result.size(), 1u);
+  EXPECT_FALSE(nan_result[0].successful);
+  auto inf_result = node->set_parameters(
+    {rclcpp::Parameter(
+      plugin_name + ".w_euc_cost", std::numeric_limits<double>::infinity())});
+  ASSERT_EQ(inf_result.size(), 1u);
+  EXPECT_FALSE(inf_result[0].successful);
+  EXPECT_DOUBLE_EQ(params->w_euc_cost, 0.5);
+}
+
+/// w_traversal_cost is validated on reconfigure but was not at load. With the free-space floor
+/// gone a negative weight makes the per-unit charge negative on high-cost cells, which is a
+/// negative edge weight and invalidates the search ordering.
+TEST(ThetaStarPlanner, test_w_traversal_cost_validation) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarTraversalValidationNode");
+  auto plugin_name = std::string("test");
+  node->declare_parameter(plugin_name + ".w_traversal_cost", rclcpp::ParameterValue(-2.0));
+
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+
+  EXPECT_GT(params->w_traversal_cost, 0.0);
+}
+
+/// Non-finite weights pass a bare "<= 0.0" test, so the load path must reject them explicitly,
+/// just as the reconfigure path does.
+TEST(ThetaStarPlanner, test_non_finite_weight_at_load) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarNonFiniteLoadNode");
+  auto plugin_name = std::string("test");
+  node->declare_parameter(plugin_name + ".w_euc_cost", rclcpp::ParameterValue(std::nan("")));
+  node->declare_parameter(
+    plugin_name + ".w_traversal_cost",
+    rclcpp::ParameterValue(std::numeric_limits<double>::infinity()));
+
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+
+  EXPECT_TRUE(std::isfinite(params->w_euc_cost));
+  EXPECT_GT(params->w_euc_cost, 0.0);
+  EXPECT_TRUE(std::isfinite(params->w_traversal_cost));
+  EXPECT_GT(params->w_traversal_cost, 0.0);
+  EXPECT_TRUE(std::isfinite(params->w_heuristic_cost));
+}
+
+/// Free space carries no traversal cost, so the traversal term contributes nothing to a line
+/// that crosses only free cells, and the cost of such a line is charged solely by w_euc_cost.
+/// The safety cutoff also becomes consistent: both isSafe overloads then admit exactly the same
+/// set of cells, where the 26 + 0.9 remap made the line-of-sight one stop a cost level earlier.
+TEST(ThetaStarTest, test_free_space_carries_no_traversal_cost) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarFreeSpaceTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(120, 120, 1.0, 0.0, 0.0, 0);
+  params->w_traversal_cost = 2.0;
+
+  double sl_cost = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 105, 5, sl_cost));
+  EXPECT_DOUBLE_EQ(sl_cost, 0.0);
+
+  /// A uniform non-free cost is still charged at its analytic density per unit distance.
+  for (int i = 0; i < 120; i++) {
+    for (int j = 0; j < 120; j++) {
+      planner_->costmap_->setCost(i, j, 126);
+    }
+  }
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 105, 5, sl_cost));
+  EXPECT_NEAR(sl_cost / 100.0, 2.0 * (126.0 / 252.0) * (126.0 / 252.0), 1e-9);
+
+  /// The highest non-obstacle cost is admitted by both overloads, not just the plain one.
+  planner_->costmap_->setCost(50, 5, MAX_NON_OBSTACLE_COST);
+  EXPECT_TRUE(planner_->isSafe(50, 5));
+  EXPECT_TRUE(planner_->ulosCheck(5, 5, 105, 5, sl_cost));
+
+  delete planner_->costmap_;
+}
+
+/// An unknown cell is charged as near-obstacle by both cost sites. Reading the raw costmap value
+/// at one site and the clamped value at the other made the same cell cost different amounts
+/// depending on whether it was reached by an expansion step or crossed by a line-of-sight check.
+TEST(ThetaStarTest, test_unknown_cost_agrees_between_cost_sites) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarUnknownTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(120, 120, 1.0, 0.0, 0.0, UNKNOWN_COST);
+  params->w_traversal_cost = 2.0;
+  params->allow_unknown = true;
+
+  /// The per-cell charge the line-of-sight check makes, recovered per unit distance.
+  double sl_cost = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(5, 5, 105, 5, sl_cost));
+  const double los_charge = sl_cost / 100.0;
+
+  /// and the charge an expansion step makes for the same cell.
+  const double step_charge = planner_->ugetTraversalCost(50, 50);
+
+  EXPECT_NEAR(los_charge, step_charge, 1e-9);
+  /// both being the near-obstacle value, not the raw UNKNOWN_COST of 255
+  const double expected = 2.0 *
+    ((OCCUPIED_COST - 1) / static_cast<double>(MAX_NON_OBSTACLE_COST)) *
+    ((OCCUPIED_COST - 1) / static_cast<double>(MAX_NON_OBSTACLE_COST));
+  EXPECT_NEAR(step_charge, expected, 1e-9);
+
+  delete planner_->costmap_;
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | n/a |
| Primary OS tested on | ubuntu (containerized) |
| Robotic platform tested on | proprietary vessel(kilted), test harness (rolling) |
| Does this PR contain AI generated software? | Yes (unsure how I was supposed to mark it) |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

I spotted this problem running on kilted where I noticed that the planner wouldn't give straight paths in situations it obviously should have. This was on kilted and didn't include the LOS changes that are on rolling. This version of the fix has only been tested in using unit tests and a few adhoc scripts since I don't have rolling on any vessels at the moment.

- Changed traversal cost to be charged per unit distance instead of per step.
- Update w_heuristic_cost when w_euc_cost changes at runtime
- Apply the same validation to w_euc_cost and w_traversal_cost at load as gets applied at runtime
- Normalized unknown cell cost - LOS check was clamping to OCCUPIED_COST-1, moved clamp into getCost
- Removed the fixed cost floor
- Normalized LOS charge length by the chord length

Regarding the cost floor removal, I am not exactly sure why it was there to begin with (it looks like it was there from the beginning, but I saw no explained rational behind it), but removing it makes the heuristic exact in free space since the true cost per meter becomes exactly w_euc_cost. This has the added benefit of improving performance whenever w_euc_cost <= 1. However, this does affect people's tuning, so I had mixed feelings about including it in this review. I figured I'd just include it and you can tell me if it needs to be removed

## Description of documentation updates required from your changes

Not sure where it would go, but w_euc_cost of 0.0 is now rejected, so there might be a migration guide. Really both w_euc_cost and w_traversal_cost must be positive finite numbers.

## Description of how this change was tested

As I mentioned, these problems were originally tested on kilted. The observed problem was that paths that should be straight bowed out to one side. The changes on kilted (independent of the LOS fix - #5908) were tested and showed that we could now generate straight paths when there was genuinely no cost.

On rolling:
- Attached unit tests
- nav2_system_tests

Note that I restructured my commits so all the added unit tests are front-loaded so its easy enough to go and see them failing without these changes.

---

## Future work that may be required in bullet points

- #5908 added corner checks to the losCheck that isn't present in setNeighbors. Its not clear if that was intentional or not.
- The currentLOS charge is a Bresenham-sampled average normalized to the chord. This is an approximation when the costmap is not uniform and could be improved with something more precise. 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
