### PR TITLE
Fix concurrent access to footprint_ (Bug4 in #6429) 

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_topic_collision_checker.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_topic_collision_checker.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <mutex>
 #include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
@@ -101,6 +102,7 @@ protected:
   CostmapSubscriber & costmap_sub_;
   FootprintSubscriber * footprint_sub_ = nullptr;
   FootprintCollisionChecker<std::shared_ptr<Costmap2D>> collision_checker_;
+  std::mutex score_mutex_;
   rclcpp::Clock::SharedPtr clock_;
   Footprint footprint_;
   std::string footprint_string_;

--- a/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/src/costmap_topic_collision_checker.cpp
@@ -82,6 +82,7 @@ double CostmapTopicCollisionChecker::scorePose(
   const geometry_msgs::msg::Pose & pose,
   bool fetch_costmap_and_footprint)
 {
+  std::lock_guard<std::mutex> score_lock(score_mutex_);
   if (fetch_costmap_and_footprint) {
     try {
       collision_checker_.setCostmap(costmap_sub_.getCostmap());


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6429 (Bug 4) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Protect `scorePose()` with a mutex so that only one behavior thread can update and use the shared collision checker at a time.

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 4 PoC from #6429 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.