### PR TITLE
Fix integer overflow in AMCL k-d tree (Bug 1 in #6430)

### DIFF
--- a/nav2_amcl/src/pf/pf_kdtree.c
+++ b/nav2_amcl/src/pf/pf_kdtree.c
@@ -27,6 +27,7 @@
 
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -220,7 +221,7 @@ pf_kdtree_node_t * pf_kdtree_insert_node(
   pf_kdtree_node_t * node, int key[], double value)
 {
   int i;
-  int split, max_split;
+  int64_t split, max_split;
 
   // If the node doesn't exist yet...
   if (node == NULL) {
@@ -252,7 +253,7 @@ pf_kdtree_node_t * pf_kdtree_insert_node(
       max_split = 0;
       node->pivot_dim = -1;
       for (i = 0; i < 3; i++) {
-        split = abs(key[i] - node->key[i]);
+        split = llabs((int64_t)key[i] - (int64_t)node->key[i]);
         if (split > max_split) {
           max_split = split;
           node->pivot_dim = i;
@@ -260,7 +261,8 @@ pf_kdtree_node_t * pf_kdtree_insert_node(
       }
       assert(node->pivot_dim >= 0);
 
-      node->pivot_value = (key[node->pivot_dim] + node->key[node->pivot_dim]) / 2.0;
+      node->pivot_value =
+        ((double)key[node->pivot_dim] + (double)node->key[node->pivot_dim]) / 2.0;
 
       if (key[node->pivot_dim] < node->pivot_value) {
         node->children[0] = pf_kdtree_insert_node(self, node, NULL, key, value);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6430 (Bug 1) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Compute the key difference in `int64_t` before taking the absolute value.
-   Compute the pivot midpoint in `double` to avoid signed integer overflow during addition.

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 1 reproduction steps from #6430 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.