### PR TITLE
Fix VoxelGrid size overflow

### DIFF
--- a/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
+++ b/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
@@ -34,6 +34,8 @@
  *
  * Author: Eitan Marder-Eppstein
  *********************************************************************/
+// [AI-generated] The VoxelGrid index-safety changes in this file were written
+// with AI assistance and reviewed by the author.
 #ifndef NAV2_VOXEL_GRID__VOXEL_GRID_HPP_
 #define NAV2_VOXEL_GRID__VOXEL_GRID_HPP_
 
@@ -107,7 +109,7 @@ public:
       return false;
     }
 
-    int index = y * size_x_ + x;
+    unsigned int index = y * size_x_ + x;
     uint32_t * col = &data_[index];
     uint32_t full_mask = ((uint32_t)1 << z << 16) | (1 << z);
     *col |= full_mask;  // clear unknown and mark cell
@@ -140,7 +142,7 @@ public:
       RCLCPP_DEBUG(logger, "Error, voxel out of bounds.\n");
       return;
     }
-    int index = y * size_x_ + x;
+    unsigned int index = y * size_x_ + x;
     uint32_t * col = &data_[index];
     uint32_t full_mask = ((uint32_t)1 << z << 16) | (1 << z);
     *col &= ~(full_mask);  // clear unknown and clear cell
@@ -260,7 +262,7 @@ public:
     unsigned int abs_dz = abs(dz);
 
     int offset_dx = sign(dx);
-    int offset_dy = sign(dy) * size_x_;
+    int offset_dy = sign(dy) * static_cast<int>(size_x_);
     int offset_dz = sign(dz);
 
     unsigned int z_mask = ((1 << 16) | 1) << (unsigned int)min_z0;

--- a/nav2_voxel_grid/src/voxel_grid.cpp
+++ b/nav2_voxel_grid/src/voxel_grid.cpp
@@ -34,16 +34,52 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+// [AI-generated] The VoxelGrid overflow validation in this file was written
+// with AI assistance and reviewed by the author.
 #include <nav2_voxel_grid/voxel_grid.hpp>
+
+#include <stdexcept>
+#include <string>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
 namespace nav2_voxel_grid
 {
+
+namespace
+{
+// Validates that a grid of size_x * size_y cells can be safely represented
+// by VoxelGrid's flattened unsigned int offsets. Throws std::invalid_argument
+// if not. size_x and size_y are each bounded by INT_MAX because raytraceLine()
+// derives signed offsets (e.g. offset_dy = sign(dy) * size_x_) from them, and
+// the product is bounded by UINT_MAX because it is the flattened offset range
+// used throughout the class.
+void validateVoxelGridSize(unsigned int size_x, unsigned int size_y)
+{
+  constexpr unsigned int kMaxDim = static_cast<unsigned int>(INT_MAX);
+  if (size_x > kMaxDim || size_y > kMaxDim) {
+    throw std::invalid_argument(
+            "VoxelGrid: size_x (" + std::to_string(size_x) + ") and size_y (" +
+            std::to_string(size_y) + ") must each not exceed INT_MAX (" +
+            std::to_string(INT_MAX) + ")");
+  }
+
+  const uint64_t cells = static_cast<uint64_t>(size_x) * static_cast<uint64_t>(size_y);
+  if (cells > static_cast<uint64_t>(UINT_MAX)) {
+    throw std::invalid_argument(
+            "VoxelGrid: size_x * size_y (" + std::to_string(cells) +
+            ") exceeds the maximum representable cell count (" +
+            std::to_string(UINT_MAX) + ")");
+  }
+}
+}  // namespace
+
 VoxelGrid::VoxelGrid(unsigned int size_x, unsigned int size_y, unsigned int size_z)
 : logger(rclcpp::get_logger("voxel_grid"))
 {
+  validateVoxelGridSize(size_x, size_y);
+
   size_x_ = size_x;
   size_y_ = size_y;
   size_z_ = size_z;
@@ -71,6 +107,8 @@ void VoxelGrid::resize(unsigned int size_x, unsigned int size_y, unsigned int si
     reset();
     return;
   }
+
+  validateVoxelGridSize(size_x, size_y);
 
   delete[] data_;
   size_x_ = size_x;

--- a/nav2_voxel_grid/test/voxel_grid_tests.cpp
+++ b/nav2_voxel_grid/test/voxel_grid_tests.cpp
@@ -34,8 +34,11 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+// [AI-generated] The VoxelGrid overflow regression tests in this file were
+// written with AI assistance and reviewed by the author.
 #include <nav2_voxel_grid/voxel_grid.hpp>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 TEST(voxel_grid, basicMarkingAndClearing) {
   int size_x = 50, size_y = 10, size_z = 16;
@@ -195,6 +198,54 @@ TEST(voxel_grid, GetVoxelData) {
   EXPECT_EQ(
     nav2_voxel_grid::VoxelGrid::getVoxel(0, 0, 0, 3, 3, 3, data), nav2_voxel_grid::FREE);
   delete[] data;
+}
+
+TEST(voxel_grid, ConstructorRejectsMultiplicationOverflow) {
+  // 65537 * 65537 = 4,295,098,369 > UINT_MAX; must be rejected before any
+  // allocation is attempted (issue #6411's reported repro values).
+  EXPECT_THROW(
+    nav2_voxel_grid::VoxelGrid vg(65537u, 65537u, 16u),
+    std::invalid_argument);
+}
+
+TEST(voxel_grid, ConstructorRejectsDimensionAboveIntMax) {
+  const unsigned int too_large = static_cast<unsigned int>(INT_MAX) + 1u;
+  // Keep the other dimension tiny so no large allocation could ever occur,
+  // even if the per-dimension check were missing and only the product
+  // check remained.
+  EXPECT_THROW(
+    nav2_voxel_grid::VoxelGrid vg(too_large, 1u, 16u),
+    std::invalid_argument);
+  EXPECT_THROW(
+    nav2_voxel_grid::VoxelGrid vg(1u, too_large, 16u),
+    std::invalid_argument);
+}
+
+TEST(voxel_grid, ResizeRejectsOverflowAndPreservesGrid) {
+  nav2_voxel_grid::VoxelGrid vg(10u, 10u, 10u);
+  vg.markVoxelInMap(5, 5, 5, 0);
+  ASSERT_EQ(vg.getVoxel(5, 5, 5), nav2_voxel_grid::MARKED);
+
+  EXPECT_THROW(vg.resize(65537u, 65537u, 10u), std::invalid_argument);
+
+  // the grid must remain exactly as it was before the failed resize
+  EXPECT_EQ(vg.sizeX(), 10u);
+  EXPECT_EQ(vg.sizeY(), 10u);
+  EXPECT_EQ(vg.sizeZ(), 10u);
+  EXPECT_EQ(vg.getVoxel(5, 5, 5), nav2_voxel_grid::MARKED);
+}
+
+TEST(voxel_grid, MarkAndClearVoxelInMapUnsignedIndex) {
+  // Ordinary-sized grid exercising markVoxelInMap()/clearVoxelInMap() after
+  // their flattened index type changed from int to unsigned int.
+  int size_x = 100, size_y = 100, size_z = 10;
+  nav2_voxel_grid::VoxelGrid vg(size_x, size_y, size_z);
+
+  EXPECT_TRUE(vg.markVoxelInMap(99, 99, 9, 0));
+  EXPECT_EQ(vg.getVoxel(99, 99, 9), nav2_voxel_grid::MARKED);
+
+  vg.clearVoxelInMap(99, 99, 9);
+  EXPECT_EQ(vg.getVoxel(99, 99, 9), nav2_voxel_grid::FREE);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | #6411 |
| Primary OS tested on | Ubuntu 24.04 on WSL |
| Robotic platform tested on | None — package-level unit tests only |
| Does this PR contain AI generated software? | Yes and it is marked inline in the code |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points


- Validate VoxelGrid X/Y dimensions before allocation.
- Run the same validation before resize() deletes or changes the existing grid.
- Compute size_x * size_y in uint64_t and reject cell counts above UINT_MAX.
- Reject individual X/Y dimensions above INT_MAX because raytrace uses signed offsets.
- Change the two flattened `int index` variables in markVoxelInMap() and clearVoxelInMap() to `unsigned int`.
- Explicitly cast size_x_ to int before signed raytrace row-offset multiplication.
- If resize() is rejected, preserve the previous grid dimensions and voxel data.
- Add regression coverage for issue #6411.

---

## Description of documentation updates required from your changes


- No documentation changes are expected.
- No new public parameter, configuration option, or user-facing feature is introduced.

---

## Description of how this change was tested


- Built nav2_common and nav2_voxel_grid successfully.
- Ran:
  `colcon test --packages-select nav2_voxel_grid --event-handlers console_direct+`
- nav2_voxel_grid: 7/7 test targets passed.
- voxel_grid_tests: 9/9 GoogleTest cases passed.
- voxel_grid_bresenham_3d: 2/2 GoogleTest cases passed.
- cppcheck passed.
- cpplint passed.
- lint_cmake passed.
- uncrustify passed.
- xmllint passed.
- `git diff --check` was clean.
- No physical robot or Nav2 simulation was required for this package-level memory-safety fix.

New regression tests cover:

- constructor rejection for 65537 × 65537 multiplication overflow;
- rejection of an individual dimension above INT_MAX;
- failed resize preserving the previous grid and marked voxel data;
- normal markVoxelInMap()/clearVoxelInMap() behavior after the unsigned index change.

---

## Future work that may be required in bullet points


- No known follow-up work is required for this fix.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
