### PR TITLE
Reject invalid z_rand (Bug4 in #6430)

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -23,6 +23,7 @@
 #include "nav2_amcl/amcl_node.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <ctime>
@@ -1050,6 +1051,11 @@ rcl_interfaces::msg::SetParametersResult AmclNode::validateParameterUpdatesCallb
       continue;
     }
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
+      if (param_name == "z_rand" && !std::isfinite(parameter.as_double())) {
+        result.successful = false;
+        result.reason = "z_rand must be finite";
+        return result;
+      }
       if (param_name == "save_pose_rate") {
         // All values are valid
         continue;

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -116,8 +116,9 @@ TEST_F(TestAmclPose, SimpleAmclTest)
 
 TEST_F(TestAmclPose, RejectNonFiniteZRand)
 {
+  auto parameter_node = rclcpp::Node::make_shared("z_rand_parameter_test");
   auto parameter_client =
-    std::make_shared<rclcpp::SyncParametersClient>(node, "amcl");
+    std::make_shared<rclcpp::SyncParametersClient>(parameter_node, "amcl");
 
   ASSERT_TRUE(parameter_client->wait_for_service(10s));
 

--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
@@ -111,6 +112,31 @@ void TestAmclPose::initTestPose()
 TEST_F(TestAmclPose, SimpleAmclTest)
 {
   EXPECT_EQ(true, defaultAmclTest());
+}
+
+TEST_F(TestAmclPose, RejectNonFiniteZRand)
+{
+  auto parameter_client =
+    std::make_shared<rclcpp::SyncParametersClient>(node, "amcl");
+
+  ASSERT_TRUE(parameter_client->wait_for_service(10s));
+
+  const double original_value =
+    parameter_client->get_parameter<double>("z_rand");
+
+  const double invalid_values[] = {
+    std::numeric_limits<double>::infinity()
+  };
+
+  for (const double invalid_value : invalid_values) {
+    const auto result = parameter_client->set_parameters_atomically(
+      {rclcpp::Parameter("z_rand", invalid_value)});
+
+    EXPECT_FALSE(result.successful);
+    EXPECT_DOUBLE_EQ(
+      parameter_client->get_parameter<double>("z_rand"),
+      original_value);
+  }
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6430 (Bug 4) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Reject the non-finite value in the runtime parameter callback

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 4 reproduction steps from #6430 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \[ \] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \[ \] Check that any significant change is added to the migration guide
-   \[ \] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \[ \] Check that any new functions have Doxygen added
-   \[ \] Check that any new features have test coverage
-   \[ \] Check that any new plugins is added to the plugins page
-   \[ \] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \[ \] Should this be backported to current distributions? If so, tag with `backport-*`.