### PR TITLE
[Jazzy] Reject invalid laser_likelihood_max_dist (Bug3 in #6430)

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -23,6 +23,7 @@
 #include "nav2_amcl/amcl_node.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -1259,7 +1260,13 @@ AmclNode::dynamicParametersCallback(
         lambda_short_ = parameter.as_double();
         reinit_laser = true;
       } else if (param_name == "laser_likelihood_max_dist") {
-        laser_likelihood_max_dist_ = parameter.as_double();
+        const double value = parameter.as_double();
+        if (!std::isfinite(value) || value < 0.0) {
+          result.successful = false;
+          result.reason = "laser_likelihood_max_dist must be finite and non-negative";
+          return result;
+        }
+        laser_likelihood_max_dist_ = value;
         reinit_laser = true;
       } else if (param_name == "laser_max_range") {
         laser_max_range_ = parameter.as_double();

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
@@ -110,6 +111,33 @@ void TestAmclPose::initTestPose()
 TEST_F(TestAmclPose, SimpleAmclTest)
 {
   EXPECT_EQ(true, defaultAmclTest());
+
+}
+
+TEST_F(TestAmclPose, RejectInvalidLaserLikelihoodMaxDist)
+{
+  auto parameter_client =
+    std::make_shared<rclcpp::SyncParametersClient>(node, "amcl");
+
+  ASSERT_TRUE(parameter_client->wait_for_service(10s));
+
+  const double original_value =
+    parameter_client->get_parameter<double>("laser_likelihood_max_dist");
+
+  const double invalid_values[] = {
+    -1.0,
+    std::numeric_limits<double>::infinity()
+  };
+
+  for (const double invalid_value : invalid_values) {
+    const auto result = parameter_client->set_parameters_atomically(
+      {rclcpp::Parameter("laser_likelihood_max_dist", invalid_value)});
+
+    EXPECT_FALSE(result.successful);
+    EXPECT_EQ(
+      parameter_client->get_parameter<double>("laser_likelihood_max_dist"),
+      original_value);
+  }
 }
 
 int main(int argc, char **argv)

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -137,6 +137,8 @@ TEST_F(TestAmclPose, RejectInvalidLaserLikelihoodMaxDist)
       parameter_client->get_parameter<double>("laser_likelihood_max_dist"),
       original_value);
   }
+    EXPECT_TRUE(parameter_client->set_parameters_atomically(
+    {rclcpp::Parameter("laser_likelihood_max_dist", 1.0)}).successful);
 }
 
 int main(int argc, char **argv)

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -137,7 +137,7 @@ TEST_F(TestAmclPose, RejectInvalidLaserLikelihoodMaxDist)
       parameter_client->get_parameter<double>("laser_likelihood_max_dist"),
       original_value);
   }
-    EXPECT_TRUE(parameter_client->set_parameters_atomically(
+  EXPECT_TRUE(parameter_client->set_parameters_atomically(
     {rclcpp::Parameter("laser_likelihood_max_dist", 1.0)}).successful);
 }
 

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -111,7 +111,6 @@ void TestAmclPose::initTestPose()
 TEST_F(TestAmclPose, SimpleAmclTest)
 {
   EXPECT_EQ(true, defaultAmclTest());
-
 }
 
 TEST_F(TestAmclPose, RejectInvalidLaserLikelihoodMaxDist)

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -138,7 +138,7 @@ TEST_F(TestAmclPose, RejectInvalidLaserLikelihoodMaxDist)
       original_value);
   }
   EXPECT_TRUE(parameter_client->set_parameters_atomically(
-    {rclcpp::Parameter("laser_likelihood_max_dist", 1.0)}).successful);
+      {rclcpp::Parameter("laser_likelihood_max_dist", 1.0)}).successful);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6430 (Bug 3) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Reject the negative value in the runtime parameter callback.
-   Reject the non-finite value in the runtime parameter callback (because NaN<0 is also False)

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 3 PoC from #6430 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.