### PR TITLE
fix: handle single-pose path concatenation correctly (#6404)

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -449,11 +449,12 @@ void PlannerServer::computePlanThroughPoses()
 
       // Concatenate paths together, but skip the first pose of subsequent paths
       // to avoid duplicating the connection point
-      if (i == 0) {
-        // First path: add all poses
+      size_t curr_path_size = curr_path.poses.size();
+      if (i == 0 || curr_path_size == 1) {
+        // First path or single-posed path: add all poses
         concat_path.poses.insert(
           concat_path.poses.end(), curr_path.poses.begin(), curr_path.poses.end());
-      } else if (curr_path.poses.size() > 1) {
+      } else if (curr_path_size > 1) {
         // Subsequent paths: skip the first pose to avoid duplication
         concat_path.poses.insert(
           concat_path.poses.end(), curr_path.poses.begin() + 1, curr_path.poses.end());


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6404 |
| Primary OS tested on | WSL - Ubuntu 24.04 |
| Robotic platform tested on | Custom Gazebo Simulation of a Ackermann Vehicle |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed planner_server handling single-pose path concatention

## Description of documentation updates required from your changes

* None

## Description of how this change was tested

* `rosdep install --ignore-src -r --rosdistro jazzy --from-path .` and `colcon build --packages-up-to nav2_planner`
* I run gazebo simulation over 4 hours with a looped mission with a custom planner (Passthrough Planner).
* Performed linting validation using `colcon test --packages-select nav2_planner`

---

## Future work that may be required in bullet points

* None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.

---

## Future work that may be required in bullet points
**It's not related with this PR, but the issues above broke the build**

* Add to package.xml `ros-jazzy-ament-cmake-google-benchmark`` depency for package nav2_costmap_2d. Despide of installing dependencies with rosdep, it was missing.
```sh
--- stderr: nav2_costmap_2d                                                                              
CMake Error at test/benchmark/CMakeLists.txt:1 (find_package):
  By not providing "Findament_cmake_google_benchmark.cmake" in
  CMAKE_MODULE_PATH this project has asked CMake to find a package
  configuration file provided by "ament_cmake_google_benchmark", but CMake
  did not find one.

  Could not find a package configuration file provided by
  "ament_cmake_google_benchmark" with any of the following names:

    ament_cmake_google_benchmarkConfig.cmake
    ament_cmake_google_benchmark-config.cmake

  Add the installation prefix of "ament_cmake_google_benchmark" to
  CMAKE_PREFIX_PATH or set "ament_cmake_google_benchmark_DIR" to a directory
  containing one of the above files.  If "ament_cmake_google_benchmark"
  provides a separate development package or SDK, be sure it has been
  installed.


gmake: *** [Makefile:1461: cmake_check_build_system] Error 1
```
* Behavior Tree CPP verison required to build is [4.9.1](https://github.com/BehaviorTree/BehaviorTree.CPP/tree/4.9.1), however it is not available yet on Ubuntu 24.04 (ros-jazzy-behaviortree-cpp is already the newest version (4.9.0-1noble.20260615.161133).)
```sh
error: ‘class BT::Tree’ has no member named ‘wakeUpSignal’; did you mean ‘emitWakeUpSignal’?
   64 |     auto wake_up = tree_->wakeUpSignal();
      |                           ^~~~~~~~~~~~
      |                           emitWakeUpSignal
gmake[2]: *** [CMakeFiles/nav2_behavior_tree.dir/build.make:76: CMakeFiles/nav2_behavior_tree.dir/src/behavior_tree_engine.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:548: CMakeFiles/nav2_behavior_tree.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< nav2_behavior_tree [1min 11s, exited with code 2]
```

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
