### PR TITLE
Fix concurrent access to Costmap2D::costmap_ (Bug 2 in #6429)

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -91,7 +91,7 @@ public:
 protected:
   bool isCostmapReceived()
   {
-    std::lock_guard<std::mutex> guard(costmap_msg_mutex_);
+    std::lock_guard<std::recursive_mutex> guard(costmap_msg_mutex_);
     return costmap_ != nullptr;
   }
   void processCurrentCostmapMsg();
@@ -109,7 +109,7 @@ protected:
 
   std::string topic_name_;
   std::string frame_id_;
-  std::mutex costmap_msg_mutex_;
+  std::recursive_mutex costmap_msg_mutex_;
   rclcpp::Logger logger_{rclcpp::get_logger("nav2_costmap_2d")};
 };
 

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -32,22 +32,15 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
 
 void CostmapSubscriber::costmapCallback(const nav2_msgs::msg::Costmap::ConstSharedPtr & msg)
 {
-  {
-    std::lock_guard<std::mutex> lock(costmap_msg_mutex_);
-    costmap_msg_ = msg;
-    frame_id_ = costmap_msg_->header.frame_id;
-  }
+  std::lock_guard<std::recursive_mutex> lock(costmap_msg_mutex_);
+  costmap_msg_ = msg;
+  frame_id_ = costmap_msg_->header.frame_id;
+
   if (!isCostmapReceived()) {
-    {
-      std::lock_guard<std::mutex> lock(costmap_msg_mutex_);
-      if (costmap_) {
-        return;
-      }
-      costmap_ = std::make_shared<Costmap2D>(
-        msg->metadata.size_x, msg->metadata.size_y,
-        msg->metadata.resolution, msg->metadata.origin.position.x,
-        msg->metadata.origin.position.y);
-    }
+    costmap_ = std::make_shared<Costmap2D>(
+      msg->metadata.size_x, msg->metadata.size_y,
+      msg->metadata.resolution, msg->metadata.origin.position.x,
+      msg->metadata.origin.position.y);
 
     processCurrentCostmapMsg();
   }

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -26,9 +26,7 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
   if (!isCostmapReceived()) {
     throw std::runtime_error("Costmap is not available");
   }
-  if (costmap_msg_) {
-    processCurrentCostmapMsg();
-  }
+  processCurrentCostmapMsg();
   return costmap_;
 }
 
@@ -53,9 +51,7 @@ void CostmapSubscriber::costmapUpdateCallback(
   const nav2_msgs::msg::CostmapUpdate::ConstSharedPtr & update_msg)
 {
   if (isCostmapReceived()) {
-    if (costmap_msg_) {
-      processCurrentCostmapMsg();
-    }
+    processCurrentCostmapMsg();
 
     std::lock_guard<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
 
@@ -89,6 +85,9 @@ void CostmapSubscriber::costmapUpdateCallback(
 void CostmapSubscriber::processCurrentCostmapMsg()
 {
   std::scoped_lock lock(*(costmap_->getMutex()), costmap_msg_mutex_);
+  if (!costmap_msg_) {
+    return;
+  }
   if (haveCostmapParametersChanged()) {
     costmap_->resizeMap(
       costmap_msg_->metadata.size_x, costmap_msg_->metadata.size_y,

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -38,10 +38,16 @@ void CostmapSubscriber::costmapCallback(const nav2_msgs::msg::Costmap::ConstShar
     frame_id_ = costmap_msg_->header.frame_id;
   }
   if (!isCostmapReceived()) {
-    costmap_ = std::make_shared<Costmap2D>(
-      msg->metadata.size_x, msg->metadata.size_y,
-      msg->metadata.resolution, msg->metadata.origin.position.x,
-      msg->metadata.origin.position.y);
+    {
+      std::lock_guard<std::mutex> lock(costmap_msg_mutex_);
+      if (costmap_) {
+        return;
+      }
+      costmap_ = std::make_shared<Costmap2D>(
+        msg->metadata.size_x, msg->metadata.size_y,
+        msg->metadata.resolution, msg->metadata.origin.position.x,
+        msg->metadata.origin.position.y);
+    }
 
     processCurrentCostmapMsg();
   }

--- a/nav2_route/src/goal_intent_extractor.cpp
+++ b/nav2_route/src/goal_intent_extractor.cpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "nav2_route/goal_intent_extractor.hpp"
@@ -142,7 +143,10 @@ GoalIntentExtractor::findStartandGoal(const std::shared_ptr<const GoalT> goal)
   bool enable_search = enable_search_;
   if (enable_search) {
     try {
-      costmap = costmap_subscriber_->getCostmap();
+      auto source_costmap = costmap_subscriber_->getCostmap();
+      std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(
+        *source_costmap->getMutex());
+      costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
       costmap_frame_id = costmap_subscriber_->getFrameID();
     } catch (const std::exception & ex) {
       enable_search = false;

--- a/nav2_route/src/goal_intent_extractor.cpp
+++ b/nav2_route/src/goal_intent_extractor.cpp
@@ -143,9 +143,7 @@ GoalIntentExtractor::findStartandGoal(const std::shared_ptr<const GoalT> goal)
   bool enable_search = enable_search_;
   if (enable_search) {
     try {
-      auto source_costmap = costmap_subscriber_->getCostmap();
-      std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*source_costmap->getMutex());
-      costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
+      costmap = costmap_subscriber_->getCostmap();
       costmap_frame_id = costmap_subscriber_->getFrameID();
     } catch (const std::exception & ex) {
       enable_search = false;
@@ -171,6 +169,7 @@ GoalIntentExtractor::findStartandGoal(const std::shared_ptr<const GoalT> goal)
     }
 
     auto transformed_start = transformPose(start_, costmap_frame_id);
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*costmap->getMutex());
     GoalIntentSearch::LoSCollisionChecker los_checker(costmap);
     if (los_checker.worldToMap(
         candidate_nodes.front().pose.position, transformed_start.pose.position))
@@ -199,6 +198,7 @@ GoalIntentExtractor::findStartandGoal(const std::shared_ptr<const GoalT> goal)
     }
 
     auto transformed_end = transformPose(goal_, costmap_frame_id);
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*costmap->getMutex());
     GoalIntentSearch::LoSCollisionChecker los_checker(costmap);
     if (los_checker.worldToMap(
         candidate_nodes.front().pose.position, transformed_end.pose.position))

--- a/nav2_route/src/goal_intent_extractor.cpp
+++ b/nav2_route/src/goal_intent_extractor.cpp
@@ -144,8 +144,7 @@ GoalIntentExtractor::findStartandGoal(const std::shared_ptr<const GoalT> goal)
   if (enable_search) {
     try {
       auto source_costmap = costmap_subscriber_->getCostmap();
-      std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(
-        *source_costmap->getMutex());
+      std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*source_costmap->getMutex());
       costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
       costmap_frame_id = costmap_subscriber_->getFrameID();
     } catch (const std::exception & ex) {

--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "nav2_route/plugins/edge_cost_functions/costmap_scorer.hpp"
@@ -74,7 +75,10 @@ void CostmapScorer::configure(
 void CostmapScorer::prepare()
 {
   try {
-    costmap_ = costmap_subscriber_->getCostmap();
+    auto source_costmap = costmap_subscriber_->getCostmap();
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(
+      *source_costmap->getMutex());
+    costmap_ = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
   } catch (...) {
     costmap_.reset();
   }

--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -76,8 +76,7 @@ void CostmapScorer::prepare()
 {
   try {
     auto source_costmap = costmap_subscriber_->getCostmap();
-    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(
-      *source_costmap->getMutex());
+    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*source_costmap->getMutex());
     costmap_ = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
   } catch (...) {
     costmap_.reset();

--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -75,9 +75,7 @@ void CostmapScorer::configure(
 void CostmapScorer::prepare()
 {
   try {
-    auto source_costmap = costmap_subscriber_->getCostmap();
-    std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*source_costmap->getMutex());
-    costmap_ = std::make_shared<nav2_costmap_2d::Costmap2D>(*source_costmap);
+    costmap_ = costmap_subscriber_->getCostmap();
   } catch (...) {
     costmap_.reset();
   }
@@ -92,6 +90,8 @@ bool CostmapScorer::score(
     RCLCPP_WARN_THROTTLE(logger_, *clock_, 1000, "No costmap yet received!");
     return false;
   }
+
+  std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*costmap_->getMutex());
 
   float largest_cost = 0.0, running_cost = 0.0, point_cost = 0.0;
   unsigned int x0, y0, x1, y1, idx = 0;

--- a/nav2_route/src/plugins/route_operations/collision_monitor.cpp
+++ b/nav2_route/src/plugins/route_operations/collision_monitor.cpp
@@ -15,6 +15,7 @@
 
 #include <math.h>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "nav2_route/plugins/route_operations/collision_monitor.hpp"
@@ -96,6 +97,8 @@ OperationResult CollisionMonitor::perform(
 
   OperationResult result;
   getCostmap();
+
+  std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> lock(*costmap_->getMutex());
 
   float dist_checked = 0.0;
   Coordinates end = curr_edge->end->coords;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6429 (Bug 2) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Move the `costmap_msg_` null check under `costmap_msg_mutex_`.
-   Copy the shared costmap while holding its mutex, then use snapshots for LoS/BFS and costmap edge scoring.

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 2 PoC from #6429 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.