### PR TITLE
feat(nav2_behavior_tree): add reset_distance and reset_time ports to RecoveryNode (#6236)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -15,8 +15,16 @@
 #ifndef NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__RECOVERY_NODE_HPP_
 #define NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__RECOVERY_NODE_HPP_
 
+#include <limits>
+#include <memory>
 #include <string>
+
 #include "behaviortree_cpp/control_node.h"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_behavior_tree/bt_utils.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_ros_common/tf2_factories.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -31,9 +39,15 @@ namespace nav2_behavior_tree
  *
  * - If the second child returns FAILURE, this control node will stop the loop and returns FAILURE.
  *
+ * - Optional reset ports (both disabled by default):
+ *   - reset_distance: resets retry_count_ to 0 once the robot has travelled this many metres
+ *     since the last reset.  Useful in dynamic environments where obstacles move out of the way.
+ *   - reset_time:     resets retry_count_ to 0 once this many seconds have elapsed since the last
+ *     reset.  Useful for slow-moving or periodic obstructions.
+ *
  * Usage in XML:
  * @code
- * <RecoveryNode number_of_retries="1">
+ * <RecoveryNode number_of_retries="10" reset_distance="0.5">
  *     <!--Add tree components here-->
  * </RecoveryNode>
  * @endcode
@@ -62,7 +76,17 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<int>("number_of_retries", 1, "Number of retries")
+      BT::InputPort<int>("number_of_retries", 1, "Number of retries"),
+      BT::InputPort<double>(
+        "reset_distance", std::numeric_limits<double>::infinity(),
+        "Reset the retry counter once the robot travels this distance (m). "
+        "Disabled (infinity) by default."),
+      BT::InputPort<double>(
+        "reset_time", std::numeric_limits<double>::infinity(),
+        "Reset the retry counter once this time has elapsed (s). "
+        "Disabled (infinity) by default."),
+      BT::InputPort<std::string>("global_frame", "map", "Global frame for TF lookups"),
+      BT::InputPort<std::string>("robot_base_frame", "base_link", "Robot base frame"),
     };
   }
 
@@ -70,6 +94,22 @@ private:
   unsigned int current_child_idx_;
   unsigned int number_of_retries_;
   unsigned int retry_count_;
+
+  // ---- reset_distance support ----
+  nav2::LifecycleNode::SharedPtr node_;
+  nav2::TransformBuffer::SharedPtr tf_;
+  double transform_tolerance_;
+  std::string global_frame_;
+  std::string robot_base_frame_;
+  geometry_msgs::msg::PoseStamped last_reset_pose_;
+  double reset_distance_;
+
+  // ---- reset_time support ----
+  rclcpp::Time last_reset_time_;
+  double reset_time_;
+
+  // True from the first tick until a valid start pose has been captured
+  bool first_tick_;
 
   /**
    * @brief The main override required by a BT action
@@ -81,6 +121,12 @@ private:
    * @brief The other (optional) override required by a BT action to reset node state
    */
   void halt() override;
+
+  /**
+   * @brief Check whether either the distance-travel or time-elapsed threshold has been crossed
+   *        and, if so, reset retry_count_ and record the new baseline.
+   */
+  void checkAndResetCounterIfNeeded();
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -519,6 +519,10 @@
 
     <Control ID="RecoveryNode">
       <input_port name="number_of_retries" type="int" default="1">Number of retries.</input_port>
+      <input_port name="reset_distance" type="double" default="numeric_limits&lt;double&gt;::infinity()">Reset retry counter once robot travels this distance (m).</input_port>
+      <input_port name="reset_time" type="double" default="numeric_limits&lt;double&gt;::infinity()">Reset retry counter once this time elapses (s).</input_port>
+      <input_port name="global_frame" type="string" default="&quot;map&quot;">Global reference frame.</input_port>
+      <input_port name="robot_base_frame" type="string" default="&quot;base_link&quot;">Robot base frame.</input_port>
     </Control>
 
     <Control ID="RoundRobin">

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <string>
+#include <limits>
 #include "nav2_behavior_tree/plugins/control/recovery_node.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -24,13 +27,78 @@ RecoveryNode::RecoveryNode(
 : BT::ControlNode::ControlNode(name, conf),
   current_child_idx_(0),
   number_of_retries_(1),
-  retry_count_(0)
+  retry_count_(0),
+  transform_tolerance_(0.1),
+  reset_distance_(std::numeric_limits<double>::infinity()),
+  reset_time_(std::numeric_limits<double>::infinity()),
+  first_tick_(true)
 {
+  node_ = config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node");
+  tf_ = config().blackboard->get<nav2::TransformBuffer::SharedPtr>("tf_buffer");
+  node_->get_parameter("transform_tolerance", transform_tolerance_);
+
+  global_frame_ = BT::deconflictPortAndParamFrame<std::string>(
+    node_, "global_frame", this);
+  robot_base_frame_ = BT::deconflictPortAndParamFrame<std::string>(
+    node_, "robot_base_frame", this);
+}
+
+void RecoveryNode::checkAndResetCounterIfNeeded()
+{
+  if (!std::isinf(reset_distance_) || !std::isinf(reset_time_)) {
+    geometry_msgs::msg::PoseStamped current_pose;
+    const bool has_pose = nav2_util::getCurrentPose(
+      current_pose, *tf_, global_frame_, robot_base_frame_,
+      transform_tolerance_);
+
+    const rclcpp::Time current_time = node_->now();
+
+    if (first_tick_) {
+      if (has_pose) {
+        last_reset_pose_ = current_pose;
+      }
+      last_reset_time_ = current_time;
+      first_tick_ = false;
+      return;
+    }
+
+    bool reset_needed = false;
+
+    // Check distance reset
+    if (!std::isinf(reset_distance_) && has_pose && last_reset_pose_.header.frame_id != "") {
+      double travelled = nav2_util::geometry_utils::euclidean_distance(
+        last_reset_pose_.pose, current_pose.pose);
+      if (travelled >= reset_distance_) {
+        reset_needed = true;
+      }
+    }
+
+    // Check time reset
+    if (!std::isinf(reset_time_) && last_reset_time_.nanoseconds() > 0) {
+      double elapsed = (current_time - last_reset_time_).seconds();
+      if (elapsed >= reset_time_) {
+        reset_needed = true;
+      }
+    }
+
+    if (reset_needed) {
+      retry_count_ = 0;
+      if (has_pose) {
+        last_reset_pose_ = current_pose;
+      }
+      last_reset_time_ = current_time;
+    }
+  }
 }
 
 BT::NodeStatus RecoveryNode::tick()
 {
   getInput("number_of_retries", number_of_retries_);
+  getInput("reset_distance", reset_distance_);
+  getInput("reset_time", reset_time_);
+
+  checkAndResetCounterIfNeeded();
+
   const unsigned children_count = children_nodes_.size();
 
   if (children_count != 2) {
@@ -123,6 +191,7 @@ void RecoveryNode::halt()
   ControlNode::halt();
   retry_count_ = 0;
   current_child_idx_ = 0;
+  first_tick_ = true;
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <thread>
+#include <chrono>
 
 #include "utils/test_behavior_tree_fixture.hpp"
 #include "utils/test_dummy_tree_node.hpp"
@@ -164,6 +166,27 @@ TEST_F(RecoveryNodeTestFixture, test_skipping)
   EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
 }
 
+TEST_F(RecoveryNodeTestFixture, test_reset_time)
+{
+  config_->input_ports["number_of_retries"] = 1;
+  config_->input_ports["reset_time"] = 0.1;  // 100 ms
+  bt_node_ = std::make_shared<nav2_behavior_tree::RecoveryNode>("recovery_node", *config_);
+  bt_node_->addChild(first_child_.get());
+  bt_node_->addChild(second_child_.get());
+
+  // first child fails, second child succeeds
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+
+  // Tick 1: retry_count_ becomes 1
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  // Sleep to allow reset_time threshold to pass
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  // Tick 2: reset_time triggers counter reset to 0, allowing another retry
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
## Description
This PR addresses #6236 by adding progress-based and time-based reset capabilities to the `RecoveryNode`. 

In dynamic environments, a fixed retry budget can cause the robot to give up too early or wait too long. This implementation allows the retry counter to reset when the robot makes actual progress (distance) or when a certain amount of time has passed, ensuring the robot only gives up when it is genuinely stuck.

## Changes
- Extended `RecoveryNode` with new input ports:
  - `reset_distance` (double, default: `infinity` / disabled): Resets retry counter when the robot moves the specified distance.
  - `reset_time` (double, default: `infinity` / disabled): Resets retry counter when the specified time elapses.
  - `global_frame` (string, default: `"map"`): Global frame for TF lookups.
  - `robot_base_frame` (string, default: `"base_link"`): Base frame for TF lookups.
- Implemented `RecoveryNode::checkAndResetCounterIfNeeded()` to track Euclidean distance via TF and elapsed time via the Node clock.
- The retry counter resets to `0` when thresholds are met, and baseline state is reset on `halt()`.
- Updated `nav2_tree_nodes.xml` with the new port definitions.
- Added unit tests for the new reset logic.

**Note on Decorator Node:** 
This PR focuses on extending the Nav2 `RecoveryNode` control node as requested in #6236. A corresponding Nav2 decorator node (mirroring the BT.CPP built-in `RetryUntilSuccessful` with these same reset capabilities) can be submitted in a follow-up PR if desired by the maintainers.

## Checklist
- [x] Code formatted (`ament_uncrustify` - 0 divergences)
- [x] Linter checks passed (`ament_cpplint` - 0 issues)
- [x] DCO Signed-off-by included
- [x] Unit tests added/updated
- [x] `nav2_tree_nodes.xml` updated