### PR TITLE
VO more efficient rasterization

### DIFF
--- a/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/polygon.hpp"
@@ -147,6 +149,25 @@ public:
   virtual bool isPointInside(const double px, const double py) const = 0;
 
   /**
+   * @brief Gets X-intervals of the shape interior along the horizontal line y = py.
+   * Intervals are half-open [begin, end) and may slightly over-cover the shape but never
+   * under-cover it; putFill() trims their ends with isPointInside()
+   * @param py Y-coordinate of the line
+   * @param spans Output world X-intervals in ascending order
+   */
+  virtual void getRowSpans(
+    const double py, std::vector<std::pair<double, double>> & spans) const = 0;
+
+  /**
+   * @brief Fills the shape on map: every cell whose center is inside the shape is updated.
+   * Produces the same result as checking isPointInside() for each cell of the shape's box
+   * @param map Output map pointer
+   * @param overlay_type Overlay type
+   * @return False if shape boundaries can not be converted to map coordinates
+   */
+  bool putFill(nav_msgs::msg::OccupancyGrid::SharedPtr map, const OverlayType overlay_type);
+
+  /**
    * @brief Puts shape borders on map.
    * Empty virtual method intended to be used in child implementations
    * @param map Output map pointer
@@ -252,6 +273,14 @@ public:
    * @return True if given point inside the shape
    */
   bool isPointInside(const double px, const double py) const;
+
+  /**
+   * @brief Gets X-intervals of the polygon interior along the horizontal line y = py.
+   * Uses the same crossing rule and arithmetic as isPointInside(), so the intervals are exact
+   * @param py Y-coordinate of the line
+   * @param spans Output world X-intervals in ascending order
+   */
+  void getRowSpans(const double py, std::vector<std::pair<double, double>> & spans) const;
 
   /**
    * @brief Puts shape borders on map.
@@ -362,6 +391,13 @@ public:
    * @return True if given point inside the shape
    */
   bool isPointInside(const double px, const double py) const;
+
+  /**
+   * @brief Gets the X-interval of the circle interior along the horizontal line y = py
+   * @param py Y-coordinate of the line
+   * @param spans Output world X-interval, empty if the line misses the circle
+   */
+  void getRowSpans(const double py, std::vector<std::pair<double, double>> & spans) const;
 
   /**
    * @brief Puts shape borders on map.

--- a/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
@@ -15,6 +15,7 @@
 #ifndef NAV2_MAP_SERVER__VECTOR_OBJECT_SHAPES_HPP_
 #define NAV2_MAP_SERVER__VECTOR_OBJECT_SHAPES_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
@@ -176,6 +177,18 @@ public:
     nav_msgs::msg::OccupancyGrid::SharedPtr map, const OverlayType overlay_type) = 0;
 
 protected:
+  /**
+   * @brief Updates a run of consecutive cells with given shape value according to the overlay type
+   * @param cells Pointer to the first cell of the run
+   * @param count Number of cells in the run
+   * @param shape_val Vector object value to be overlaid on map
+   * @param overlay_type Type of overlay
+   * @throw std::exception in case of unknown overlay type
+   */
+  static void processRun(
+    int8_t * cells, const size_t count, const int8_t shape_val,
+    const OverlayType overlay_type);
+
   /// @brief Type of shape
   ShapeType type_;
 

--- a/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_shapes.hpp
@@ -149,18 +149,17 @@ public:
   virtual bool isPointInside(const double px, const double py) const = 0;
 
   /**
-   * @brief Gets X-intervals of the shape interior along the horizontal line y = py.
-   * Intervals are half-open [begin, end) and may slightly over-cover the shape but never
-   * under-cover it; putFill() trims their ends with isPointInside()
+   * @brief Gets X-intervals covered by the shape on the horizontal line y = py.
+   * Intervals may be slightly wider than the shape, but never narrower.
+   * Empty virtual method intended to be used in child implementations
    * @param py Y-coordinate of the line
-   * @param spans Output world X-intervals in ascending order
+   * @param spans Output [begin, end) intervals in world coordinates, sorted by X
    */
   virtual void getRowSpans(
     const double py, std::vector<std::pair<double, double>> & spans) const = 0;
 
   /**
-   * @brief Fills the shape on map: every cell whose center is inside the shape is updated.
-   * Produces the same result as checking isPointInside() for each cell of the shape's box
+   * @brief Puts filled shape on map
    * @param map Output map pointer
    * @param overlay_type Overlay type
    * @return False if shape boundaries can not be converted to map coordinates
@@ -275,10 +274,9 @@ public:
   bool isPointInside(const double px, const double py) const;
 
   /**
-   * @brief Gets X-intervals of the polygon interior along the horizontal line y = py.
-   * Uses the same crossing rule and arithmetic as isPointInside(), so the intervals are exact
+   * @brief Gets X-intervals covered by the polygon on the horizontal line y = py
    * @param py Y-coordinate of the line
-   * @param spans Output world X-intervals in ascending order
+   * @param spans Output [begin, end) intervals in world coordinates, sorted by X
    */
   void getRowSpans(const double py, std::vector<std::pair<double, double>> & spans) const;
 
@@ -393,9 +391,9 @@ public:
   bool isPointInside(const double px, const double py) const;
 
   /**
-   * @brief Gets the X-interval of the circle interior along the horizontal line y = py
+   * @brief Gets X-interval covered by the circle on the horizontal line y = py
    * @param py Y-coordinate of the line
-   * @param spans Output world X-interval, empty if the line misses the circle
+   * @param spans Output [begin, end) interval in world coordinates, empty if the line misses
    */
   void getRowSpans(const double py, std::vector<std::pair<double, double>> & spans) const;
 

--- a/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
@@ -16,6 +16,8 @@
 #define NAV2_MAP_SERVER__VECTOR_OBJECT_UTILS_HPP_
 
 #include <uuid/uuid.h>
+#include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 
@@ -86,6 +88,43 @@ inline void processVal(
 }
 
 /**
+ * @brief Updates a contiguous run of cells with given shape value according to the overlay type.
+ * Same result as processVal() on each cell; branch-free loops keep the run vectorizable
+ * @param cells Pointer to the first cell of the run
+ * @param count Number of cells in the run
+ * @param shape_val Vector object value to be overlaid on map
+ * @param overlay_type Type of overlay
+ * @throw std::exception in case of unknown overlay type
+ */
+inline void processRun(
+  int8_t * cells, const size_t count, const int8_t shape_val,
+  const OverlayType overlay_type)
+{
+  switch (overlay_type) {
+    case OverlayType::OVERLAY_SEQ:
+      std::fill_n(cells, count, shape_val);
+      return;
+    case OverlayType::OVERLAY_MAX:
+      for (size_t i = 0; i < count; i++) {
+        cells[i] = std::max(cells[i], shape_val);
+      }
+      return;
+    case OverlayType::OVERLAY_MIN:
+      if (shape_val == nav2_util::OCC_GRID_UNKNOWN) {
+        return;
+      }
+      for (size_t i = 0; i < count; i++) {
+        if (cells[i] == nav2_util::OCC_GRID_UNKNOWN || shape_val < cells[i]) {
+          cells[i] = shape_val;
+        }
+      }
+      return;
+    default:
+      throw std::runtime_error{"Unknown overlay type"};
+  }
+}
+
+/**
  * @brief Updates the cell on the map with given shape value according to the given overlay type
  * @param map Output map to be updated with
  * @param offset Offset to the cell to be updated
@@ -93,14 +132,12 @@ inline void processVal(
  * @param overlay_type Type of overlay
  */
 inline void processCell(
-  nav_msgs::msg::OccupancyGrid::SharedPtr map,
+  const nav_msgs::msg::OccupancyGrid::SharedPtr & map,
   const unsigned int offset,
   const int8_t shape_val,
   const OverlayType overlay_type)
 {
-  int8_t map_val = map->data[offset];
-  processVal(map_val, shape_val, overlay_type);
-  map->data[offset] = map_val;
+  processVal(map->data[offset], shape_val, overlay_type);
 }
 
 /// @brief Functor class used in raytraceLine algorithm

--- a/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
@@ -88,8 +88,7 @@ inline void processVal(
 }
 
 /**
- * @brief Updates a contiguous run of cells with given shape value according to the overlay type.
- * Same result as processVal() on each cell; branch-free loops keep the run vectorizable
+ * @brief Updates a run of consecutive cells with given shape value according to the overlay type
  * @param cells Pointer to the first cell of the run
  * @param count Number of cells in the run
  * @param shape_val Vector object value to be overlaid on map

--- a/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_utils.hpp
@@ -16,8 +16,6 @@
 #define NAV2_MAP_SERVER__VECTOR_OBJECT_UTILS_HPP_
 
 #include <uuid/uuid.h>
-#include <algorithm>
-#include <cstddef>
 #include <stdexcept>
 #include <string>
 
@@ -80,42 +78,6 @@ inline void processVal(
         shape_val != nav2_util::OCC_GRID_UNKNOWN)
       {
         map_val = shape_val;
-      }
-      return;
-    default:
-      throw std::runtime_error{"Unknown overlay type"};
-  }
-}
-
-/**
- * @brief Updates a run of consecutive cells with given shape value according to the overlay type
- * @param cells Pointer to the first cell of the run
- * @param count Number of cells in the run
- * @param shape_val Vector object value to be overlaid on map
- * @param overlay_type Type of overlay
- * @throw std::exception in case of unknown overlay type
- */
-inline void processRun(
-  int8_t * cells, const size_t count, const int8_t shape_val,
-  const OverlayType overlay_type)
-{
-  switch (overlay_type) {
-    case OverlayType::OVERLAY_SEQ:
-      std::fill_n(cells, count, shape_val);
-      return;
-    case OverlayType::OVERLAY_MAX:
-      for (size_t i = 0; i < count; i++) {
-        cells[i] = std::max(cells[i], shape_val);
-      }
-      return;
-    case OverlayType::OVERLAY_MIN:
-      if (shape_val == nav2_util::OCC_GRID_UNKNOWN) {
-        return;
-      }
-      for (size_t i = 0; i < count; i++) {
-        if (cells[i] == nav2_util::OCC_GRID_UNKNOWN || shape_val < cells[i]) {
-          cells[i] = shape_val;
-        }
       }
       return;
     default:

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -307,37 +307,11 @@ void VectorObjectServer::putVectorObjectsOnMap()
   // Filling the shapes
   for (auto shape : shapes_) {
     if (shape->isFill()) {
-      // Put filled shape on map
-      double wx1 = std::numeric_limits<double>::max();
-      double wy1 = std::numeric_limits<double>::max();
-      double wx2 = std::numeric_limits<double>::lowest();
-      double wy2 = std::numeric_limits<double>::lowest();
-      unsigned int mx1 = 0;
-      unsigned int my1 = 0;
-      unsigned int mx2 = 0;
-      unsigned int my2 = 0;
-
-      shape->getBoundaries(wx1, wy1, wx2, wy2);
-      if (
-        !nav2_util::worldToMap(map_, wx1, wy1, mx1, my1) ||
-        !nav2_util::worldToMap(map_, wx2, wy2, mx2, my2))
-      {
+      if (!shape->putFill(map_, overlay_type_)) {
         RCLCPP_ERROR(
           get_logger(),
           "Error to get shape boundaries on map (UUID: %s)", shape->getUUID().c_str());
         return;
-      }
-
-      unsigned int it;
-      for (unsigned int my = my1; my <= my2; my++) {
-        for (unsigned int mx = mx1; mx <= mx2; mx++) {
-          it = my * map_->info.width + mx;
-          double wx, wy;
-          nav2_util::mapToWorld(map_, mx, my, wx, wy);
-          if (shape->isPointInside(wx, wy)) {
-            processVal(map_->data[it], shape->getValue(), overlay_type_);
-          }
-        }
       }
     } else {
       // Put shape borders on map

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -23,7 +23,6 @@
 
 #include "rclcpp/create_timer.hpp"
 
-#include "nav2_util/occ_grid_utils.hpp"
 #include "nav2_util/occ_grid_values.hpp"
 
 using namespace std::placeholders;

--- a/nav2_map_server/src/vo_server/vector_object_shapes.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_shapes.cpp
@@ -110,8 +110,8 @@ bool Shape::putFill(
       while (hi >= lo && !inside(static_cast<unsigned int>(hi))) {
         hi--;
       }
-      for (int64_t mx = lo; mx <= hi; mx++) {
-        processVal(row[mx], value, overlay_type);
+      if (lo <= hi) {
+        processRun(row + lo, static_cast<size_t>(hi - lo + 1), value, overlay_type);
       }
     }
   }

--- a/nav2_map_server/src/vo_server/vector_object_shapes.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_shapes.cpp
@@ -15,10 +15,12 @@
 #include "nav2_map_server/vector_object_shapes.hpp"
 
 #include <uuid/uuid.h>
+#include <algorithm>
 #include <cmath>
 #include <exception>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -45,6 +47,75 @@ Shape::~Shape()
 ShapeType Shape::getType()
 {
   return type_;
+}
+
+bool Shape::putFill(
+  nav_msgs::msg::OccupancyGrid::SharedPtr map, const OverlayType overlay_type)
+{
+  double wx1, wy1, wx2, wy2;
+  unsigned int mx1, my1, mx2, my2;
+  getBoundaries(wx1, wy1, wx2, wy2);
+  if (
+    !nav2_util::worldToMap(map, wx1, wy1, mx1, my1) ||
+    !nav2_util::worldToMap(map, wx2, wy2, mx2, my2))
+  {
+    return false;
+  }
+
+  const double origin_x = map->info.origin.position.x;
+  const double resolution = map->info.resolution;
+  const int8_t value = getValue();
+  std::vector<std::pair<double, double>> spans;
+  for (unsigned int my = my1; my <= my2; my++) {
+    double row_x, row_y;
+    nav2_util::mapToWorld(map, mx1, my, row_x, row_y);
+    // Same cell-center test as the per-cell approach, evaluated only at span ends
+    const auto inside = [&](unsigned int mx) {
+        double wx, wy;
+        nav2_util::mapToWorld(map, mx, my, wx, wy);
+        return isPointInside(wx, wy);
+      };
+    getRowSpans(row_y, spans);
+    int8_t * row = map->data.data() + static_cast<size_t>(my) * map->info.width;
+    for (const auto & [x_begin, x_end] : spans) {
+      // Cells whose center lies in [x_begin, x_end), located with the same cell-center
+      // arithmetic as the predicate; index estimates alone can be one cell off at ties
+      const auto center_x = [&](int64_t mx) {
+          double wx, wy;
+          nav2_util::mapToWorld(map, static_cast<unsigned int>(mx), my, wx, wy);
+          return wx;
+        };
+      int64_t lo = static_cast<int64_t>(std::clamp(
+          std::ceil((x_begin - origin_x) / resolution - 0.5),
+          static_cast<double>(mx1), static_cast<double>(mx2)));
+      int64_t hi = static_cast<int64_t>(std::clamp(
+          std::floor((x_end - origin_x) / resolution - 0.5),
+          static_cast<double>(mx1), static_cast<double>(mx2)));
+      while (lo > mx1 && center_x(lo - 1) >= x_begin) {
+        lo--;
+      }
+      while (lo <= mx2 && center_x(lo) < x_begin) {
+        lo++;
+      }
+      while (hi < mx2 && center_x(hi + 1) < x_end) {
+        hi++;
+      }
+      while (hi >= mx1 && center_x(hi) >= x_end) {
+        hi--;
+      }
+      // Spans may be slightly wider than the shape (circles): trim with the exact predicate
+      while (lo <= hi && !inside(static_cast<unsigned int>(lo))) {
+        lo++;
+      }
+      while (hi >= lo && !inside(static_cast<unsigned int>(hi))) {
+        hi--;
+      }
+      for (int64_t mx = lo; mx <= hi; mx++) {
+        processVal(row[mx], value, overlay_type);
+      }
+    }
+  }
+  return true;
 }
 
 bool Shape::obtainShapeUUID(const std::string & shape_name, unsigned char * out_uuid)
@@ -241,6 +312,35 @@ void Polygon::getBoundaries(double & min_x, double & min_y, double & max_x, doub
 bool Polygon::isPointInside(const double px, const double py) const
 {
   return nav2_util::geometry_utils::isPointInsidePolygon(px, py, polygon_->points);
+}
+
+void Polygon::getRowSpans(
+  const double py, std::vector<std::pair<double, double>> & spans) const
+{
+  // Mirrors the edge selection and intersection arithmetic of isPointInsidePolygon()
+  const auto & points = polygon_->points;
+  std::vector<double> crossings;
+  int i = points.size() - 1;
+  for (int j = 0; j < static_cast<int>(points.size()); j++) {
+    if ((py <= points[i].y) == (py > points[j].y)) {
+      crossings.push_back(
+        points[i].x + (py - points[i].y) * (points[j].x - points[i].x) /
+        (points[j].y - points[i].y));
+    }
+    i = j;
+  }
+  std::sort(crossings.begin(), crossings.end());
+
+  spans.clear();
+  const size_t count = crossings.size();
+  if (count % 2 == 1) {
+    spans.emplace_back(std::numeric_limits<double>::lowest(), crossings[0]);
+  }
+  for (size_t k = 1; k < count; k++) {
+    if ((count - k) % 2 == 1) {
+      spans.emplace_back(crossings[k - 1], crossings[k]);
+    }
+  }
 }
 
 void Polygon::putBorders(
@@ -446,6 +546,21 @@ bool Circle::isPointInside(const double px, const double py) const
 {
   return ( (px - center_->x) * (px - center_->x) + (py - center_->y) * (py - center_->y) ) <=
          params_->radius * params_->radius;
+}
+
+void Circle::getRowSpans(
+  const double py, std::vector<std::pair<double, double>> & spans) const
+{
+  spans.clear();
+  const double dy = py - center_->y;
+  const double half_chord_sq = params_->radius * params_->radius - dy * dy;
+  if (half_chord_sq < 0.0) {
+    return;
+  }
+  const double half_chord = std::sqrt(half_chord_sq);
+  // Slightly over-cover so rounding never drops a boundary cell; putFill() trims exactly
+  const double padding = std::max(1.0, static_cast<double>(params_->radius)) * 1e-9;
+  spans.emplace_back(center_->x - half_chord - padding, center_->x + half_chord + padding);
 }
 
 void Circle::putBorders(

--- a/nav2_map_server/src/vo_server/vector_object_shapes.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_shapes.cpp
@@ -69,7 +69,6 @@ bool Shape::putFill(
   for (unsigned int my = my1; my <= my2; my++) {
     double row_x, row_y;
     nav2_util::mapToWorld(map, mx1, my, row_x, row_y);
-    // Same cell-center test as the per-cell approach, evaluated only at span ends
     const auto inside = [&](unsigned int mx) {
         double wx, wy;
         nav2_util::mapToWorld(map, mx, my, wx, wy);
@@ -78,8 +77,7 @@ bool Shape::putFill(
     getRowSpans(row_y, spans);
     int8_t * row = map->data.data() + static_cast<size_t>(my) * map->info.width;
     for (const auto & [x_begin, x_end] : spans) {
-      // Cells whose center lies in [x_begin, x_end), located with the same cell-center
-      // arithmetic as the predicate; index estimates alone can be one cell off at ties
+      // First and last cell whose center is in [x_begin, x_end)
       const auto center_x = [&](int64_t mx) {
           double wx, wy;
           nav2_util::mapToWorld(map, static_cast<unsigned int>(mx), my, wx, wy);
@@ -91,6 +89,7 @@ bool Shape::putFill(
       int64_t hi = static_cast<int64_t>(std::clamp(
           std::floor((x_end - origin_x) / resolution - 0.5),
           static_cast<double>(mx1), static_cast<double>(mx2)));
+      // ceil/floor may be off by one when a center lies exactly on the boundary
       while (lo > mx1 && center_x(lo - 1) >= x_begin) {
         lo--;
       }
@@ -103,7 +102,7 @@ bool Shape::putFill(
       while (hi >= mx1 && center_x(hi) >= x_end) {
         hi--;
       }
-      // Spans may be slightly wider than the shape (circles): trim with the exact predicate
+      // Spans may be slightly too wide (circles): trim with the exact test
       while (lo <= hi && !inside(static_cast<unsigned int>(lo))) {
         lo++;
       }
@@ -317,7 +316,7 @@ bool Polygon::isPointInside(const double px, const double py) const
 void Polygon::getRowSpans(
   const double py, std::vector<std::pair<double, double>> & spans) const
 {
-  // Mirrors the edge selection and intersection arithmetic of isPointInsidePolygon()
+  // Same edge rule and intersection formula as isPointInsidePolygon()
   const auto & points = polygon_->points;
   std::vector<double> crossings;
   int i = points.size() - 1;
@@ -558,7 +557,7 @@ void Circle::getRowSpans(
     return;
   }
   const double half_chord = std::sqrt(half_chord_sq);
-  // Slightly over-cover so rounding never drops a boundary cell; putFill() trims exactly
+  // Pad against rounding, putFill() trims the ends
   const double padding = std::max(1.0, static_cast<double>(params_->radius)) * 1e-9;
   spans.emplace_back(center_->x - half_chord - padding, center_->x + half_chord + padding);
 }

--- a/nav2_map_server/src/vo_server/vector_object_shapes.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_shapes.cpp
@@ -117,6 +117,34 @@ bool Shape::putFill(
   return true;
 }
 
+void Shape::processRun(
+  int8_t * cells, const size_t count, const int8_t shape_val,
+  const OverlayType overlay_type)
+{
+  switch (overlay_type) {
+    case OverlayType::OVERLAY_SEQ:
+      std::fill_n(cells, count, shape_val);
+      return;
+    case OverlayType::OVERLAY_MAX:
+      for (size_t i = 0; i < count; i++) {
+        cells[i] = std::max(cells[i], shape_val);
+      }
+      return;
+    case OverlayType::OVERLAY_MIN:
+      if (shape_val == nav2_util::OCC_GRID_UNKNOWN) {
+        return;
+      }
+      for (size_t i = 0; i < count; i++) {
+        if (cells[i] == nav2_util::OCC_GRID_UNKNOWN || shape_val < cells[i]) {
+          cells[i] = shape_val;
+        }
+      }
+      return;
+    default:
+      throw std::runtime_error{"Unknown overlay type"};
+  }
+}
+
 bool Shape::obtainShapeUUID(const std::string & shape_name, unsigned char * out_uuid)
 {
   auto node = node_.lock();

--- a/nav2_map_server/test/unit/test_vector_object_shapes.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_shapes.cpp
@@ -19,7 +19,10 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <random>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/point32.hpp"
@@ -785,6 +788,195 @@ TEST_F(Tester, testCircleDifferentFrame)
 
   // Try to transform to incorrect frame
   ASSERT_FALSE(circle_->toFrame("incorrect_frame", tf_buffer_, 0.1));
+}
+
+// Fills each cell of the shape's box whose center is inside: the reference putFill() must match
+static nav_msgs::msg::OccupancyGrid::SharedPtr fillPerCell(
+  nav2_map_server::Shape & shape, nav_msgs::msg::OccupancyGrid::ConstSharedPtr map,
+  const nav2_map_server::OverlayType overlay_type)
+{
+  auto expected = std::make_shared<nav_msgs::msg::OccupancyGrid>(*map);
+  double wx1, wy1, wx2, wy2;
+  unsigned int mx1 = 0, my1 = 0, mx2 = 0, my2 = 0;
+  shape.getBoundaries(wx1, wy1, wx2, wy2);
+  EXPECT_TRUE(nav2_util::worldToMap(map, wx1, wy1, mx1, my1));
+  EXPECT_TRUE(nav2_util::worldToMap(map, wx2, wy2, mx2, my2));
+  for (unsigned int my = my1; my <= my2; my++) {
+    for (unsigned int mx = mx1; mx <= mx2; mx++) {
+      double wx, wy;
+      nav2_util::mapToWorld(map, mx, my, wx, wy);
+      if (shape.isPointInside(wx, wy)) {
+        nav2_map_server::processVal(
+          expected->data[my * map->info.width + mx], shape.getValue(), overlay_type);
+      }
+    }
+  }
+  return expected;
+}
+
+// Pre-existing content (unknown, free and a mid-value stripe) makes the overlay rules observable
+static nav_msgs::msg::OccupancyGrid::SharedPtr makePrefilledMap()
+{
+  auto map = std::make_shared<nav_msgs::msg::OccupancyGrid>();
+  map->header.frame_id = GLOBAL_FRAME_ID;
+  map->info.resolution = 0.1;
+  map->info.width = 40;
+  map->info.height = 40;
+  map->info.origin.position.x = -2.0;
+  map->info.origin.position.y = -2.0;
+  map->data.assign(40 * 40, nav2_util::OCC_GRID_UNKNOWN);
+  for (unsigned int i = 0; i < map->data.size(); i++) {
+    if (i % 7 == 0) {
+      map->data[i] = 50;
+    } else if (i % 3 == 0) {
+      map->data[i] = nav2_util::OCC_GRID_FREE;
+    }
+  }
+  return map;
+}
+
+static const nav2_map_server::OverlayType OVERLAYS[] = {
+  nav2_map_server::OverlayType::OVERLAY_SEQ,
+  nav2_map_server::OverlayType::OVERLAY_MAX,
+  nav2_map_server::OverlayType::OVERLAY_MIN};
+
+static void expectFillMatchesPerCell(nav2_map_server::Shape & shape, const std::string & label)
+{
+  for (const auto overlay : OVERLAYS) {
+    auto map = makePrefilledMap();
+    ASSERT_TRUE(shape.putFill(map, overlay)) << label;
+    ASSERT_EQ(map->data, fillPerCell(shape, makePrefilledMap(), overlay)->data)
+      << label << " overlay " << static_cast<int>(overlay);
+  }
+}
+
+TEST_F(Tester, testPutFillMatchesPerCellCheck)
+{
+  std::mt19937 generator(7);
+  std::uniform_real_distribution<float> coordinate(-1.8f, 1.8f);
+  std::uniform_int_distribution<int> vertices(3, 9);
+  for (int iteration = 0; iteration < 200; iteration++) {
+    auto po = makePolygonObject({});
+    po->points.clear();
+    const int count = vertices(generator);
+    for (int i = 0; i < count; i++) {
+      geometry_msgs::msg::Point32 p;
+      p.x = coordinate(generator);
+      p.y = coordinate(generator);
+      if (i % 3 == 0) {
+        // Vertices on cell centers and cell edges exercise the tie-breaking rules
+        p.x = std::round(p.x * 10.0f) / 10.0f + ((i % 2) ? 0.05f : 0.0f);
+      }
+      po->points.push_back(p);
+    }
+    ASSERT_TRUE(polygon_->setParams(po));
+    expectFillMatchesPerCell(*polygon_, "polygon " + std::to_string(iteration));
+
+    auto co = makeCircleObject({});
+    co->center.x = coordinate(generator) / 2.0f;
+    co->center.y = std::round(coordinate(generator) * 10.0f) / 20.0f;
+    co->radius = 0.05 + std::abs(coordinate(generator)) / 2.0;
+    ASSERT_TRUE(circle_->setParams(co));
+    expectFillMatchesPerCell(*circle_, "circle " + std::to_string(iteration));
+  }
+}
+
+TEST_F(Tester, testPutFillDegeneratePolygonsMatchPerCellCheck)
+{
+  // Cell centers of the test map lie on x, y = -1.95, -1.85, ..., 1.95
+  const std::vector<std::pair<std::string, std::vector<std::pair<float, float>>>> cases = {
+    {"bow-tie", {{-1.0f, -1.0f}, {1.0f, 1.0f}, {1.0f, -1.0f}, {-1.0f, 1.0f}}},
+    {"horizontal edges on cell-center rows",
+      {{-1.0f, 0.05f}, {1.0f, 0.05f}, {1.0f, 0.55f}, {-1.0f, 0.55f}}},
+    {"vertical edges on cell-center columns",
+      {{0.05f, -1.0f}, {0.55f, -1.0f}, {0.55f, 1.0f}, {0.05f, 1.0f}}},
+    {"vertex on a cell center", {{-1.0f, -1.0f}, {1.0f, -1.0f}, {0.05f, 1.05f}}},
+    {"duplicate consecutive vertices",
+      {{-1.0f, -1.0f}, {-1.0f, -1.0f}, {1.0f, -1.0f}, {1.0f, 1.0f}, {1.0f, 1.0f}, {-1.0f, 1.0f}}},
+    {"collinear vertices",
+      {{-1.0f, -1.0f}, {0.0f, -1.0f}, {1.0f, -1.0f}, {1.0f, 1.0f}, {-1.0f, 1.0f}}},
+    {"sub-cell polygon", {{0.01f, 0.01f}, {0.03f, 0.01f}, {0.02f, 0.03f}}},
+    {"zero-area polygon", {{-1.0f, 0.0f}, {1.0f, 0.0f}, {0.0f, 0.0f}}},
+    {"touching the last cell center",
+      {{-1.0f, -1.0f}, {1.95f, -1.0f}, {1.95f, 1.95f}, {-1.0f, 1.95f}}},
+    {"concave with a notch on a cell-center row",
+      {{-1.5f, -1.5f}, {1.5f, -1.5f}, {1.5f, 1.5f}, {0.5f, 1.5f}, {0.5f, 0.05f}, {-0.5f, 0.05f},
+        {-0.5f, 1.5f}, {-1.5f, 1.5f}}},
+  };
+  for (const auto & [label, vertices] : cases) {
+    auto po = makePolygonObject({});
+    po->points.clear();
+    for (const auto & [x, y] : vertices) {
+      geometry_msgs::msg::Point32 p;
+      p.x = x;
+      p.y = y;
+      po->points.push_back(p);
+    }
+    ASSERT_TRUE(polygon_->setParams(po)) << label;
+    expectFillMatchesPerCell(*polygon_, label);
+  }
+}
+
+TEST_F(Tester, testPutFillOutsideMap)
+{
+  auto po = makePolygonObject({});
+  for (auto & p : po->points) {
+    p.x += 10.0f;
+  }
+  ASSERT_TRUE(polygon_->setParams(po));
+  auto map = makeMap();
+  ASSERT_FALSE(polygon_->putFill(map, nav2_map_server::OverlayType::OVERLAY_SEQ));
+  verifyMapEmpty(map);
+
+  // Larger than the map: boundaries can not be converted either
+  po = makePolygonObject({});
+  for (auto & p : po->points) {
+    p.x *= 3.0f;
+    p.y *= 3.0f;
+  }
+  ASSERT_TRUE(polygon_->setParams(po));
+  ASSERT_FALSE(polygon_->putFill(map, nav2_map_server::OverlayType::OVERLAY_SEQ));
+  verifyMapEmpty(map);
+}
+
+class CountingPolygon : public nav2_map_server::Polygon
+{
+public:
+  explicit CountingPolygon(const nav2::LifecycleNode::WeakPtr & node)
+  : Polygon(node)
+  {}
+
+  bool isPointInside(const double px, const double py) const override
+  {
+    ++point_checks;
+    return Polygon::isPointInside(px, py);
+  }
+
+  mutable size_t point_checks{0};
+};
+
+TEST_F(Tester, testPutFillChecksPointsPerRowNotPerCell)
+{
+  auto po = makePolygonObject({});
+  for (auto & p : po->points) {
+    p.x *= 1.5f;
+    p.y *= 1.5f;
+  }
+  auto polygon = std::make_shared<CountingPolygon>(node_);
+  ASSERT_TRUE(polygon->setParams(po));
+
+  auto map = makeMap();
+  map->info.resolution = 0.01;
+  map->info.width = 400;
+  map->info.height = 400;
+  map->data.assign(400 * 400, nav2_util::OCC_GRID_FREE);
+  ASSERT_TRUE(polygon->putFill(map, nav2_map_server::OverlayType::OVERLAY_SEQ));
+
+  const size_t filled = std::count(map->data.begin(), map->data.end(),
+    nav2_util::OCC_GRID_OCCUPIED);
+  ASSERT_EQ(filled, 300u * 300u);
+  // Interior cells are filled without testing them; only span ends are checked (a few per row)
+  EXPECT_LE(polygon->point_checks, 8u * 300u);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_map_server/test/unit/test_vector_object_shapes.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_shapes.cpp
@@ -790,7 +790,7 @@ TEST_F(Tester, testCircleDifferentFrame)
   ASSERT_FALSE(circle_->toFrame("incorrect_frame", tf_buffer_, 0.1));
 }
 
-// Fills each cell of the shape's box whose center is inside: the reference putFill() must match
+// Reference implementation: check every cell of the shape's bounding box
 static nav_msgs::msg::OccupancyGrid::SharedPtr fillPerCell(
   nav2_map_server::Shape & shape, nav_msgs::msg::OccupancyGrid::ConstSharedPtr map,
   const nav2_map_server::OverlayType overlay_type)
@@ -814,7 +814,7 @@ static nav_msgs::msg::OccupancyGrid::SharedPtr fillPerCell(
   return expected;
 }
 
-// Pre-existing content (unknown, free and a mid-value stripe) makes the overlay rules observable
+// Map with a mix of unknown, free and 50 cells so that overlay types give different results
 static nav_msgs::msg::OccupancyGrid::SharedPtr makePrefilledMap()
 {
   auto map = std::make_shared<nav_msgs::msg::OccupancyGrid>();
@@ -850,7 +850,7 @@ static void expectFillMatchesPerCell(nav2_map_server::Shape & shape, const std::
   }
 }
 
-TEST_F(Tester, testPutFillMatchesPerCellCheck)
+TEST_F(Tester, testPutFillRandomShapes)
 {
   std::mt19937 generator(7);
   std::uniform_real_distribution<float> coordinate(-1.8f, 1.8f);
@@ -864,7 +864,7 @@ TEST_F(Tester, testPutFillMatchesPerCellCheck)
       p.x = coordinate(generator);
       p.y = coordinate(generator);
       if (i % 3 == 0) {
-        // Vertices on cell centers and cell edges exercise the tie-breaking rules
+        // Put some vertices exactly on cell centers and cell edges
         p.x = std::round(p.x * 10.0f) / 10.0f + ((i % 2) ? 0.05f : 0.0f);
       }
       po->points.push_back(p);
@@ -881,9 +881,9 @@ TEST_F(Tester, testPutFillMatchesPerCellCheck)
   }
 }
 
-TEST_F(Tester, testPutFillDegeneratePolygonsMatchPerCellCheck)
+TEST_F(Tester, testPutFillDegeneratePolygons)
 {
-  // Cell centers of the test map lie on x, y = -1.95, -1.85, ..., 1.95
+  // Cell centers of the test map are at x, y = -1.95, -1.85, ..., 1.95
   const std::vector<std::pair<std::string, std::vector<std::pair<float, float>>>> cases = {
     {"bow-tie", {{-1.0f, -1.0f}, {1.0f, 1.0f}, {1.0f, -1.0f}, {-1.0f, 1.0f}}},
     {"horizontal edges on cell-center rows",
@@ -928,7 +928,7 @@ TEST_F(Tester, testPutFillOutsideMap)
   ASSERT_FALSE(polygon_->putFill(map, nav2_map_server::OverlayType::OVERLAY_SEQ));
   verifyMapEmpty(map);
 
-  // Larger than the map: boundaries can not be converted either
+  // Polygon larger than the map
   po = makePolygonObject({});
   for (auto & p : po->points) {
     p.x *= 3.0f;
@@ -955,7 +955,7 @@ public:
   mutable size_t point_checks{0};
 };
 
-TEST_F(Tester, testPutFillChecksPointsPerRowNotPerCell)
+TEST_F(Tester, testPutFillComplexity)
 {
   auto po = makePolygonObject({});
   for (auto & p : po->points) {
@@ -975,13 +975,13 @@ TEST_F(Tester, testPutFillChecksPointsPerRowNotPerCell)
   const size_t filled = std::count(map->data.begin(), map->data.end(),
     nav2_util::OCC_GRID_OCCUPIED);
   ASSERT_EQ(filled, 300u * 300u);
-  // Interior cells are filled without testing them; only span ends are checked (a few per row)
+  // Only span ends should be tested, not every cell
   EXPECT_LE(polygon->point_checks, 8u * 300u);
 }
 
 TEST_F(Tester, testPutFillLargeMap)
 {
-  // 9000 x 9000 cells at 5 cm (81 M cells, 450 m): warehouse-scale VO grid
+  // 9000 x 9000 cells at 5 cm resolution
   const unsigned int size = 9000;
   auto map = std::make_shared<nav_msgs::msg::OccupancyGrid>();
   map->header.frame_id = GLOBAL_FRAME_ID;
@@ -995,8 +995,7 @@ TEST_F(Tester, testPutFillLargeMap)
       return map->data[static_cast<size_t>(my) * size + mx];
     };
 
-  // Axis-aligned rectangle spanning most of the grid: the filled count is exactly
-  // (columns whose center is inside) x (rows whose center is inside)
+  // Rectangle: number of filled cells must be (columns inside) x (rows inside)
   auto po = makePolygonObject({});
   po->points.clear();
   for (auto [x, y] : {std::pair{10.1f, 20.3f}, {439.7f, 20.3f}, {439.7f, 430.9f},
@@ -1026,8 +1025,7 @@ TEST_F(Tester, testPutFillLargeMap)
   EXPECT_EQ(cell(size - 1, size - 1), nav2_util::OCC_GRID_UNKNOWN);
   EXPECT_EQ(cell(size / 2, size / 2), nav2_util::OCC_GRID_OCCUPIED);
 
-  // A rotated triangle and a large circle overlaid with MAX; compare against the per-cell
-  // predicate on a strided sample plus every cell of the rows and columns at their extremes
+  // Triangle and circle: check a sample of cells plus some full rows and columns
   po->points.clear();
   for (auto [x, y] : {std::pair{5.0f, 100.0f}, {300.0f, 5.0f}, {445.0f, 440.0f}}) {
     geometry_msgs::msg::Point32 p;

--- a/nav2_map_server/test/unit/test_vector_object_shapes.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_shapes.cpp
@@ -979,6 +979,100 @@ TEST_F(Tester, testPutFillChecksPointsPerRowNotPerCell)
   EXPECT_LE(polygon->point_checks, 8u * 300u);
 }
 
+TEST_F(Tester, testPutFillLargeMap)
+{
+  // 9000 x 9000 cells at 5 cm (81 M cells, 450 m): warehouse-scale VO grid
+  const unsigned int size = 9000;
+  auto map = std::make_shared<nav_msgs::msg::OccupancyGrid>();
+  map->header.frame_id = GLOBAL_FRAME_ID;
+  map->info.resolution = 0.05;
+  map->info.width = size;
+  map->info.height = size;
+  map->info.origin.position.x = 0.0;
+  map->info.origin.position.y = 0.0;
+  map->data.assign(static_cast<size_t>(size) * size, nav2_util::OCC_GRID_UNKNOWN);
+  const auto cell = [&](unsigned int mx, unsigned int my) {
+      return map->data[static_cast<size_t>(my) * size + mx];
+    };
+
+  // Axis-aligned rectangle spanning most of the grid: the filled count is exactly
+  // (columns whose center is inside) x (rows whose center is inside)
+  auto po = makePolygonObject({});
+  po->points.clear();
+  for (auto [x, y] : {std::pair{10.1f, 20.3f}, {439.7f, 20.3f}, {439.7f, 430.9f},
+      {10.1f, 430.9f}})
+  {
+    geometry_msgs::msg::Point32 p;
+    p.x = x;
+    p.y = y;
+    po->points.push_back(p);
+  }
+  ASSERT_TRUE(polygon_->setParams(po));
+  ASSERT_TRUE(polygon_->putFill(map, nav2_map_server::OverlayType::OVERLAY_SEQ));
+  size_t columns_inside = 0, rows_inside = 0;
+  for (unsigned int i = 0; i < size; i++) {
+    double wx, wy;
+    nav2_util::mapToWorld(map, i, i, wx, wy);
+    columns_inside += polygon_->isPointInside(wx, 200.0);
+    rows_inside += polygon_->isPointInside(200.0, wy);
+  }
+  EXPECT_EQ(columns_inside, 8592u);
+  EXPECT_EQ(rows_inside, 8212u);
+  EXPECT_EQ(
+    static_cast<size_t>(std::count(
+      map->data.begin(), map->data.end(), nav2_util::OCC_GRID_OCCUPIED)),
+    columns_inside * rows_inside);
+  EXPECT_EQ(cell(0, 0), nav2_util::OCC_GRID_UNKNOWN);
+  EXPECT_EQ(cell(size - 1, size - 1), nav2_util::OCC_GRID_UNKNOWN);
+  EXPECT_EQ(cell(size / 2, size / 2), nav2_util::OCC_GRID_OCCUPIED);
+
+  // A rotated triangle and a large circle overlaid with MAX; compare against the per-cell
+  // predicate on a strided sample plus every cell of the rows and columns at their extremes
+  po->points.clear();
+  for (auto [x, y] : {std::pair{5.0f, 100.0f}, {300.0f, 5.0f}, {445.0f, 440.0f}}) {
+    geometry_msgs::msg::Point32 p;
+    p.x = x;
+    p.y = y;
+    po->points.push_back(p);
+  }
+  po->value = 70;
+  ASSERT_TRUE(polygon_->setParams(po));
+  auto co = makeCircleObject({});
+  co->center.x = 225.0;
+  co->center.y = 225.0;
+  co->radius = 210.0;
+  co->value = 90;
+  ASSERT_TRUE(circle_->setParams(co));
+  map->data.assign(map->data.size(), nav2_util::OCC_GRID_UNKNOWN);
+  ASSERT_TRUE(polygon_->putFill(map, nav2_map_server::OverlayType::OVERLAY_MAX));
+  ASSERT_TRUE(circle_->putFill(map, nav2_map_server::OverlayType::OVERLAY_MAX));
+  const auto expected = [&](unsigned int mx, unsigned int my) {
+      double wx, wy;
+      nav2_util::mapToWorld(map, mx, my, wx, wy);
+      int8_t value = nav2_util::OCC_GRID_UNKNOWN;
+      if (polygon_->isPointInside(wx, wy)) {
+        value = 70;
+      }
+      if (circle_->isPointInside(wx, wy)) {
+        value = 90;
+      }
+      return value;
+    };
+  size_t mismatches = 0;
+  for (unsigned int my = 0; my < size; my += 37) {
+    for (unsigned int mx = 0; mx < size; mx += 41) {
+      mismatches += cell(mx, my) != expected(mx, my);
+    }
+  }
+  for (unsigned int i = 0; i < size; i++) {
+    for (unsigned int edge : {99u, 100u, 8699u, 8700u, 8799u, 8800u, size - 1}) {
+      mismatches += cell(i, edge) != expected(i, edge);
+      mismatches += cell(edge, i) != expected(edge, i);
+    }
+  }
+  EXPECT_EQ(mismatches, 0u);
+}
+
 int main(int argc, char ** argv)
 {
   // Initialize the system


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6278 |
| Primary OS tested on | ROS 2 Lyrical |
| Robotic platform tested on | Gazebo simulation of Dexory|
| Does this PR contain AI generated software? | Yes Fable 5.1|
| Was this PR description generated by AI software? | Drafted with AI and refined|

---

## Description of contribution in a few bullet points

* Replace the per-cell fill in `VectorObjectServer::putVectorObjectsOnMap()` — which ran a point-in-shape test on every cell of each filled shape's bounding box (O(bbox cells × vertices)) — with a scanline rasterizer, `Shape::putFill()` (O(filled cells + rows × vertices)).
* `Polygon::getRowSpans()` computes per-row interior intervals using exactly the edge-selection rule and intersection arithmetic of `nav2_util::geometry_utils::isPointInsidePolygon()`; `Circle::getRowSpans()` uses the chord width with a tiny over-cover. `putFill()` brackets the cells whose centers fall in each half-open interval with the same cell-center arithmetic as the predicate and trims the ends with `isPointInside()`, so the filled cell set is **bit-identical** to the previous implementation for polygons and circles, under all three overlay types.
* New `processRun()` writes a span with the overlay dispatch hoisted out of the per-cell loop (`std::fill_n` for SEQ, vectorizable `std::max` loop for MAX). `processCell()` now takes the map by const reference instead of copying the `shared_ptr` per cell (used by border raytracing).


### Performance

Real customer maps (not sharing for confidentiality). Every case: **0 mismatched cells** vs the previous implementation.

| Map | Shapes | Grid (cells) | Filled cells | Before | After | Speedup |
|---|---:|---|---:|---:|---:|---:|
| A (all zones) | 295 | 8882 × 3838 | 19.0 M | 383 ms | 7.9 ms | 48× |
| B (all zones) | 313 | 13641 × 7846 | 74.8 M | 2110 ms | 20.7 ms | 102× |
| C (all zones) | 131 | 5456 × 2706 | 14.2 M | 369 ms | 4.3 ms | 86× |
| D (all zones) | 175 | 6207 × 3492 | 11.6 M | 171 ms | 2.0 ms | 84× |
| E (all zones) | 277 | 10721 × 6598 | 25.6 M | 441 ms | 8.7 ms | 51× |

For reference, `cv::fillPoly` on the same inputs is ~2.5–3× faster still (memset per span, no per-row math) but fills 0.7 % of cells differently (edge-inclusive rounding grows shapes by up to one cell). The remaining gap is per-row bookkeeping, not per-cell work; the fill loops are already vectorized by the compiler.

## Description of documentation updates required from your changes

Maybe Release notes?

## Description of how this change was tested

* New unit tests in `nav2_map_server/test/unit/test_vector_object_shapes.cpp`:
  * `testPutFillMatchesPerCellCheck`: 200 random polygons (3–9 vertices, some on cell centers/edges) and 200 random circles, filled with `putFill()` and with the reference per-cell `isPointInside()` loop on a prefilled map, compared cell-for-cell under `OVERLAY_SEQ`, `OVERLAY_MAX`, `OVERLAY_MIN`.
  * `testPutFillDegeneratePolygonsMatchPerCellCheck`: self-intersecting bow-tie, edges on cell-center rows/columns, vertex on a cell center, duplicate and collinear vertices, sub-cell and zero-area polygons, polygon touching the last cell center, concave notch on a cell-center row. (The bow-tie case caught a span-extension bug during development; fixed before this PR.)
  * `testPutFillOutsideMap`: shapes outside or larger than the map return `false` and leave the map untouched.
  * `testPutFillChecksPointsPerRowNotPerCell`: a counting `Polygon` subclass fills a 300 × 300-cell rectangle; asserts 90 000 cells filled with ≤ 2 400 `isPointInside()` calls — timing-independent guard against regressing to per-cell testing.
  * `testPutFillLargeMap`: 9000 × 9000-cell grid (81 M cells). An axis-aligned rectangle's filled count must equal (columns inside) × (rows inside) derived from the predicate; a rotated triangle and a 210 m-radius circle under `OVERLAY_MAX` are compared against the predicate on a strided sample plus full rows/columns at the shape extremes and grid edge. Runs in ~70 ms.
* Offline A/B on 12 real annotation maps: old vs new rasterizer on the auto-sized VO grid, 0 mismatched cells on all maps; timings above.

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
