### PR TITLE
fix(theta_star_planner): charge unknown cells consistently at both co…

### DIFF
--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -186,13 +186,10 @@ protected:
    */
   bool isSafe(const int & cx, const int & cy, double & cost) const
   {
-    double curr_cost = getCost(cx, cy);
+    const double curr_cost = getCost(cx, cy);
     if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && params_->allow_unknown) ||
       curr_cost <= MAX_NON_OBSTACLE_COST)
     {
-      if (costmap_->getCost(cx, cy) == UNKNOWN_COST) {
-        curr_cost = OCCUPIED_COST - 1;
-      }
       cost += params_->w_traversal_cost * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
         MAX_NON_OBSTACLE_COST;
       return true;
@@ -201,13 +198,17 @@ protected:
     }
   }
 
-  /*
+  /**
    * @brief this function scales the costmap cost by shifting the origin to 25 and then multiply
    *           the actual costmap cost by 0.9 to keep the output in the range of [25, 255)
+   *           an unknown cell is charged as near-obstacle, so that traversing one is discouraged
+   *           wherever allow_unknown permits it at all
+   * @return the scaled cost thus obtained
    */
   inline double getCost(const int & cx, const int & cy) const
   {
-    return 26 + 0.9 * costmap_->getCost(cx, cy);
+    const unsigned char cost = costmap_->getCost(cx, cy);
+    return 26 + 0.9 * (cost == UNKNOWN_COST ? OCCUPIED_COST - 1 : cost);
   }
 
   /**

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -39,6 +39,8 @@ public:
 
   bool uwithinLimits(const int & cx, const int & cy) {return withinLimits(cx, cy);}
 
+  double ugetTraversalCost(const int & cx, const int & cy) {return getTraversalCost(cx, cy);}
+
   bool uisGoal(const tree_node & this_node) {return isGoal(this_node);}
 
   void uinitializePosn(int size_inc = 0)
@@ -257,6 +259,31 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
     life_node->get_node_base_interface(),
     results);
   EXPECT_EQ(life_node->get_parameter("test.w_euc_cost").as_double(), 1.0);
+}
+
+TEST(ThetaStarTest, test_unknown_cost_agrees_between_cost_sites) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarUnknownTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(2, 1, 1.0, 0.0, 0.0, UNKNOWN_COST);
+  params->w_traversal_cost = 2.0;
+  params->allow_unknown = true;
+
+  // test if a line of sight check charges an unknown cell as an expansion step does
+  double sl_cost = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(0, 0, 1, 0, sl_cost));
+  EXPECT_DOUBLE_EQ(sl_cost, planner_->ugetTraversalCost(0, 0));
+
+  // test if that charge is the one for a near-obstacle cell
+  planner_->costmap_->setCost(1, 0, OCCUPIED_COST - 1);
+  EXPECT_DOUBLE_EQ(planner_->ugetTraversalCost(0, 0), planner_->ugetTraversalCost(1, 0));
+
+  delete planner_->costmap_;
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | ubuntu |
| Robotic platform tested on | custom |
| Does this PR contain AI generated software? | yes |
| Was this PR description generated by AI software? | no |

---

## Description of contribution in a few bullet points

- UNKNOWN_COST is now handled uniformly 

Previously, UNKNOWN_COST was handled differently for LOS vs regular expansion resulting in different costs for the same cell in each case. This unifies those two cases by pushing the UNKNOWN_COST handling into getCost. Consequently, getCost now adheres to its documented output range; it now returns 253.7 instead of 255.5 for an UNKNOWN_COST cell.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
