### PR TITLE
Prevent stack overflow in AMCL k-d tree cluster traversal (Bug5 in #6430)

### DIFF
--- a/nav2_amcl/src/pf/pf_kdtree.c
+++ b/nav2_amcl/src/pf/pf_kdtree.c
@@ -48,8 +48,10 @@ static pf_kdtree_node_t * pf_kdtree_find_node(
   pf_kdtree_t * self, pf_kdtree_node_t * node,
   int key[]);
 
-// Recursively label nodes in this cluster
-static void pf_kdtree_cluster_node(pf_kdtree_t * self, pf_kdtree_node_t * node, int depth);
+// Add neighboring nodes in this cluster to the queue
+static void pf_kdtree_cluster_node(
+  pf_kdtree_t * self, pf_kdtree_node_t * node,
+  pf_kdtree_node_t ** queue, int * queue_count);
 
 // Recursive node printing
 // static void pf_kdtree_print_node(pf_kdtree_t *self, pf_kdtree_node_t *node);
@@ -351,13 +353,11 @@ void pf_kdtree_cluster(pf_kdtree_t * self)
   queue_count = 0;
   queue = calloc(self->node_count, sizeof(queue[0]));
 
-  // Put all the leaves in a queue
+  // Reset cluster labels
   for (i = 0; i < self->node_count; i++) {
     node = self->nodes + i;
     if (node->leaf) {
       node->cluster = -1;
-      assert(queue_count < self->node_count);
-      queue[queue_count++] = node;
 
       // TESTING; remove
       assert(node == pf_kdtree_find_node(self, self->root, node->key));
@@ -367,19 +367,24 @@ void pf_kdtree_cluster(pf_kdtree_t * self)
   cluster_count = 0;
 
   // Do connected components for each node
-  while (queue_count > 0) {
-    node = queue[--queue_count];
+  for (i = self->node_count - 1; i >= 0; i--) {
+    node = self->nodes + i;
 
     // If this node has already been labelled, skip it
-    if (node->cluster >= 0) {
+    if (!node->leaf || node->cluster >= 0) {
       continue;
     }
 
     // Assign a label to this cluster
     node->cluster = cluster_count++;
 
-    // Recursively label nodes in this cluster
-    pf_kdtree_cluster_node(self, node, 0);
+    // Iteratively label nodes in this cluster
+    assert(queue_count < self->node_count);
+    queue[queue_count++] = node;
+    while (queue_count > 0) {
+      node = queue[--queue_count];
+      pf_kdtree_cluster_node(self, node, queue, &queue_count);
+    }
   }
 
   free(queue);
@@ -387,8 +392,10 @@ void pf_kdtree_cluster(pf_kdtree_t * self)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Recursively label nodes in this cluster
-void pf_kdtree_cluster_node(pf_kdtree_t * self, pf_kdtree_node_t * node, int depth)
+// Add neighboring nodes in this cluster to the queue
+void pf_kdtree_cluster_node(
+  pf_kdtree_t * self, pf_kdtree_node_t * node,
+  pf_kdtree_node_t ** queue, int * queue_count)
 {
   int i;
   int nkey[3];
@@ -413,10 +420,10 @@ void pf_kdtree_cluster_node(pf_kdtree_t * self, pf_kdtree_node_t * node, int dep
       continue;
     }
 
-    // Label this node and recurse
+    // Label this node and add it to the work queue
     nnode->cluster = node->cluster;
-
-    pf_kdtree_cluster_node(self, nnode, depth + 1);
+    assert(*queue_count < self->node_count);
+    queue[(*queue_count)++] = nnode;
   }
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #6430 (Bug 5) |
| Primary OS tested on | Ubuntu 24.04.4 LTS (x86_64) |
| Robotic platform tested on | TurtleBot3 simulation / Nav2 source build |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

* * *

## Description of contribution in a few bullet points

-   Replace recursive AMCL k-d tree cluster traversal with an iterative approach

## Description of documentation updates required from your changes

-   N/A. This change does not add any parameters or modify the documented behavior.

## Description of how this change was tested

-   Built the Navigation2 workspace with Clang AddressSanitizer.
-   Ran the Bug 5 reproduction steps from #6430 and verified that the reported ASan crash no longer occurred and that the node remained alive.

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->

-   \\\[ \\\] Check that any new parameters added are updated in [docs.nav2.org](http://docs.nav2.org/)
-   \\\[ \\\] Check that any significant change is added to the migration guide
-   \\\[ \\\] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-   \\\[ \\\] Check that any new functions have Doxygen added
-   \\\[ \\\] Check that any new features have test coverage
-   \\\[ \\\] Check that any new plugins is added to the plugins page
-   \\\[ \\\] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
-   \\\[ \\\] Should this be backported to current distributions? If so, tag with `backport-*`.