### PR TITLE
Fix concurrent access to NavFn planner costmap (Bug3 in #6429)

### DIFF
--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -243,16 +243,12 @@ NavfnPlanner::makePlan(
   // clear the starting cell within the costmap because we know it can't be an obstacle
   clearRobotCell(mx, my);
 
-  std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
-
   // make sure to resize the underlying array that Navfn uses
   planner_->setNavArr(
     costmap_->getSizeInCellsX(),
     costmap_->getSizeInCellsY());
 
   planner_->setCostmap(costmap_->getCharMap(), true, params_->allow_unknown);
-
-  lock.unlock();
 
   int map_start[2];
   map_start[0] = mx;

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -124,6 +124,9 @@ nav_msgs::msg::Path NavfnPlanner::createPlan(
   const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
+  std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> costmap_lock(
+    *(costmap_->getMutex()));
+
 #ifdef BENCHMARK_TESTING
   steady_clock::time_point a = steady_clock::now();
 #endif


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6429 (Bug 3) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Hold the costmap mutex for the complete `createPlan()` operation so the costmap geometry and NavFn potential array remain consistent.

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 3 PoC from #6429 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.