### PR TITLE
fix: handle single-pose path concatenation correctly (#6404)

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -438,11 +438,12 @@ void PlannerServer::computePlanThroughPoses()
 
       // Concatenate paths together, but skip the first pose of subsequent paths
       // to avoid duplicating the connection point
-      if (i == 0) {
-        // First path: add all poses
+      size_t curr_path_size = curr_path.poses.size();
+      if (i == 0 || curr_path_size == 1) {
+        // First path or single-posed path: add all poses
         concat_path.poses.insert(
           concat_path.poses.end(), curr_path.poses.begin(), curr_path.poses.end());
-      } else if (curr_path.poses.size() > 1) {
+      } else if (curr_path_size > 1) {
         // Subsequent paths: skip the first pose to avoid duplication
         concat_path.poses.insert(
           concat_path.poses.end(), curr_path.poses.begin() + 1, curr_path.poses.end());


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6404 |
| Primary OS tested on | WSL - Ubuntu 24.04 |
| Robotic platform tested on | Custom Gazebo Simulation of a Ackermann Vehicle |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed planner_server handling single-pose path concatention

## Description of documentation updates required from your changes

* None

## Description of how this change was tested

* I run gazebo simulation over 4 hours with a looped mission with a custom planner (Passthrough Planner).
* Performed linting validation using `colcon test --packages-select nav2_planner`

---

## Future work that may be required in bullet points

* None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
