### PR TITLE
Fix Theta* skipping expansion of the last popped open-set node

### DIFF
--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -54,11 +54,12 @@ bool ThetaStar::generatePath(std::vector<coordsW> & raw_path, std::function<bool
     src_g_cost + src_h_cost};
   queue_.push({&nodes_data_[index_generated_]});
   addIndex(src_.x, src_.y, &nodes_data_[index_generated_]);
-  tree_node * curr_data = &nodes_data_[index_generated_];
   index_generated_++;
   nodes_opened = 0;
 
   while (!queue_.empty()) {
+    tree_node * curr_data = queue_.top();
+    queue_.pop();
     nodes_opened++;
 
     if (nodes_opened % params_->terminal_checking_interval == 0 && cancel_checker()) {
@@ -67,25 +68,17 @@ bool ThetaStar::generatePath(std::vector<coordsW> & raw_path, std::function<bool
     }
 
     if (isGoal(*curr_data)) {
-      break;
+      backtrace(raw_path, curr_data);
+      clearQueue();
+      return true;
     }
 
     resetParent(curr_data);
     setNeighbors(curr_data);
-
-    curr_data = queue_.top();
-    queue_.pop();
   }
 
-  if (queue_.empty()) {
-    raw_path.clear();
-    return false;
-  }
-
-  backtrace(raw_path, curr_data);
-  clearQueue();
-
-  return true;
+  raw_path.clear();
+  return false;
 }
 
 void ThetaStar::resetParent(tree_node * curr_data)


### PR DESCRIPTION
Fixes #6398

`generatePath` expanded the current node before popping the next open-set
node. After the last remaining node was popped, the queue was empty so the
loop exited without `setNeighbors` or `isGoal` on that node.

This could return a false no-path when that node was the goal or the only
8-connected gateway out of a pocket.

Pop the next node at the start of the loop, then expand or accept it as the
goal. Keep the existing `cancel_checker` handling.