### PR TITLE
Proposed costmap layer: monocular (learned) depth with confidence gating

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(layers SHARED
   plugins/range_sensor_layer.cpp
   plugins/denoise_layer.cpp
   plugins/plugin_container_layer.cpp
+  pulgins/monocular_depth_layer.cpp
 )
 target_include_directories(layers
   PUBLIC

--- a/nav2_costmap_2d/costmap_plugins.xml
+++ b/nav2_costmap_2d/costmap_plugins.xml
@@ -27,6 +27,9 @@
     <class type="nav2_costmap_2d::PluginContainerLayer" base_class_type="nav2_costmap_2d::Layer">
       <description>Plugin to group different layers within the same costmap</description>
     </class>
+    <class type="nav2_costmap_2d::MonocularDepthLayer" base_class_type="nav2_costmap_2d::Layer">
+      <description>Monocular depth layer costmap</description>
+    </class>
   </library>
 
   <library path="filters">

--- a/nav2_costmap_2d/include/nav2_costmap_2d/deprojection.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/deprojection.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Ocean Code AI Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file was authored with the assistance of an AI system,
+// reviewed and validated by the submitter. Disclosed per the Nav2 PR
+// template's AI-generated-software policy.
+
+#ifndef NAV2_MONOCULAR_DEPTH_LAYER__DEPROJECTION_HPP_
+#define NAV2_MONOCULAR_DEPTH_LAYER__DEPROJECTION_HPP_
+
+#include <array>
+
+namespace nav2_monocular_depth_layer
+{
+
+/**
+ * @brief Deproject an image pixel with a known metric depth into a 3D point in
+ *        the camera OPTICAL frame (REP 103: +x right, +y down, +z forward).
+ *
+ * @param u     pixel column
+ * @param v     pixel row
+ * @param depth metric depth along the optical axis, in metres (> 0)
+ * @param fx    focal length x (pixels), CameraInfo K[0]
+ * @param fy    focal length y (pixels), CameraInfo K[4]
+ * @param cx    principal point x (pixels), CameraInfo K[2]
+ * @param cy    principal point y (pixels), CameraInfo K[5]
+ * @return {x, y, z} in the camera optical frame, in metres
+ */
+inline std::array<double, 3> deproject(
+  double u, double v, double depth,
+  double fx, double fy, double cx, double cy)
+{
+  return {
+    (u - cx) * depth / fx,
+    (v - cy) * depth / fy,
+    depth
+  };
+}
+
+}  // namespace nav2_monocular_depth_layer
+
+#endif  // NAV2_MONOCULAR_DEPTH_LAYER__DEPROJECTION_HPP_

--- a/nav2_costmap_2d/include/nav2_costmap_2d/monocular_depth_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/monocular_depth_layer.hpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Ocean Code AI Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file was authored with the assistance of an AI system,
+// reviewed and validated by the submitter. Disclosed per the Nav2 PR
+// template's AI-generated-software policy.
+
+#ifndef NAV2_MONOCULAR_DEPTH_LAYER__MONOCULAR_DEPTH_LAYER_HPP_
+#define NAV2_MONOCULAR_DEPTH_LAYER__MONOCULAR_DEPTH_LAYER_HPP_
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "tf2/time.hpp"
+
+#include "nav2_costmap_2d/costmap_layer.hpp"
+#include "nav2_costmap_2d/layered_costmap.hpp"
+
+namespace nav2_monocular_depth_layer
+{
+
+/**
+ * @class MonocularDepthLayer
+ * @brief A costmap layer that marks and clears cells from a single monocular
+ *        depth stream (e.g. a learned DINOv2/DPT depth network) plus its
+ *        CameraInfo, with per-pixel confidence gating and spatial agreement
+ *        filtering to reject the flicker that dense learned depth produces.
+ *
+ * This layer intentionally does NOT run any neural network. A separate node is
+ * expected to publish metric depth as sensor_msgs/Image (32FC1 in metres, or
+ * 16UC1 in millimetres) and, optionally, a matching confidence image (32FC1 in
+ * [0, 1]). Keeping inference out of the costmap process preserves Nav2's
+ * separation of concerns and lets any monocular estimator drive the layer.
+ */
+class MonocularDepthLayer : public nav2_costmap_2d::CostmapLayer
+{
+public:
+  MonocularDepthLayer() = default;
+  ~MonocularDepthLayer() override = default;
+
+  void onInitialize() override;
+  void updateBounds(
+    double robot_x, double robot_y, double robot_yaw,
+    double * min_x, double * min_y, double * max_x, double * max_y) override;
+  void updateCosts(
+    nav2_costmap_2d::Costmap2D & master_grid,
+    int min_i, int min_j, int max_i, int max_j) override;
+
+  void activate() override {}
+  void deactivate() override {}
+  void reset() override;
+  bool isClearable() override {return true;}
+
+private:
+  /// @brief Cache the latest depth frame (thread: subscription callback).
+  void depthCallback(sensor_msgs::msg::Image::ConstSharedPtr msg);
+  /// @brief Cache the latest confidence frame.
+  void confidenceCallback(sensor_msgs::msg::Image::ConstSharedPtr msg);
+  /// @brief Cache the latest intrinsics.
+  void cameraInfoCallback(sensor_msgs::msg::CameraInfo::ConstSharedPtr msg);
+
+  /// @brief Read one pixel of a 32FC1/16UC1 depth image, in metres. Returns
+  ///        NaN for invalid/zero returns.
+  double depthAt(const sensor_msgs::msg::Image & img, int u, int v) const;
+  /// @brief Read one pixel of a 32FC1 confidence image in [0, 1]. Returns 1.0
+  ///        if no confidence image is available.
+  double confidenceAt(int u, int v) const;
+
+  /// @brief Deproject, transform, filter and write the pending frame into this
+  ///        layer's own costmap buffer. Returns the touched world bounds.
+  bool processPendingFrame(
+    double * min_x, double * min_y, double * max_x, double * max_y);
+
+  // --- Parameters -----------------------------------------------------------
+  std::string depth_topic_;
+  std::string confidence_topic_;
+  std::string camera_info_topic_;
+  std::string global_frame_;
+
+  double min_obstacle_range_{0.3};    ///< metres; nearer returns are ignored
+  double max_obstacle_range_{8.0};    ///< metres; farther returns are ignored
+  double max_clearing_range_{8.0};    ///< metres; ray-clear up to this distance
+  double min_obstacle_height_{0.05};  ///< metres in the global frame
+  double max_obstacle_height_{2.0};   ///< metres in the global frame
+  double min_confidence_{0.5};        ///< [0, 1]; pixels below are dropped
+  double depth_scale_correction_{1.0};///< static multiplier for residual scale
+  int subsample_step_{4};             ///< process every Nth pixel per axis
+  int min_points_per_cell_{2};        ///< spatial-agreement mark threshold
+  double observation_persistence_{0.0};  ///< s; 0 keeps only the latest frame
+  double transform_tolerance_{0.2};   ///< s
+  int combination_method_{1};         ///< 0=overwrite 1=max 2=max-no-unknown
+  bool track_unknown_space_{false};
+  bool clearing_enabled_{true};
+
+  // --- State ----------------------------------------------------------------
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr depth_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr confidence_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
+
+  std::mutex data_lock_;
+  sensor_msgs::msg::Image::ConstSharedPtr pending_depth_;
+  sensor_msgs::msg::Image::ConstSharedPtr latest_confidence_;
+  sensor_msgs::msg::CameraInfo::ConstSharedPtr camera_info_;
+  rclcpp::Time last_frame_stamp_{0, 0, RCL_ROS_TIME};
+
+  bool rolling_window_{false};
+  bool was_reset_{false};
+  tf2::Duration transform_tolerance_dur_{tf2::durationFromSec(0.2)};
+
+  // Per-cell hit accumulator, sized to the layer, reused each frame.
+  std::vector<uint16_t> hit_counts_;
+};
+
+}  // namespace nav2_monocular_depth_layer
+
+#endif  // NAV2_MONOCULAR_DEPTH_LAYER__MONOCULAR_DEPTH_LAYER_HPP_

--- a/nav2_costmap_2d/plugins/monocular_depth_layer.cpp
+++ b/nav2_costmap_2d/plugins/monocular_depth_layer.cpp
@@ -1,0 +1,369 @@
+// Copyright (c) 2026 Ocean Code AI Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file was authored with the assistance of an AI system,
+// reviewed and validated by the submitter. Disclosed per the Nav2 PR
+// template's AI-generated-software policy.
+
+#include "nav2_monocular_depth_layer/monocular_depth_layer.hpp"
+#include "nav2_monocular_depth_layer/deprojection.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+
+#include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_util/raytrace_line_2d.hpp"
+#include "tf2/LinearMath/Transform.hpp"
+#include "tf2/LinearMath/Vector3.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "pluginlib/class_list_macros.hpp"
+
+using nav2_costmap_2d::FREE_SPACE;
+using nav2_costmap_2d::LETHAL_OBSTACLE;
+using nav2_costmap_2d::NO_INFORMATION;
+
+namespace nav2_monocular_depth_layer
+{
+
+void MonocularDepthLayer::onInitialize()
+{
+  auto node = node_.lock();
+  if (!node) {
+    throw std::runtime_error{"MonocularDepthLayer: failed to lock node"};
+  }
+
+  global_frame_ = layered_costmap_->getGlobalFrameID();
+  rolling_window_ = layered_costmap_->isRolling();
+
+  enabled_ = node->declare_or_get_parameter(name_ + "." + "enabled", true);
+  depth_topic_ = node->declare_or_get_parameter(
+    name_ + "." + "depth_topic", std::string("depth"));
+  confidence_topic_ = node->declare_or_get_parameter(
+    name_ + "." + "confidence_topic", std::string(""));
+  camera_info_topic_ = node->declare_or_get_parameter(
+    name_ + "." + "camera_info_topic", std::string("camera_info"));
+
+  min_obstacle_range_ = node->declare_or_get_parameter(
+    name_ + "." + "min_obstacle_range", 0.3);
+  max_obstacle_range_ = node->declare_or_get_parameter(
+    name_ + "." + "max_obstacle_range", 8.0);
+  max_clearing_range_ = node->declare_or_get_parameter(
+    name_ + "." + "max_clearing_range", 8.0);
+  min_obstacle_height_ = node->declare_or_get_parameter(
+    name_ + "." + "min_obstacle_height", 0.05);
+  max_obstacle_height_ = node->declare_or_get_parameter(
+    name_ + "." + "max_obstacle_height", 2.0);
+  min_confidence_ = node->declare_or_get_parameter(
+    name_ + "." + "min_confidence", 0.5);
+  depth_scale_correction_ = node->declare_or_get_parameter(
+    name_ + "." + "depth_scale_correction", 1.0);
+  subsample_step_ = node->declare_or_get_parameter(
+    name_ + "." + "subsample_step", 4);
+  min_points_per_cell_ = node->declare_or_get_parameter(
+    name_ + "." + "min_points_per_cell", 2);
+  observation_persistence_ = node->declare_or_get_parameter(
+    name_ + "." + "observation_persistence", 0.0);
+  combination_method_ = node->declare_or_get_parameter(
+    name_ + "." + "combination_method", 1);
+  track_unknown_space_ = node->declare_or_get_parameter(
+    name_ + "." + "track_unknown_space", layered_costmap_->isTrackingUnknown());
+  clearing_enabled_ = node->declare_or_get_parameter(
+    name_ + "." + "clearing_enabled", true);
+  transform_tolerance_ = node->declare_or_get_parameter(
+    name_ + "." + "transform_tolerance", 0.2);
+  transform_tolerance_dur_ = tf2::durationFromSec(transform_tolerance_);
+
+  subsample_step_ = std::max(1, subsample_step_);
+
+  default_value_ = track_unknown_space_ ? NO_INFORMATION : FREE_SPACE;
+  matchSize();
+  current_ = true;
+  was_reset_ = false;
+
+  depth_topic_ = joinWithParentNamespace(depth_topic_);
+  camera_info_topic_ = joinWithParentNamespace(camera_info_topic_);
+
+  depth_sub_ = node->create_subscription<sensor_msgs::msg::Image>(
+    depth_topic_,
+    std::bind(&MonocularDepthLayer::depthCallback, this, std::placeholders::_1),
+    rclcpp::SensorDataQoS());
+  camera_info_sub_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
+    camera_info_topic_,
+    std::bind(&MonocularDepthLayer::cameraInfoCallback, this, std::placeholders::_1),
+    rclcpp::SensorDataQoS());
+
+  if (!confidence_topic_.empty()) {
+    confidence_topic_ = joinWithParentNamespace(confidence_topic_);
+    confidence_sub_ = node->create_subscription<sensor_msgs::msg::Image>(
+      confidence_topic_,
+      std::bind(&MonocularDepthLayer::confidenceCallback, this, std::placeholders::_1),
+      rclcpp::SensorDataQoS());
+  }
+
+  RCLCPP_INFO(
+    logger_,
+    "MonocularDepthLayer '%s' subscribing to depth '%s' and camera_info '%s'",
+    name_.c_str(), depth_topic_.c_str(), camera_info_topic_.c_str());
+}
+
+void MonocularDepthLayer::depthCallback(sensor_msgs::msg::Image::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(data_lock_);
+  pending_depth_ = msg;
+}
+
+void MonocularDepthLayer::confidenceCallback(sensor_msgs::msg::Image::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(data_lock_);
+  latest_confidence_ = msg;
+}
+
+void MonocularDepthLayer::cameraInfoCallback(sensor_msgs::msg::CameraInfo::ConstSharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(data_lock_);
+  camera_info_ = msg;
+}
+
+double MonocularDepthLayer::depthAt(const sensor_msgs::msg::Image & img, int u, int v) const
+{
+  const auto row = static_cast<size_t>(v) * img.step;
+  if (img.encoding == "32FC1") {
+    float d;
+    std::memcpy(&d, &img.data[row + static_cast<size_t>(u) * sizeof(float)], sizeof(float));
+    if (!std::isfinite(d) || d <= 0.0f) {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return static_cast<double>(d) * depth_scale_correction_;
+  } else if (img.encoding == "16UC1") {
+    uint16_t d;
+    std::memcpy(&d, &img.data[row + static_cast<size_t>(u) * sizeof(uint16_t)], sizeof(uint16_t));
+    if (d == 0) {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return static_cast<double>(d) * 0.001 * depth_scale_correction_;  // mm -> m
+  }
+  return std::numeric_limits<double>::quiet_NaN();
+}
+
+double MonocularDepthLayer::confidenceAt(int u, int v) const
+{
+  if (!latest_confidence_ || latest_confidence_->encoding != "32FC1") {
+    return 1.0;
+  }
+  const auto & img = *latest_confidence_;
+  if (u < 0 || v < 0 ||
+    u >= static_cast<int>(img.width) || v >= static_cast<int>(img.height))
+  {
+    return 1.0;
+  }
+  const auto idx = static_cast<size_t>(v) * img.step + static_cast<size_t>(u) * sizeof(float);
+  float c;
+  std::memcpy(&c, &img.data[idx], sizeof(float));
+  return std::isfinite(c) ? static_cast<double>(c) : 0.0;
+}
+
+bool MonocularDepthLayer::processPendingFrame(
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  sensor_msgs::msg::Image::ConstSharedPtr depth;
+  sensor_msgs::msg::CameraInfo::ConstSharedPtr info;
+  {
+    std::lock_guard<std::mutex> lock(data_lock_);
+    depth = pending_depth_;
+    info = camera_info_;
+    pending_depth_.reset();
+  }
+  if (!depth || !info) {
+    return false;
+  }
+  if (depth->encoding != "32FC1" && depth->encoding != "16UC1") {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000,
+      "MonocularDepthLayer: unsupported depth encoding '%s' (need 32FC1 or 16UC1)",
+      depth->encoding.c_str());
+    return false;
+  }
+
+  // Look up the camera-optical -> global transform once for the whole frame.
+  geometry_msgs::msg::TransformStamped tf_msg;
+  try {
+    tf_msg = tf_->lookupTransform(
+      global_frame_, depth->header.frame_id,
+      tf2::TimePoint(std::chrono::nanoseconds(rclcpp::Time(depth->header.stamp).nanoseconds())),
+      transform_tolerance_dur_);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000,
+      "MonocularDepthLayer: transform %s -> %s failed: %s",
+      depth->header.frame_id.c_str(), global_frame_.c_str(), ex.what());
+    return false;
+  }
+
+  tf2::Transform cam_to_global;
+  tf2::fromMsg(tf_msg.transform, cam_to_global);
+  const tf2::Vector3 sensor_origin = cam_to_global.getOrigin();
+
+  const double fx = info->k[0], fy = info->k[4];
+  const double cx = info->k[2], cy = info->k[5];
+  if (fx == 0.0 || fy == 0.0) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_, 5000, "MonocularDepthLayer: CameraInfo has zero focal length");
+    return false;
+  }
+
+  const int width = static_cast<int>(depth->width);
+  const int height = static_cast<int>(depth->height);
+  const double min_r2 = min_obstacle_range_ * min_obstacle_range_;
+  const double max_r2 = max_obstacle_range_ * max_obstacle_range_;
+
+  // Fresh layer each frame (this layer is intended for a rolling local costmap
+  // and does not persist marks across frames unless observation_persistence>0,
+  // which is left as documented future work). Reset the accumulator too.
+  resetMaps();
+  hit_counts_.assign(static_cast<size_t>(size_x_) * size_y_, 0);
+
+  unsigned int sx, sy;
+  const bool have_sensor_cell = worldToMap(sensor_origin.x(), sensor_origin.y(), sx, sy);
+
+  // Pass 1: deproject, transform, range/height/confidence filter, and either
+  // accumulate a mark hit or ray-clear free space toward the return.
+  for (int v = 0; v < height; v += subsample_step_) {
+    for (int u = 0; u < width; u += subsample_step_) {
+      const double d = depthAt(*depth, u, v);
+      if (!std::isfinite(d)) {
+        continue;
+      }
+      const double r2 = d * d;
+      if (r2 < min_r2 || r2 > max_r2) {
+        continue;
+      }
+      if (confidenceAt(u, v) < min_confidence_) {
+        continue;
+      }
+
+      // Optical-frame deprojection (REP 103: x right, y down, z forward).
+      const auto pc = deproject(u, v, d, fx, fy, cx, cy);
+      const tf2::Vector3 p = cam_to_global * tf2::Vector3(pc[0], pc[1], pc[2]);
+
+      unsigned int mx, my;
+      if (!worldToMap(p.x(), p.y(), mx, my)) {
+        continue;
+      }
+
+      // Clear free space along the ray from the sensor to this return.
+      if (clearing_enabled_ && have_sensor_cell && d <= max_clearing_range_) {
+        nav2_costmap_2d::Costmap2D::MarkCell clearer(costmap_, FREE_SPACE);
+        nav2_util::raytraceLine(clearer, sx, sy, mx, my, size_x_);
+      }
+
+      // Only returns inside the height band count as obstacles.
+      if (p.z() >= min_obstacle_height_ && p.z() <= max_obstacle_height_) {
+        hit_counts_[static_cast<size_t>(my) * size_x_ + mx]++;
+      }
+    }
+  }
+
+  // Pass 2: promote cells with enough spatial agreement to lethal, and grow the
+  // update bounds to cover everything we touched.
+  bool touched_any = false;
+  for (unsigned int j = 0; j < size_y_; ++j) {
+    for (unsigned int i = 0; i < size_x_; ++i) {
+      const size_t idx = static_cast<size_t>(j) * size_x_ + i;
+      double wx, wy;
+      if (hit_counts_[idx] >= static_cast<uint16_t>(min_points_per_cell_)) {
+        costmap_[idx] = LETHAL_OBSTACLE;
+        mapToWorld(i, j, wx, wy);
+        touch(wx, wy, min_x, min_y, max_x, max_y);
+        touched_any = true;
+      } else if (clearing_enabled_ && costmap_[idx] == FREE_SPACE && default_value_ != FREE_SPACE) {
+        // A cell we actively cleared; include it in the bounds so it is written.
+        mapToWorld(i, j, wx, wy);
+        touch(wx, wy, min_x, min_y, max_x, max_y);
+        touched_any = true;
+      }
+    }
+  }
+
+  last_frame_stamp_ = clock_->now();
+  return touched_any;
+}
+
+void MonocularDepthLayer::updateBounds(
+  double robot_x, double robot_y, double /*robot_yaw*/,
+  double * min_x, double * min_y, double * max_x, double * max_y)
+{
+  if (rolling_window_) {
+    updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
+  }
+  if (!enabled_) {
+    return;
+  }
+  useExtraBounds(min_x, min_y, max_x, max_y);
+
+  const bool had_new = processPendingFrame(min_x, min_y, max_x, max_y);
+
+  // Staleness check: if no fresh frame within the persistence window, flag the
+  // layer as not-current so the planner knows this data may be unsafe.
+  const double age = (clock_->now() - last_frame_stamp_).seconds();
+  if (had_new) {
+    current_ = true;
+  } else if (observation_persistence_ > 0.0 && age > observation_persistence_) {
+    current_ = false;
+  }
+
+  if (was_reset_) {
+    was_reset_ = false;
+    current_ = false;
+  }
+}
+
+void MonocularDepthLayer::updateCosts(
+  nav2_costmap_2d::Costmap2D & master_grid,
+  int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_) {
+    return;
+  }
+  switch (combination_method_) {
+    case 0:  // Overwrite
+      updateWithOverwrite(master_grid, min_i, min_j, max_i, max_j);
+      break;
+    case 2:  // Max, but do not overwrite known cells with unknown
+      updateWithMaxWithoutUnknownOverwrite(master_grid, min_i, min_j, max_i, max_j);
+      break;
+    case 1:  // Max (default)
+    default:
+      updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+      break;
+  }
+}
+
+void MonocularDepthLayer::reset()
+{
+  resetMaps();
+  {
+    std::lock_guard<std::mutex> lock(data_lock_);
+    pending_depth_.reset();
+  }
+  current_ = false;
+  was_reset_ = true;
+}
+
+}  // namespace nav2_monocular_depth_layer
+
+PLUGINLIB_EXPORT_CLASS(
+  nav2_monocular_depth_layer::MonocularDepthLayer, nav2_costmap_2d::Layer)

--- a/nav2_costmap_2d/test/unit/test_deprojection.cpp
+++ b/nav2_costmap_2d/test/unit/test_deprojection.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Ocean Code AI Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file was authored with the assistance of an AI system,
+// reviewed and validated by the submitter. Disclosed per the Nav2 PR
+// template's AI-generated-software policy.
+
+#include <gtest/gtest.h>
+#include "nav2_monocular_depth_layer/deprojection.hpp"
+
+using nav2_monocular_depth_layer::deproject;
+
+// A pixel at the principal point projects straight down the optical axis.
+TEST(Deprojection, PrincipalPointIsOnAxis)
+{
+  const double fx = 500.0, fy = 500.0, cx = 320.0, cy = 240.0;
+  const auto p = deproject(cx, cy, 2.0, fx, fy, cx, cy);
+  EXPECT_NEAR(p[0], 0.0, 1e-9);
+  EXPECT_NEAR(p[1], 0.0, 1e-9);
+  EXPECT_NEAR(p[2], 2.0, 1e-9);
+}
+
+// A pixel one focal length to the right of centre sits at 45 degrees: x == z.
+TEST(Deprojection, FortyFiveDegreesRight)
+{
+  const double fx = 500.0, fy = 500.0, cx = 320.0, cy = 240.0;
+  const auto p = deproject(cx + fx, cy, 3.0, fx, fy, cx, cy);
+  EXPECT_NEAR(p[0], 3.0, 1e-9);   // +x is image-right in the optical frame
+  EXPECT_NEAR(p[1], 0.0, 1e-9);
+  EXPECT_NEAR(p[2], 3.0, 1e-9);
+}
+
+// +y is image-down in the optical frame (REP 103).
+TEST(Deprojection, PositiveYIsDown)
+{
+  const double fx = 500.0, fy = 400.0, cx = 320.0, cy = 240.0;
+  const auto p = deproject(cx, cy + fy, 5.0, fx, fy, cx, cy);
+  EXPECT_NEAR(p[1], 5.0, 1e-9);
+}
+
+// Depth scales the deprojected point linearly.
+TEST(Deprojection, LinearInDepth)
+{
+  const double fx = 600.0, fy = 600.0, cx = 320.0, cy = 240.0;
+  const auto near = deproject(100.0, 50.0, 1.0, fx, fy, cx, cy);
+  const auto far = deproject(100.0, 50.0, 4.0, fx, fy, cx, cy);
+  EXPECT_NEAR(far[0], 4.0 * near[0], 1e-9);
+  EXPECT_NEAR(far[1], 4.0 * near[1], 1e-9);
+  EXPECT_NEAR(far[2], 4.0 * near[2], 1e-9);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (Proposed costmap layer: monocular (learned) depth with confidence gating) |
| Primary OS tested on | (Ubuntu, Windows) |
| Robotic platform tested on | (In simulation/headless demo only) |
| Does this PR contain AI generated software? | (Yes, and it is marked inline in the code) |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added a new nav2_costmap_2d layer that marks/clears from a monocular depth image + CameraInfo (+ optional confidence image)
* Runs no network, estimator-agnostic; three monocular-specific behaviours, per-pixel confidence gating, spatial-agreement marking, & static scale correction.
* I built this against the 1.5.0 Costmaplayer API.
* This is not just a pointcloud2 -> obstacle layer modifcation as it learned depth needs confidence + agreement + scale handling that a real sensor doesn't.
-->

## Description of documentation updates required from your changes

<!--
* A new config page for the layer's parameters on docs.nav2.org.
* optionally a row in the plugins overview table
-->

## Description of how this change was tested

<!--
* deprojection unit tests were done as the depth-publisher's scale/confidence unit tests.
* a headless demo (synthetic camera → publisher → standalone costmap) that asserts obstacle cells appear and lint via pre-commit/colcon test. 
-->

---

## Future work that may be required in bullet points

<!--
* I am thinking of temporal persistence across frames that message_filters depth/confidence sync; online scale estimation 
* a possible PointCloud2-input variant if preferred
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
