### PR TITLE
Add AxisAlignCritic to MPPI for holonomic (mecanum) platforms

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(mppi_critics SHARED
   src/critics/prefer_forward_critic.cpp
   src/critics/twirling_critic.cpp
   src/critics/velocity_deadband_critic.cpp
+  src/critics/axis_align_critic.cpp
 )
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # Apple Clang: use C++20 and optimization, omit -fconcepts

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -191,6 +191,16 @@ Uses inflated costmap cost directly to avoid obstacles
  | deadband_velocities   | double[] | Default [0.0, 0.0, 0.0].  The array of deadband velocities [vx, vz, wz]. A zero array indicates that the critic will take no action.      |
 
 
+#### Axis Align Critic
+ | Parameter             | Type     | Definition                                                                                                  |
+ | ---------------       | ------   | ----------------------------------------------------------------------------------------------------------- |
+ | cost_weight           | double   | Default 3.0. Weight to apply to critic term.                                                                |
+ | cost_power            | int      | Default 1. Power order to apply to term.                                                                    |
+ | threshold_to_consider | double   | Default 0.5. Distance between robot and goal above which the critic is considered, so the final approach into the goal is left to the goal critics. |
+ | normalize             | bool     | Default true. Score the ratio of the minor to the major body-axis velocity (0 for axis-aligned motion, 1 at 45 degrees), which is independent of speed. If false, score the minor-axis velocity magnitude itself, which also discourages driving fast. |
+
+Penalizes diagonal motion (commanding `vx` and `vy` at the same time) on holonomic platforms. Mecanum bases only drive two of their four wheels when translating at 45 degrees, which slips on real hardware, while pure forward or pure lateral motion drives all four. The critic is inactive for non-holonomic motion models. Weights of 2 to 4 work well alongside the default critic set; much larger weights start to trade diagonal motion for in-place rotation.
+
 ### XML configuration example
 ```
 controller_server:

--- a/nav2_mppi_controller/critics.xml
+++ b/nav2_mppi_controller/critics.xml
@@ -45,5 +45,9 @@
       <description>mppi critic for restricting command velocities in deadband range</description>
     </class>
 
+    <class type="mppi::critics::AxisAlignCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic for penalizing diagonal (simultaneous vx and vy) motion on holonomic platforms such as mecanum bases</description>
+    </class>
+
   </library>
 </class_libraries>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Rem3000
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// AI disclosure: this file was drafted with AI assistance (Claude) and reviewed by the author.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__AXIS_ALIGN_CRITIC_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__AXIS_ALIGN_CRITIC_HPP_
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/models/state.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::AxisAlignCritic
+ * @brief Critic objective function for holonomic platforms that penalizes diagonal motion,
+ * i.e. commanding vx and vy at the same time.
+ *
+ * Mecanum bases only drive two of their four wheels when translating at 45 degrees, which makes
+ * diagonal motion slip-prone and poorly tracked on real hardware, while pure forward/backward or
+ * pure lateral motion drives all four wheels. This critic scores each trajectory by how far its
+ * body-frame velocity is from either axis. It is inactive for non-holonomic motion models.
+ */
+class AxisAlignCritic : public CriticFunction
+{
+public:
+  /**
+   * @brief Initialize critic
+   */
+  void initialize() override;
+
+  /**
+   * @brief Evaluate cost related to diagonal (simultaneous vx / vy) motion
+   *
+   * @param costs [out] add reference cost values to this tensor
+   */
+  void score(CriticData & data) override;
+
+protected:
+  unsigned int power_{0};
+  float weight_{0};
+  float threshold_to_consider_{0};
+  bool normalize_{true};
+};
+
+}  // namespace mppi::critics
+
+#endif  // NAV2_MPPI_CONTROLLER__CRITICS__AXIS_ALIGN_CRITIC_HPP_

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
@@ -33,6 +33,28 @@ namespace mppi::critics
  * diagonal motion slip-prone and poorly tracked on real hardware, while pure forward/backward or
  * pure lateral motion drives all four wheels. This critic scores each trajectory by how far its
  * body-frame velocity is from either axis. It is inactive for non-holonomic motion models.
+ *
+ * The normalized score is not an arbitrary heuristic: for a mecanum base it is exactly the wheel
+ * speed imbalance whenever wz is zero. With 45 degree rollers, wheel radius r, half-wheelbase lx
+ * and half-track ly, the inverse kinematics of the four wheels are
+ *
+ *     r * w_fl = vx - vy - (lx + ly) * wz       r * w_fr = vx + vy + (lx + ly) * wz
+ *     r * w_rl = vx + vy - (lx + ly) * wz       r * w_rr = vx - vy + (lx + ly) * wz
+ *
+ * At wz = 0 the four wheel speeds collapse onto two magnitudes, |vx + vy| / r and |vx - vy| / r,
+ * whose larger and smaller values are (|vx| + |vy|) / r and abs(|vx| - |vy|) / r. Their
+ * normalized imbalance is therefore
+ *
+ *     (max - min) / (max + min) = 2 * min(|vx|, |vy|) / (2 * max(|vx|, |vy|))
+ *                               = min(|vx|, |vy|) / max(|vx|, |vy|)
+ *
+ * which is the ratio scored below. The geometry cancels, so the score depends on neither r nor
+ * lx, ly: it is 0 when all four wheels turn at the same speed and 1 at 45 degrees, where two of
+ * them are commanded to a standstill and the entire traction demand falls on the other two. That
+ * loss of traction margin, rather than kinematic infeasibility, is what the critic prices in.
+ * A non-zero wz breaks the pairing above, so the identity is stated for pure translation; the
+ * critic scores the translational part only and leaves rotation to the other critics. The
+ * identity is pinned by the AxisAlignCriticWheelSpeedImbalance test in test/critics_tests.cpp.
  */
 class AxisAlignCritic : public CriticFunction
 {

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/axis_align_critic.hpp
@@ -45,7 +45,7 @@ public:
   /**
    * @brief Evaluate cost related to diagonal (simultaneous vx / vy) motion
    *
-   * @param costs [out] add reference cost values to this tensor
+   * @param data Critic data to use in scoring; cost values are added to data.costs
    */
   void score(CriticData & data) override;
 

--- a/nav2_mppi_controller/src/critics/axis_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/axis_align_critic.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Rem3000
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// AI disclosure: this file was drafted with AI assistance (Claude) and reviewed by the author.
+
+#include "nav2_mppi_controller/critics/axis_align_critic.hpp"
+
+namespace mppi::critics
+{
+
+void AxisAlignCritic::initialize()
+{
+  auto getParam = parameters_handler_->getParamGetter(name_);
+
+  getParam(power_, "cost_power", 1);
+  getParam(weight_, "cost_weight", 3.0f);
+  getParam(threshold_to_consider_, "threshold_to_consider", 0.5f);
+  getParam(normalize_, "normalize", true);
+
+  RCLCPP_INFO(
+    logger_,
+    "AxisAlignCritic instantiated with %d power and %f weight, %s scaling.",
+    power_, weight_, normalize_ ? "ratio" : "absolute");
+}
+
+void AxisAlignCritic::score(CriticData & data)
+{
+  if (!enabled_ || !data.motion_model->isHolonomic() ||
+    data.state.local_path_length < threshold_to_consider_)
+  {
+    return;
+  }
+
+  const auto vx = data.state.vx.abs();
+  const auto vy = data.state.vy.abs();
+
+  Eigen::ArrayXf diagonal;
+  if (normalize_) {
+    // Ratio of the minor to the major body-axis velocity: 0 for axis-aligned motion,
+    // 1 at 45 degrees. Independent of speed, so the critic does not also discourage
+    // driving fast (the absolute form below does, which is rarely wanted).
+    diagonal = (vx.min(vy) / (vx.max(vy) + 1e-3f)).rowwise().mean();
+  } else {
+    diagonal = vx.min(vy).rowwise().mean();
+  }
+
+  if (power_ > 1u) {
+    data.costs += (diagonal * weight_).pow(power_);
+  } else {
+    data.costs += diagonal * weight_;
+  }
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mppi::critics::AxisAlignCritic, mppi::critics::CriticFunction)

--- a/nav2_mppi_controller/src/critics/axis_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/axis_align_critic.cpp
@@ -50,6 +50,8 @@ void AxisAlignCritic::score(CriticData & data)
     // Ratio of the minor to the major body-axis velocity: 0 for axis-aligned motion,
     // exactly 1 at 45 degrees. Independent of speed, so the critic does not also
     // discourage driving fast (the absolute form below does, which is rarely wanted).
+    // For a mecanum base at wz = 0 this ratio is the normalized wheel speed imbalance,
+    // see the derivation in the class documentation.
     // The major axis is clamped to a small floor only to avoid dividing by zero at rest.
     diagonal = (vx.min(vy) / vx.max(vy).max(1e-3f)).rowwise().mean();
   } else {

--- a/nav2_mppi_controller/src/critics/axis_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/axis_align_critic.cpp
@@ -48,9 +48,10 @@ void AxisAlignCritic::score(CriticData & data)
   Eigen::ArrayXf diagonal;
   if (normalize_) {
     // Ratio of the minor to the major body-axis velocity: 0 for axis-aligned motion,
-    // 1 at 45 degrees. Independent of speed, so the critic does not also discourage
-    // driving fast (the absolute form below does, which is rarely wanted).
-    diagonal = (vx.min(vy) / (vx.max(vy) + 1e-3f)).rowwise().mean();
+    // exactly 1 at 45 degrees. Independent of speed, so the critic does not also
+    // discourage driving fast (the absolute form below does, which is rarely wanted).
+    // The major axis is clamped to a small floor only to avoid dividing by zero at rest.
+    diagonal = (vx.min(vy) / vx.max(vy).max(1e-3f)).rowwise().mean();
   } else {
     diagonal = vx.min(vy).rowwise().mean();
   }

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -32,6 +32,7 @@
 #include "nav2_mppi_controller/critics/prefer_forward_critic.hpp"
 #include "nav2_mppi_controller/critics/twirling_critic.hpp"
 #include "nav2_mppi_controller/critics/velocity_deadband_critic.hpp"
+#include "nav2_mppi_controller/critics/axis_align_critic.hpp"
 #include "utils_test.cpp"  // NOLINT
 
 // Tests the various critic plugin functions
@@ -41,6 +42,20 @@
 using namespace mppi;  // NOLINT
 using namespace mppi::critics;  // NOLINT
 using namespace mppi::utils;  // NOLINT
+
+class AxisAlignCriticWrapper : public AxisAlignCritic
+{
+public:
+  AxisAlignCriticWrapper()
+  : AxisAlignCritic()
+  {
+  }
+
+  void setNormalize(bool normalize)
+  {
+    normalize_ = normalize;
+  }
+};
 
 class PathAngleCriticWrapper : public PathAngleCritic
 {
@@ -927,4 +942,93 @@ TEST(CriticTests, VelocityDeadbandCritic)
   critic.score(data);
   // 35.0 weight * 0.1 model_dt * (0.07 + 0.06 + 0.059) * 30 timesteps = 56.7
   EXPECT_NEAR(costs(1), 19.845, 0.01);
+}
+
+TEST(CriticTests, AxisAlignCritic)
+{
+  // Standard preamble
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  std::string name = "test";
+  ParametersHandler param_handler(node, name);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+
+  models::State state;
+  state.reset(1000, 30);
+  models::ControlSequence control_sequence;
+  models::Trajectories generated_trajectories;
+  models::Path path;
+  geometry_msgs::msg::Pose goal;
+  Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
+  float model_dt = 0.1;
+  CriticData data =
+  {state, generated_trajectories, path, goal, costs, model_dt,
+    false, nullptr, nullptr, std::nullopt, std::nullopt, {}};
+  data.motion_model = std::make_shared<OmniMotionModel>();
+  state.local_path_length = 5.0f;  // far from goal, critic active
+
+  // Initialization testing
+
+  // Make sure initializes correctly and that defaults are reasonable
+  AxisAlignCriticWrapper critic;
+  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
+  EXPECT_EQ(critic.getName(), "critic");
+
+  // Scoring testing
+
+  // pure forward motion is axis aligned, should not have any costs
+  state.vx.setConstant(0.80f);
+  state.vy.setConstant(0.0f);
+  critic.score(data);
+  EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
+
+  // pure lateral motion is axis aligned too
+  state.vx.setConstant(0.0f);
+  state.vy.setConstant(0.60f);
+  critic.score(data);
+  EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
+
+  // 45 degree motion: ratio 0.5 / (0.5 + 1e-3) * 3.0 weight
+  state.vx.setConstant(0.50f);
+  state.vy.setConstant(0.50f);
+  critic.score(data);
+  EXPECT_NEAR(costs(1), 3.0 * 0.5 / 0.501, 1e-3);
+
+  // partially diagonal motion: ratio 0.3 / (0.6 + 1e-3) * 3.0 weight
+  costs.setZero();
+  state.vx.setConstant(0.60f);
+  state.vy.setConstant(0.30f);
+  critic.score(data);
+  EXPECT_NEAR(costs(1), 3.0 * 0.3 / 0.601, 1e-3);
+
+  // ratio scaling is independent of speed: slow 45 degree motion costs the same as fast
+  costs.setZero();
+  state.vx.setConstant(0.10f);
+  state.vy.setConstant(0.10f);
+  critic.score(data);
+  EXPECT_NEAR(costs(1), 3.0 * 0.1 / 0.101, 1e-3);
+
+  // absolute scaling: minor axis magnitude 0.3 * 3.0 weight
+  critic.setNormalize(false);
+  costs.setZero();
+  state.vx.setConstant(0.60f);
+  state.vy.setConstant(0.30f);
+  critic.score(data);
+  EXPECT_NEAR(costs(1), 0.9, 1e-3);
+  critic.setNormalize(true);
+
+  // within threshold_to_consider of the goal the critic yields to the goal critics
+  costs.setZero();
+  state.local_path_length = 0.2f;
+  critic.score(data);
+  EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
+  state.local_path_length = 5.0f;
+
+  // non-holonomic motion models have no vy, critic is inactive
+  costs.setZero();
+  data.motion_model = std::make_shared<DiffDriveMotionModel>();
+  critic.score(data);
+  EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
 }

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -16,6 +16,10 @@
 #include <chrono>
 #include <thread>
 #include <random>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
@@ -1031,4 +1035,79 @@ TEST(CriticTests, AxisAlignCritic)
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   critic.score(data);
   EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
+}
+
+TEST(CriticTests, AxisAlignCriticWheelSpeedImbalance)
+{
+  // The normalized AxisAlignCritic score is not a free-form heuristic: at wz = 0 it is exactly
+  // the wheel speed imbalance of a mecanum base, derived in axis_align_critic.hpp. This test
+  // pins that identity against an independent implementation of the mecanum inverse kinematics,
+  // so the ratio in score() cannot drift away from the physical quantity it claims to measure.
+  auto wheel_speed_imbalance = [](float vx, float vy, float r, float lx_plus_ly) {
+      const float wz = 0.0f;  // the identity holds for pure translation
+      const float rot = lx_plus_ly * wz;
+      const float w_front_left = (vx - vy - rot) / r;
+      const float w_front_right = (vx + vy + rot) / r;
+      const float w_rear_left = (vx + vy - rot) / r;
+      const float w_rear_right = (vx - vy + rot) / r;
+      const float highest = std::max(
+        std::max(std::fabs(w_front_left), std::fabs(w_front_right)),
+        std::max(std::fabs(w_rear_left), std::fabs(w_rear_right)));
+      const float lowest = std::min(
+        std::min(std::fabs(w_front_left), std::fabs(w_front_right)),
+        std::min(std::fabs(w_rear_left), std::fabs(w_rear_right)));
+      return (highest - lowest) / (highest + lowest);
+    };
+
+  // Standard preamble
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", true);
+  std::string name = "test";
+  ParametersHandler param_handler(node, name);
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+
+  models::State state;
+  state.reset(1000, 30);
+  models::ControlSequence control_sequence;
+  models::Trajectories generated_trajectories;
+  models::Path path;
+  geometry_msgs::msg::Pose goal;
+  Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
+  float model_dt = 0.1;
+  CriticData data =
+  {state, generated_trajectories, path, goal, costs, model_dt,
+    false, nullptr, nullptr, std::nullopt, std::nullopt, {}};
+  data.motion_model = std::make_shared<OmniMotionModel>();
+  state.local_path_length = 5.0f;  // far from goal, critic active
+
+  AxisAlignCritic critic;
+  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
+  const float weight = 3.0f;  // default cost_weight, with the default cost_power of 1
+
+  // Axis aligned, diagonal, and everything in between, including negative velocities
+  const std::vector<std::pair<float, float>> velocities = {
+    {0.80f, 0.00f}, {0.00f, 0.60f}, {0.50f, 0.50f}, {0.10f, 0.10f},
+    {0.60f, 0.30f}, {0.72f, 0.18f}, {-0.60f, 0.30f}, {0.35f, -0.70f}};
+
+  // A small and a large platform: r, lx and ly cancel, so both must give the same imbalance
+  const std::vector<std::pair<float, float>> geometries = {{0.0375f, 0.16f}, {0.1275f, 0.53f}};
+
+  for (const auto & velocity : velocities) {
+    const float vx = velocity.first;
+    const float vy = velocity.second;
+    state.vx.setConstant(vx);
+    state.vy.setConstant(vy);
+    state.wz.setConstant(0.0f);
+    costs.setZero();
+    critic.score(data);
+    const float scored_ratio = costs(0) / weight;
+
+    for (const auto & geometry : geometries) {
+      EXPECT_NEAR(
+        scored_ratio, wheel_speed_imbalance(vx, vy, geometry.first, geometry.second),
+        1e-5);
+    }
+  }
 }

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -1014,6 +1014,31 @@ TEST(CriticTests, AxisAlignCritic)
   critic.score(data);
   EXPECT_NEAR(costs(1), 3.0, 1e-5);
 
+  // at a standstill the clamped major axis keeps the ratio finite instead of dividing 0 by 0
+  costs.setZero();
+  state.vx.setConstant(0.0f);
+  state.vy.setConstant(0.0f);
+  critic.score(data);
+  EXPECT_TRUE(std::isfinite(costs(0)));
+  EXPECT_NEAR(costs(0), 0.0, 1e-6);
+
+  // below the 1e-3 floor the clamp scales the ratio down rather than reporting a full diagonal:
+  // 45 degree motion at 1e-4 scores 1e-4 / 1e-3 = 0.1 of the ratio, 0.1 * 3.0 weight
+  costs.setZero();
+  state.vx.setConstant(1e-4f);
+  state.vy.setConstant(1e-4f);
+  critic.score(data);
+  EXPECT_GT(costs(0), 0.0f);
+  EXPECT_LT(costs(0), 3.0f);
+  EXPECT_NEAR(costs(0), 0.3, 1e-5);
+
+  // at the floor itself the ratio is unaffected, 45 degree motion scores the full 1.0 * 3.0 weight
+  costs.setZero();
+  state.vx.setConstant(1e-3f);
+  state.vy.setConstant(1e-3f);
+  critic.score(data);
+  EXPECT_NEAR(costs(0), 3.0, 1e-5);
+
   // absolute scaling: minor axis magnitude 0.3 * 3.0 weight
   critic.setNormalize(false);
   costs.setZero();
@@ -1022,6 +1047,19 @@ TEST(CriticTests, AxisAlignCritic)
   critic.score(data);
   EXPECT_NEAR(costs(1), 0.9, 1e-3);
   critic.setNormalize(true);
+
+  // cost power greater than one squares the weighted ratio: (0.5 ratio * 3.0 weight)^2 = 2.25
+  node->set_parameter(rclcpp::Parameter("critic.cost_power", 2));
+  critic = AxisAlignCriticWrapper();
+  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
+  costs.setZero();
+  state.vx.setConstant(0.60f);
+  state.vy.setConstant(0.30f);
+  critic.score(data);
+  EXPECT_NEAR(costs(1), 2.25, 1e-5);
+  node->set_parameter(rclcpp::Parameter("critic.cost_power", 1));
+  critic = AxisAlignCriticWrapper();
+  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
 
   // within threshold_to_consider of the goal the critic yields to the goal critics
   costs.setZero();

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -990,25 +990,25 @@ TEST(CriticTests, AxisAlignCritic)
   critic.score(data);
   EXPECT_NEAR(costs.sum(), 0.0, 1e-6);
 
-  // 45 degree motion: ratio 0.5 / (0.5 + 1e-3) * 3.0 weight
+  // 45 degree motion: ratio 1.0 * 3.0 weight
   state.vx.setConstant(0.50f);
   state.vy.setConstant(0.50f);
   critic.score(data);
-  EXPECT_NEAR(costs(1), 3.0 * 0.5 / 0.501, 1e-3);
+  EXPECT_NEAR(costs(1), 3.0, 1e-5);
 
-  // partially diagonal motion: ratio 0.3 / (0.6 + 1e-3) * 3.0 weight
+  // partially diagonal motion: ratio 0.3 / 0.6 * 3.0 weight
   costs.setZero();
   state.vx.setConstant(0.60f);
   state.vy.setConstant(0.30f);
   critic.score(data);
-  EXPECT_NEAR(costs(1), 3.0 * 0.3 / 0.601, 1e-3);
+  EXPECT_NEAR(costs(1), 1.5, 1e-5);
 
   // ratio scaling is independent of speed: slow 45 degree motion costs the same as fast
   costs.setZero();
   state.vx.setConstant(0.10f);
   state.vy.setConstant(0.10f);
   critic.score(data);
-  EXPECT_NEAR(costs(1), 3.0 * 0.1 / 0.101, 1e-3);
+  EXPECT_NEAR(costs(1), 3.0, 1e-5);
 
   // absolute scaling: minor axis magnitude 0.3 * 3.0 weight
   critic.setNormalize(false);


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6330 . This is the issue discussing the hardware limitations of mecanum wheels, and the maintainer mentioned that contributions of a new critic are welcome. |
| Primary OS tested on | I am developing on Ubuntu 22.04, with builds and tests in a ROS rolling container (Ubuntu 24.04). |
| Robotic platform tested on | A mecanum robot, simulated in both Gazebo Classic and Isaac Sim within a 40 cm corridor maze. |
| Does this PR contain AI generated software? | Yes, the files are marked accordingly. |
| Was this PR description generated by AI software? | No. |

---

## Description of contribution in a few bullet points

I was testing Nav2 on last year's competition environment with the mecanum robot and noticed that diagonal motion in reality causes noticeable wheel slip and poor path tracking. I asked the AI to add a new critic named AxisAlignCritic for holonomic platforms. Its function is to penalize vx and vy commanded at the same time, essentially discouraging diagonal motion. This has no effect on non-holonomic motion models.

Reasoning: When a mecanum robot performs 45° diagonal motion, only two wheels drive, which in real-world navigation leads to wheel slip. In contrast, pure forward motion or pure lateral motion engages all four wheels, reducing slips.

The cost is based on the ratio of the minor to the major body-axis velocity, ranging from 0 to 1, and is independent of speed, so it does not slow the robot down. Like other critics, it is disabled within `threshold_to_consider` of the goal.

## Description of documentation updates required from your changes

- A companion PR to docs.nav2.org adds the parameter section and a migration guide entry: ros-navigation/docs.nav2.org#966
- The README parameter table has also been updated.

## Description of how this change was tested

- Unit tests were drafted with AI assistance, reviewed and executed by me, located in critics_tests.cpp, and built in the rolling container. All 26 critics_tests passed, and lint checks are clean.
- Gazebo experiments: 4 parallel runs per setting. With a weight of 4.0, the share of commanded diagonal motion decreased from 45% to 30–32%, and the lap time improved from 14.3 seconds to 13.4–13.6 seconds (each set validated over 3–4 runs). Clearance remained the same or slightly better: 3.0 cm without the critic, 3.6–4.1 cm with the critic enabled.
- Note: Recovery behaviors appeared starting at weight 6.0 (3 recoveries in one run). In-place rotation increased to 23% only at 8.0 or above. The README recommends a weight of 2–4.

---

## Future work that may be required in bullet points

- Haven't yet measured improvements in wheel slip on the physical robot. I plan to perform real-world tests within two weeks and update the results. Current tests are only with one simulated robot in a single maze.

This is my first contribution—feedback is welcome!

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
