### PR TITLE
Fix axis_goal_checker when path gets truncated too short

### DIFF
--- a/nav2_controller/include/nav2_controller/plugins/axis_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/axis_goal_checker.hpp
@@ -16,6 +16,7 @@
 #define NAV2_CONTROLLER__PLUGINS__AXIS_GOAL_CHECKER_HPP_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -110,6 +111,9 @@ protected:
   double path_length_tolerance_;
   double direction_estimation_distance_;
   bool is_overshoot_valid_;
+  // Last successfully estimated end-of-path direction; reused when the pruned
+  // plan no longer contains a pose far enough from the goal to estimate it.
+  std::optional<double> cached_end_of_path_yaw_;
   // Dynamic parameters handler
   std::mutex mutex_;
   rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;

--- a/nav2_controller/include/nav2_controller/plugins/axis_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/axis_goal_checker.hpp
@@ -111,8 +111,6 @@ protected:
   double path_length_tolerance_;
   double direction_estimation_distance_;
   bool is_overshoot_valid_;
-  // Last successfully estimated end-of-path direction; reused when the pruned
-  // plan no longer contains a pose far enough from the goal to estimate it.
   std::optional<double> cached_end_of_path_yaw_;
   // Dynamic parameters handler
   std::mutex mutex_;

--- a/nav2_controller/plugins/axis_goal_checker.cpp
+++ b/nav2_controller/plugins/axis_goal_checker.cpp
@@ -82,6 +82,8 @@ void AxisGoalChecker::initialize(
 
 void AxisGoalChecker::reset()
 {
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+  cached_end_of_path_yaw_.reset();
 }
 
 bool AxisGoalChecker::isGoalReached(
@@ -107,72 +109,70 @@ bool AxisGoalChecker::isGoalXYReached(
     return false;
   }
 
-  // Check if we have at least 2 poses to determine path direction
+  // Try to estimate the end-of-path direction from the plan
+  double end_of_path_yaw = 0.0;
+  bool direction_found = false;
   if (transformed_global_plan.poses.size() >= 2) {
-    const geometry_msgs::msg::Pose * before_goal_pose_ptr = nullptr;
-    double dx = 0.0;
-    double dy = 0.0;
-
     // Walk back from the goal until a pose is at least direction_estimation_distance_ away
     for (int i = transformed_global_plan.poses.size() - 2; i >= 0; --i) {
       const auto & candidate_pose = transformed_global_plan.poses[i].pose;
-      dx = goal_pose.position.x - candidate_pose.position.x;
-      dy = goal_pose.position.y - candidate_pose.position.y;
+      double dx = goal_pose.position.x - candidate_pose.position.x;
+      double dy = goal_pose.position.y - candidate_pose.position.y;
       double pose_distance = std::hypot(dx, dy);
 
       if (pose_distance >= direction_estimation_distance_) {
-        before_goal_pose_ptr = &candidate_pose;
+        end_of_path_yaw = atan2(dy, dx);
+        cached_end_of_path_yaw_ = end_of_path_yaw;
+        direction_found = true;
         break;
       }
     }
+  }
 
-    // If no pose is far enough back to estimate a direction, fall back to simple distance check
-    if (!before_goal_pose_ptr) {
-      RCLCPP_DEBUG(
-        logger_,
-        "No plan pose far enough to estimate direction, falling back to simple distance check");
-      double distance_to_goal = std::hypot(
-        goal_pose.position.x - query_pose.position.x,
-        goal_pose.position.y - query_pose.position.y);
-      double tolerance = std::min(along_path_tolerance_, cross_track_tolerance_);
-      return distance_to_goal < tolerance;
-    }
-
-    // end of path direction
-    double end_of_path_yaw = atan2(dy, dx);
-
-    // Check if robot is already at goal (would cause atan2(0,0))
-    double robot_to_goal_dx = goal_pose.position.x - query_pose.position.x;
-    double robot_to_goal_dy = goal_pose.position.y - query_pose.position.y;
-    double distance_to_goal = std::hypot(robot_to_goal_dx, robot_to_goal_dy);
-
-    if (distance_to_goal < 1e-6) {
-      return true;  // Robot is at goal
-    }
-
-    double robot_to_goal_yaw = atan2(robot_to_goal_dy, robot_to_goal_dx);
-    double projection_angle = angles::shortest_angular_distance(
-      robot_to_goal_yaw, end_of_path_yaw);
-    double along_path_distance = distance_to_goal * cos(projection_angle);
-    double cross_track_distance = distance_to_goal * sin(projection_angle);
-
-    if (is_overshoot_valid_) {
-      return along_path_distance < along_path_tolerance_ &&
-             fabs(cross_track_distance) < cross_track_tolerance_;
-    } else {
-      return fabs(along_path_distance) < along_path_tolerance_ &&
-             fabs(cross_track_distance) < cross_track_tolerance_;
-    }
-  } else {
-    // Fallback: path has only 1 point, use simple distance check
+  // The plan is pruned to start at the pose closest to the robot, so near the goal it may
+  // no longer contain a pose far enough back to estimate the direction; reuse the direction
+  // estimated on a previous cycle instead of degrading to a euclidean check.
+  if (!direction_found && cached_end_of_path_yaw_.has_value()) {
+    end_of_path_yaw = cached_end_of_path_yaw_.value();
+    direction_found = true;
     RCLCPP_DEBUG(
       logger_,
-      "Path has fewer than 2 poses, falling back to simple distance check");
+      "No plan pose far enough to estimate direction, using cached path direction");
+  }
+
+  // If no direction was ever estimated, fall back to simple distance check
+  if (!direction_found) {
+    RCLCPP_DEBUG(
+      logger_,
+      "No path direction available, falling back to simple distance check");
     double distance_to_goal = std::hypot(
       goal_pose.position.x - query_pose.position.x,
       goal_pose.position.y - query_pose.position.y);
     double tolerance = std::min(along_path_tolerance_, cross_track_tolerance_);
     return distance_to_goal < tolerance;
+  }
+
+  // Check if robot is already at goal (would cause atan2(0,0))
+  double robot_to_goal_dx = goal_pose.position.x - query_pose.position.x;
+  double robot_to_goal_dy = goal_pose.position.y - query_pose.position.y;
+  double distance_to_goal = std::hypot(robot_to_goal_dx, robot_to_goal_dy);
+
+  if (distance_to_goal < 1e-6) {
+    return true;  // Robot is at goal
+  }
+
+  double robot_to_goal_yaw = atan2(robot_to_goal_dy, robot_to_goal_dx);
+  double projection_angle = angles::shortest_angular_distance(
+    robot_to_goal_yaw, end_of_path_yaw);
+  double along_path_distance = distance_to_goal * cos(projection_angle);
+  double cross_track_distance = distance_to_goal * sin(projection_angle);
+
+  if (is_overshoot_valid_) {
+    return along_path_distance < along_path_tolerance_ &&
+           fabs(cross_track_distance) < cross_track_tolerance_;
+  } else {
+    return fabs(along_path_distance) < along_path_tolerance_ &&
+           fabs(cross_track_distance) < cross_track_tolerance_;
   }
 }
 

--- a/nav2_controller/plugins/axis_goal_checker.cpp
+++ b/nav2_controller/plugins/axis_goal_checker.cpp
@@ -102,20 +102,17 @@ bool AxisGoalChecker::isGoalXYReached(
   const nav_msgs::msg::Path & transformed_global_plan)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
-  // If the local plan length is longer than the tolerance, we skip the check
-  if (nav2_util::geometry_utils::calculate_path_length(transformed_global_plan) >
-    path_length_tolerance_)
-  {
-    return false;
-  }
 
   double robot_to_goal_dx = goal_pose.position.x - query_pose.position.x;
   double robot_to_goal_dy = goal_pose.position.y - query_pose.position.y;
   double distance_to_goal = std::hypot(robot_to_goal_dx, robot_to_goal_dy);
 
-  // Try to estimate the end-of-path direction from the plan; keep the previously
-  // cached direction if the pruned plan no longer reaches far enough back from the goal.
-  // Walk back from the goal until a pose is at least direction_estimation_distance_ away
+  // Already on the goal; skip the direction math and the atan2(0,0) below.
+  if (distance_to_goal < 1e-6) {
+    return true;
+  }
+
+  // Cache the direction
   for (int i = static_cast<int>(transformed_global_plan.poses.size()) - 2; i >= 0; --i) {
     const auto & candidate_pose = transformed_global_plan.poses[i].pose;
     double dx = goal_pose.position.x - candidate_pose.position.x;
@@ -127,17 +124,19 @@ bool AxisGoalChecker::isGoalXYReached(
     }
   }
 
+  // If the local plan length is longer than the tolerance, we skip the check
+  if (nav2_util::geometry_utils::calculate_path_length(transformed_global_plan) >
+    path_length_tolerance_)
+  {
+    return false;
+  }
+
   // If no direction was ever estimated, fall back to simple distance check
   if (!cached_end_of_path_yaw_.has_value()) {
     RCLCPP_DEBUG(
       logger_,
       "No path direction available, falling back to simple distance check");
     return distance_to_goal < std::min(along_path_tolerance_, cross_track_tolerance_);
-  }
-
-  // Check if robot is already at goal (would cause atan2(0,0))
-  if (distance_to_goal < 1e-6) {
-    return true;  // Robot is at goal
   }
 
   double robot_to_goal_yaw = atan2(robot_to_goal_dy, robot_to_goal_dx);

--- a/nav2_controller/plugins/axis_goal_checker.cpp
+++ b/nav2_controller/plugins/axis_goal_checker.cpp
@@ -109,61 +109,40 @@ bool AxisGoalChecker::isGoalXYReached(
     return false;
   }
 
-  // Try to estimate the end-of-path direction from the plan
-  double end_of_path_yaw = 0.0;
-  bool direction_found = false;
-  if (transformed_global_plan.poses.size() >= 2) {
-    // Walk back from the goal until a pose is at least direction_estimation_distance_ away
-    for (int i = transformed_global_plan.poses.size() - 2; i >= 0; --i) {
-      const auto & candidate_pose = transformed_global_plan.poses[i].pose;
-      double dx = goal_pose.position.x - candidate_pose.position.x;
-      double dy = goal_pose.position.y - candidate_pose.position.y;
-      double pose_distance = std::hypot(dx, dy);
-
-      if (pose_distance >= direction_estimation_distance_) {
-        end_of_path_yaw = atan2(dy, dx);
-        cached_end_of_path_yaw_ = end_of_path_yaw;
-        direction_found = true;
-        break;
-      }
-    }
-  }
-
-  // The plan is pruned to start at the pose closest to the robot, so near the goal it may
-  // no longer contain a pose far enough back to estimate the direction; reuse the direction
-  // estimated on a previous cycle instead of degrading to a euclidean check.
-  if (!direction_found && cached_end_of_path_yaw_.has_value()) {
-    end_of_path_yaw = cached_end_of_path_yaw_.value();
-    direction_found = true;
-    RCLCPP_DEBUG(
-      logger_,
-      "No plan pose far enough to estimate direction, using cached path direction");
-  }
-
-  // If no direction was ever estimated, fall back to simple distance check
-  if (!direction_found) {
-    RCLCPP_DEBUG(
-      logger_,
-      "No path direction available, falling back to simple distance check");
-    double distance_to_goal = std::hypot(
-      goal_pose.position.x - query_pose.position.x,
-      goal_pose.position.y - query_pose.position.y);
-    double tolerance = std::min(along_path_tolerance_, cross_track_tolerance_);
-    return distance_to_goal < tolerance;
-  }
-
-  // Check if robot is already at goal (would cause atan2(0,0))
   double robot_to_goal_dx = goal_pose.position.x - query_pose.position.x;
   double robot_to_goal_dy = goal_pose.position.y - query_pose.position.y;
   double distance_to_goal = std::hypot(robot_to_goal_dx, robot_to_goal_dy);
 
+  // Try to estimate the end-of-path direction from the plan; keep the previously
+  // cached direction if the pruned plan no longer reaches far enough back from the goal.
+  // Walk back from the goal until a pose is at least direction_estimation_distance_ away
+  for (int i = static_cast<int>(transformed_global_plan.poses.size()) - 2; i >= 0; --i) {
+    const auto & candidate_pose = transformed_global_plan.poses[i].pose;
+    double dx = goal_pose.position.x - candidate_pose.position.x;
+    double dy = goal_pose.position.y - candidate_pose.position.y;
+
+    if (std::hypot(dx, dy) >= direction_estimation_distance_) {
+      cached_end_of_path_yaw_ = atan2(dy, dx);
+      break;
+    }
+  }
+
+  // If no direction was ever estimated, fall back to simple distance check
+  if (!cached_end_of_path_yaw_.has_value()) {
+    RCLCPP_DEBUG(
+      logger_,
+      "No path direction available, falling back to simple distance check");
+    return distance_to_goal < std::min(along_path_tolerance_, cross_track_tolerance_);
+  }
+
+  // Check if robot is already at goal (would cause atan2(0,0))
   if (distance_to_goal < 1e-6) {
     return true;  // Robot is at goal
   }
 
   double robot_to_goal_yaw = atan2(robot_to_goal_dy, robot_to_goal_dx);
   double projection_angle = angles::shortest_angular_distance(
-    robot_to_goal_yaw, end_of_path_yaw);
+    robot_to_goal_yaw, cached_end_of_path_yaw_.value());
   double along_path_distance = distance_to_goal * cos(projection_angle);
   double cross_track_distance = distance_to_goal * sin(projection_angle);
 

--- a/nav2_controller/plugins/test/axis_goal_checker.cpp
+++ b/nav2_controller/plugins/test/axis_goal_checker.cpp
@@ -680,6 +680,10 @@ TEST(AxisGoalChecker, multiple_consecutive_poses_too_close_to_goal)
     {2.0, 0.0}
   });
 
+  // A new path implies a reset of the checker (as done by the controller server),
+  // clearing any cached path direction
+  agc.reset();
+
   // Robot within the fallback tolerance should succeed (fallback to distance check).
   // The fallback uses the stricter min of the two tolerances.
   query_pose.position.x = 2.0 + 0.1;
@@ -695,6 +699,52 @@ TEST(AxisGoalChecker, multiple_consecutive_poses_too_close_to_goal)
   distance = std::hypot(0.2, 0.2);
   EXPECT_GT(distance, fallback_tolerance);  // Verify we're outside tolerance
   EXPECT_FALSE(agc.isGoalReached(query_pose, goal_pose, velocity, path_all_close));
+}
+
+TEST(AxisGoalChecker, truncated_plan_uses_cached_direction)
+{
+  auto node = std::make_shared<TestLifecycleNode>("axis_goal_checker_test");
+  AxisGoalChecker agc;
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
+
+  agc.initialize(node, "test", costmap);
+
+  geometry_msgs::msg::Pose goal_pose;
+  goal_pose.position.x = 2.0;
+  goal_pose.position.y = 0.0;
+  goal_pose.position.z = 0.0;
+  goal_pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::Pose query_pose;
+  geometry_msgs::msg::Twist velocity;
+
+  // First cycle: plan still contains a pose far enough from the goal, direction gets cached
+  nav_msgs::msg::Path full_path = createPath({{1.2, 0.0}, {1.6, 0.0}, {2.0, 0.0}});
+  query_pose.position.x = 1.3;
+  query_pose.position.y = 0.0;
+  EXPECT_FALSE(agc.isGoalReached(query_pose, goal_pose, velocity, full_path));
+
+  // Later cycle: the path handler pruned the plan behind the robot so all remaining
+  // poses are within direction_estimation_distance (0.15) of the goal
+  nav_msgs::msg::Path truncated_path = createPath({{1.95, 0.0}, {2.0, 0.0}});
+
+  // Overshoot with cross-track offset: euclidean distance (0.283) exceeds the fallback
+  // tolerance, but the axis check with the cached direction accepts it
+  query_pose.position.x = 2.2;
+  query_pose.position.y = 0.2;
+  EXPECT_TRUE(agc.isGoalReached(query_pose, goal_pose, velocity, truncated_path));
+
+  // Along-path error beyond tolerance is still rejected with the cached direction
+  query_pose.position.x = 1.7;
+  query_pose.position.y = 0.0;
+  EXPECT_FALSE(agc.isGoalReached(query_pose, goal_pose, velocity, truncated_path));
+
+  // After reset (new path) the cache is cleared, so the same overshoot pose falls
+  // back to the euclidean check and is rejected
+  agc.reset();
+  query_pose.position.x = 2.2;
+  query_pose.position.y = 0.2;
+  EXPECT_FALSE(agc.isGoalReached(query_pose, goal_pose, velocity, truncated_path));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

In #6345 I failed to realize that the global path passed to the goal checker is the truncated one so when we get too close to the goal, the path is too small to estimate direction from it, falling back every time to euclidean distance check.

This PR fixes that by caching the `end_of_path_yaw` so that it is used once the path becomes too short to calculate it again.

- Added `std::optional<double> cached_end_of_path_yaw_`: the direction estimation loop now assigns directly into it whenever the plan still contains a pose at least `direction_estimation_distance` away from the goal, so the cache always holds the latest valid estimate.
- When the truncated plan no longer reaches far enough back to estimate the direction, the cached value is reused for the along-path / cross-track decomposition instead of degrading to the euclidean distance check.
- The euclidean fallback (with `min(along_path_tolerance, cross_track_tolerance)`) now only applies when no direction was ever estimable for the current path.
- Simplified `isGoalXYReached()`: hoisted the robot-to-goal delta/distance computation (previously duplicated in the fallback branch), and removed the `poses.size() >= 2` guard by casting `poses.size()` to `int` in the loop initializer so 0/1-pose paths are handled naturally.


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
