### PR TITLE
Fix concurrent access to Costmap2D::costmap_ (Bug 1 in #6429)

### DIFF
--- a/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
@@ -15,6 +15,7 @@
 // Modified by: Shivang Patel (shivaan14@gmail.com)
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -87,6 +88,8 @@ double CostmapTopicCollisionChecker::scorePose(
       throw CollisionCheckerException(e.what());
     }
   }
+  auto costmap = collision_checker_.getCostmap();
+  std::lock_guard<Costmap2D::mutex_t> costmap_lock(*costmap->getMutex());
 
   unsigned int cell_x, cell_y;
   if (!collision_checker_.worldToMap(pose.x, pose.y, cell_x, cell_y)) {


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#6429 (Bug 1) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? |No |
| Was this PR description generated by AI software? |No |

---

## Description of contribution in a few bullet points
- Holds the costmap mutex for the complete collision check.

## Description of documentation updates required from your changes
- N/A. This change does not add any parameters or modify the documented behavior.


## Description of how this change was tested

- Built the Navigation2 workspace with Clang AddressSanitizer.
- Ran the Bug 1 PoC from #6429 and verified that the reported ASan crash no longer occurred and that the node remained alive.


## Future work that may be required in bullet points
N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
