### PR TITLE
feat: return to dock staging pose on failure

### DIFF
--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -263,18 +263,6 @@ void DockingServer::dockRobot()
         tf2::getYaw(staging_pose.pose.orientation) + M_PI);
     }
 
-    auto reset_approach = [this, dock, dock_backward, goal, result, &staging_pose]() -> bool {
-        if (resetApproach(staging_pose, dock_backward)) {
-          return true;
-        }
-        // Cancelled, preempted, or shutting down
-        publishZeroVelocity();
-        dock->plugin->stopDetectionProcess();
-        stashDockData(goal->use_dock_id, dock, false);
-        docking_action_server_->terminate_all(result);
-        return false;
-      };
-
     // Docking control loop: while not docked, run controller
     while (rclcpp::ok()) {
       try {
@@ -313,13 +301,13 @@ void DockingServer::dockRobot()
       } catch (opennav_docking_core::DockingException & e) {
         if (++num_retries_ > params_->max_retries) {
           RCLCPP_ERROR(get_logger(), "Failed to dock, all retries have been used");
-          try {  // swallow new exceptions, so as to report original failure
-            if (!reset_approach()) {
-              return;
+          if (params_->max_retries > 0) {
+            try {  // swallow new exceptions, so as to report original failure
+              (void) resetApproach(staging_pose, dock_backward);
+            } catch (const std::exception & ex) {
+              RCLCPP_ERROR(
+                get_logger(), "Failed to return to staging pose: %s", ex.what());
             }
-          } catch (const std::exception & ex) {
-            RCLCPP_ERROR(
-              get_logger(), "Failed to return to staging pose: %s", ex.what());
           }
           throw;
         }
@@ -327,7 +315,12 @@ void DockingServer::dockRobot()
       }
 
       // Reset to staging pose to try again
-      if (!reset_approach()) {
+      if (!resetApproach(staging_pose, dock_backward)) {
+        // Cancelled, preempted, or shutting down
+        publishZeroVelocity();
+        dock->plugin->stopDetectionProcess();
+        stashDockData(goal->use_dock_id, dock, false);
+        docking_action_server_->terminate_all(result);
         return;
       }
       RCLCPP_INFO(get_logger(), "Returned to staging pose, attempting docking again");

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -263,8 +263,19 @@ void DockingServer::dockRobot()
         tf2::getYaw(staging_pose.pose.orientation) + M_PI);
     }
 
+    auto reset_approach = [this, dock, dock_backward, goal, result, &staging_pose]() -> bool {
+        if (resetApproach(staging_pose, dock_backward)) {
+          return true;
+        }
+        // Cancelled, preempted, or shutting down
+        publishZeroVelocity();
+        dock->plugin->stopDetectionProcess();
+        stashDockData(goal->use_dock_id, dock, false);
+        docking_action_server_->terminate_all(result);
+        return false;
+      };
+
     // Docking control loop: while not docked, run controller
-    rclcpp::Time dock_contact_time;
     while (rclcpp::ok()) {
       try {
         // Perform a 180º to face away from the dock if needed
@@ -302,18 +313,21 @@ void DockingServer::dockRobot()
       } catch (opennav_docking_core::DockingException & e) {
         if (++num_retries_ > params_->max_retries) {
           RCLCPP_ERROR(get_logger(), "Failed to dock, all retries have been used");
+          try {  // swallow new exceptions, so as to report original failure
+            if (!reset_approach()) {
+              return;
+            }
+          } catch (const std::exception & ex) {
+            RCLCPP_ERROR(
+              get_logger(), "Failed to return to staging pose: %s", ex.what());
+          }
           throw;
         }
         RCLCPP_WARN(get_logger(), "Docking failed, will retry: %s", e.what());
       }
 
       // Reset to staging pose to try again
-      if (!resetApproach(staging_pose, dock_backward)) {
-        // Cancelled, preempted, or shutting down
-        publishZeroVelocity();
-        dock->plugin->stopDetectionProcess();
-        stashDockData(goal->use_dock_id, dock, false);
-        docking_action_server_->terminate_all(result);
+      if (!reset_approach()) {
         return;
       }
       RCLCPP_INFO(get_logger(), "Returned to staging pose, attempting docking again");

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -303,7 +303,7 @@ void DockingServer::dockRobot()
           RCLCPP_ERROR(get_logger(), "Failed to dock, all retries have been used");
           if (params_->max_retries > 0) {
             try {  // swallow new exceptions, so as to report original failure
-              (void) resetApproach(staging_pose, dock_backward);
+              resetApproach(staging_pose, dock_backward);
             } catch (const std::exception & ex) {
               RCLCPP_ERROR(
                 get_logger(), "Failed to return to staging pose: %s", ex.what());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6399 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | ros iron simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* if all docking retries have failed, then return to the dock staging pose before reporting failure
* swallow any new exceptions that may occur, in order to report the original docking failure reason

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
This PR merely adds predictable behavior in case of docking failure.

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
Tested on simulation only, with an older `docking_server.cpp` version.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.

