### PR TITLE
[WIP] Pluggable docking controllers

### DIFF
--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -219,8 +219,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | docks  |  Instead of `dock_database`, the set of docks specified in the params file itself | vector<string> | N/A     |
 | navigator_bt_xml  | BT XML to use for Navigator, if non-default | string | ""     |
 | controllers  | The set of controller plugin instances to load. Each entry names a parameter namespace and requires a `<name>.plugin` type. | vector<string> | ["controller"]     |
-| \<dock plugin\>.controller  | Name of the controller every dock of this type drives with. Must name an entry of `controllers`. Optional with one controller loaded; **required** with more than one. | string | ""     |
-| \<dock\>.controller  | Name of the controller this one dock drives with, overriding the one its type names. Always optional. Also settable per entry in a `dock_database` file. | string | ""     |
+| \<dock plugin\>.controller  | Name of the controller for every dock of this type. Must be in `controllers` list. Optional with one controller loaded; **required** with more than one. | string | ""     |
+| \<dock\>.controller  | Name of the controller this dock instance drives with, overriding the one given by dock type. Always optional. | string | ""     |
 | controller.k_phi  | Ratio of the rate of change in phi to the rate of change in r. Controls the convergence of the slow subsystem  | double | 3.0  |
 | controller.k_delta  | Constant factor applied to the heading error feedback. Controls the convergence of the fast subsystem | double | 2.0     |
 | controller.beta  | Constant factor applied to the path curvature. This value must be positive. Determines how fast the velocity drops when the curvature increases | double | 0.4  |
@@ -241,13 +241,6 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.dock_collision_threshold | Distance (m) from the dock pose to ignore collisions. | double | 0.3     |
 
 Note: `dock_plugins` and either `docks` or `dock_database` are required.
-
-Note: the `controller.*` parameters above are the parameters of one controller *instance*. When
-`controllers` is not set, a single instance named `controller` of type
-`opennav_docking::GracefulController` is created, so those names apply as written. When
-`controllers` is set, each listed instance takes the same parameters under its own name, e.g.
-`graceful.k_phi`.
-
 
 | SimpleChargingDock Parameter | Description                                             | Type   | Default   |
 |------------------------------|---------------------------------------------------------|--------|-----------|

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -236,6 +236,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.projection_time | Time to look ahead for collisions (s). | double | 5.0     |
 | controller.simulation_time_step | Time step for projections (s). | double | 0.1     |
 | controller.dock_collision_threshold | Distance (m) from the dock pose to ignore collisions. | double | 0.3     |
+| controller.publish_trajectory | Whether to publish the projected docking trajectory for visualization / debugging. When false, no publisher is created and the trajectory is not assembled. Read at configure time only. | bool | false     |
+| controller.trajectory_topic | The topic on which to publish the projected trajectory, when `publish_trajectory` is enabled. | string | "docking_trajectory"     |
 
 Note: `dock_plugins` and either `docks` or `dock_database` are required.
 

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -219,6 +219,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | docks  |  Instead of `dock_database`, the set of docks specified in the params file itself | vector<string> | N/A     |
 | navigator_bt_xml  | BT XML to use for Navigator, if non-default | string | ""     |
 | controllers  | The set of controller plugin instances to load. Each entry names a parameter namespace and requires a `<name>.plugin` type. | vector<string> | ["controller"]     |
+| \<dock plugin\>.controller  | Name of the controller for every dock of this type. Must be in `controllers` list. Optional with one controller loaded; **required** with more than one. | string | ""     |
+| \<dock\>.controller  | Name of the controller this dock instance drives with, overriding the one given by dock type. Always optional. | string | ""     |
 | controller.k_phi  | Ratio of the rate of change in phi to the rate of change in r. Controls the convergence of the slow subsystem  | double | 3.0  |
 | controller.k_delta  | Constant factor applied to the heading error feedback. Controls the convergence of the fast subsystem | double | 2.0     |
 | controller.beta  | Constant factor applied to the path curvature. This value must be positive. Determines how fast the velocity drops when the curvature increases | double | 0.4  |
@@ -247,7 +249,6 @@ Note: the `controller.*` parameters above are the parameters of one controller *
 `opennav_docking::GracefulController` is created, so those names apply as written. When
 `controllers` is set, each listed instance takes the same parameters under its own name, e.g.
 `graceful.k_phi`.
-
 
 | SimpleChargingDock Parameter | Description                                             | Type   | Default   |
 |------------------------------|---------------------------------------------------------|--------|-----------|

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -218,6 +218,7 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | dock_database  |  The filepath to the dock database to use for this environment | string |  N/A  |
 | docks  |  Instead of `dock_database`, the set of docks specified in the params file itself | vector<string> | N/A     |
 | navigator_bt_xml  | BT XML to use for Navigator, if non-default | string | ""     |
+| controllers  | The set of controller plugin instances to load. Each entry names a parameter namespace and requires a `<name>.plugin` type. | vector<string> | ["controller"]     |
 | controller.k_phi  | Ratio of the rate of change in phi to the rate of change in r. Controls the convergence of the slow subsystem  | double | 3.0  |
 | controller.k_delta  | Constant factor applied to the heading error feedback. Controls the convergence of the fast subsystem | double | 2.0     |
 | controller.beta  | Constant factor applied to the path curvature. This value must be positive. Determines how fast the velocity drops when the curvature increases | double | 0.4  |
@@ -240,6 +241,12 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.trajectory_topic | The topic on which to publish the projected trajectory, when `publish_trajectory` is enabled. | string | "docking_trajectory"     |
 
 Note: `dock_plugins` and either `docks` or `dock_database` are required.
+
+Note: the `controller.*` parameters above are the parameters of one controller *instance*. When
+`controllers` is not set, a single instance named `controller` of type
+`opennav_docking::GracefulController` is created, so those names apply as written. When
+`controllers` is set, each listed instance takes the same parameters under its own name, e.g.
+`graceful.k_phi`.
 
 
 | SimpleChargingDock Parameter | Description                                             | Type   | Default   |

--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -219,8 +219,8 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | docks  |  Instead of `dock_database`, the set of docks specified in the params file itself | vector<string> | N/A     |
 | navigator_bt_xml  | BT XML to use for Navigator, if non-default | string | ""     |
 | controllers  | The set of controller plugin instances to load. Each entry names a parameter namespace and requires a `<name>.plugin` type. | vector<string> | ["controller"]     |
-| \<dock plugin\>.controller  | Name of the controller for every dock of this type. Must be in `controllers` list. Optional with one controller loaded; **required** with more than one. | string | ""     |
-| \<dock\>.controller  | Name of the controller this dock instance drives with, overriding the one given by dock type. Always optional. | string | ""     |
+| \<dock plugin\>.controller  | Name of the controller every dock of this type drives with. Must name an entry of `controllers`. Optional with one controller loaded; **required** with more than one. | string | ""     |
+| \<dock\>.controller  | Name of the controller this one dock drives with, overriding the one its type names. Always optional. Also settable per entry in a `dock_database` file. | string | ""     |
 | controller.k_phi  | Ratio of the rate of change in phi to the rate of change in r. Controls the convergence of the slow subsystem  | double | 3.0  |
 | controller.k_delta  | Constant factor applied to the heading error feedback. Controls the convergence of the fast subsystem | double | 2.0     |
 | controller.beta  | Constant factor applied to the path curvature. This value must be positive. Determines how fast the velocity drops when the curvature increases | double | 0.4  |
@@ -239,8 +239,6 @@ For debugging purposes, there are several publishers which can be used with RVIZ
 | controller.projection_time | Time to look ahead for collisions (s). | double | 5.0     |
 | controller.simulation_time_step | Time step for projections (s). | double | 0.1     |
 | controller.dock_collision_threshold | Distance (m) from the dock pose to ignore collisions. | double | 0.3     |
-| controller.publish_trajectory | Whether to publish the projected docking trajectory for visualization / debugging. When false, no publisher is created and the trajectory is not assembled. Read at configure time only. | bool | false     |
-| controller.trajectory_topic | The topic on which to publish the projected trajectory, when `publish_trajectory` is enabled. | string | "docking_trajectory"     |
 
 Note: `dock_plugins` and either `docks` or `dock_database` are required.
 
@@ -249,6 +247,7 @@ Note: the `controller.*` parameters above are the parameters of one controller *
 `opennav_docking::GracefulController` is created, so those names apply as written. When
 `controllers` is set, each listed instance takes the same parameters under its own name, e.g.
 `graceful.k_phi`.
+
 
 | SimpleChargingDock Parameter | Description                                             | Type   | Default   |
 |------------------------------|---------------------------------------------------------|--------|-----------|

--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(angles REQUIRED)
 find_package(backward_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
+find_package(nav2_costmap_2d REQUIRED)
 find_package(nav2_graceful_controller REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -34,6 +35,8 @@ set(library_name ${executable_name}_core)
 
 add_library(controller SHARED
   src/controller.cpp
+  src/controller_base.cpp
+  src/graceful_controller.cpp
 )
 target_include_directories(controller
   PUBLIC
@@ -42,11 +45,20 @@ target_include_directories(controller
 )
 target_link_libraries(controller PUBLIC
   geometry_msgs::geometry_msgs
+  nav2_costmap_2d::nav2_costmap_2d_core
   nav2_graceful_controller::nav2_graceful_controller
   nav2_ros_common::nav2_ros_common
+  nav_msgs::nav_msgs
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   rcl_interfaces::rcl_interfaces
+  tf2_ros::tf2_ros
+)
+target_link_libraries(controller PRIVATE
+  nav2_util::nav2_util_core
+  pluginlib::pluginlib
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 add_library(${library_name} SHARED
@@ -170,6 +182,7 @@ target_link_libraries(simple_non_charging_dock PRIVATE
 )
 
 pluginlib_export_plugin_description_file(opennav_docking_core plugins.xml)
+pluginlib_export_plugin_description_file(opennav_docking plugins.xml)
 
 install(TARGETS ${library_name} controller pose_filter simple_charging_dock simple_non_charging_dock
   EXPORT ${PROJECT_NAME}
@@ -205,9 +218,11 @@ ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name} controller pose_filter)
 ament_export_dependencies(
   geometry_msgs
+  nav2_costmap_2d
   nav2_graceful_controller
   nav2_msgs
   nav2_util
+  nav_msgs
   opennav_docking_core
   pluginlib
   nav2_ros_common

--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -33,9 +33,37 @@ nav2_package()
 set(executable_name opennav_docking)
 set(library_name ${executable_name}_core)
 
+add_library(controller_base SHARED
+  src/controller_base.cpp
+)
+target_include_directories(controller_base
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(controller_base PUBLIC
+  geometry_msgs::geometry_msgs
+  nav2_costmap_2d::nav2_costmap_2d_client
+  nav2_costmap_2d::nav2_costmap_2d_core
+  nav2_ros_common::nav2_ros_common
+  nav_msgs::nav_msgs
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  rcl_interfaces::rcl_interfaces
+  tf2_ros::tf2_ros
+)
+target_link_libraries(controller_base PRIVATE
+  nav2_util::nav2_util_core
+  pluginlib::pluginlib
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+)
+
+# opennav_following links this library directly (nav2_following/opennav_following/
+# CMakeLists.txt:39) and is composed into the docking server's process, so it is kept
+# to keep changes limited
 add_library(controller SHARED
   src/controller.cpp
-  src/controller_base.cpp
   src/graceful_controller.cpp
 )
 target_include_directories(controller
@@ -44,6 +72,7 @@ target_include_directories(controller
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 target_link_libraries(controller PUBLIC
+  controller_base
   geometry_msgs::geometry_msgs
   nav2_costmap_2d::nav2_costmap_2d_core
   nav2_graceful_controller::nav2_graceful_controller
@@ -61,6 +90,22 @@ target_link_libraries(controller PRIVATE
   tf2_geometry_msgs::tf2_geometry_msgs
 )
 
+add_library(graceful_controller_plugin SHARED
+  src/graceful_controller_plugin.cpp
+)
+target_include_directories(graceful_controller_plugin
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(graceful_controller_plugin PUBLIC
+  controller
+  rclcpp::rclcpp
+)
+target_link_libraries(graceful_controller_plugin PRIVATE
+  pluginlib::pluginlib
+)
+
 add_library(${library_name} SHARED
   src/docking_server.cpp
   src/dock_database.cpp
@@ -74,7 +119,7 @@ target_include_directories(${library_name}
 )
 target_link_libraries(${library_name} PUBLIC
   angles::angles
-  controller
+  controller_base
   geometry_msgs::geometry_msgs
   nav2_msgs::nav2_msgs
   nav2_util::nav2_util_core
@@ -184,7 +229,8 @@ target_link_libraries(simple_non_charging_dock PRIVATE
 pluginlib_export_plugin_description_file(opennav_docking_core plugins.xml)
 pluginlib_export_plugin_description_file(opennav_docking plugins.xml)
 
-install(TARGETS ${library_name} controller pose_filter simple_charging_dock simple_non_charging_dock
+install(TARGETS ${library_name} controller controller_base graceful_controller_plugin
+  pose_filter simple_charging_dock simple_non_charging_dock
   EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -215,7 +261,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_libraries(${library_name} controller pose_filter)
+ament_export_libraries(${library_name} controller controller_base graceful_controller_plugin pose_filter)
 ament_export_dependencies(
   geometry_msgs
   nav2_costmap_2d

--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -59,9 +59,8 @@ target_link_libraries(controller_base PRIVATE
   tf2_geometry_msgs::tf2_geometry_msgs
 )
 
-# opennav_following links this library directly (nav2_following/opennav_following/
-# CMakeLists.txt:39) and is composed into the docking server's process, so it is kept
-# to keep changes limited
+# opennav_following links this library directly
+# so it is kept to keep changes limited
 add_library(controller SHARED
   src/controller.cpp
   src/graceful_controller.cpp

--- a/nav2_docking/opennav_docking/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(controller_base PRIVATE
 add_library(controller SHARED
   src/controller.cpp
   src/graceful_controller.cpp
+  src/pid_controller.cpp
 )
 target_include_directories(controller
   PUBLIC
@@ -72,6 +73,7 @@ target_include_directories(controller
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 target_link_libraries(controller PUBLIC
+  angles::angles
   controller_base
   geometry_msgs::geometry_msgs
   nav2_costmap_2d::nav2_costmap_2d_core
@@ -103,6 +105,22 @@ target_link_libraries(graceful_controller_plugin PUBLIC
   rclcpp::rclcpp
 )
 target_link_libraries(graceful_controller_plugin PRIVATE
+  pluginlib::pluginlib
+)
+
+add_library(pid_controller_plugin SHARED
+  src/pid_controller_plugin.cpp
+)
+target_include_directories(pid_controller_plugin
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(pid_controller_plugin PUBLIC
+  controller
+  rclcpp::rclcpp
+)
+target_link_libraries(pid_controller_plugin PRIVATE
   pluginlib::pluginlib
 )
 
@@ -230,7 +248,7 @@ pluginlib_export_plugin_description_file(opennav_docking_core plugins.xml)
 pluginlib_export_plugin_description_file(opennav_docking plugins.xml)
 
 install(TARGETS ${library_name} controller controller_base graceful_controller_plugin
-  pose_filter simple_charging_dock simple_non_charging_dock
+  pid_controller_plugin pose_filter simple_charging_dock simple_non_charging_dock
   EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -261,7 +279,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_libraries(${library_name} controller controller_base graceful_controller_plugin pose_filter)
+ament_export_libraries(${library_name} controller controller_base graceful_controller_plugin
+  pid_controller_plugin pose_filter)
 ament_export_dependencies(
   geometry_msgs
   nav2_costmap_2d

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2024 Open Navigation LLC
 // Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,21 +23,18 @@
 
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/twist.hpp"
-#include "nav2_costmap_2d/costmap_subscriber.hpp"
-#include "nav2_costmap_2d/footprint_subscriber.hpp"
-#include "nav2_costmap_2d/costmap_topic_collision_checker.hpp"
-#include "nav2_graceful_controller/smooth_control_law.hpp"
-#include "nav_msgs/msg/path.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_ros_common/tf2_factories.hpp"
+#include "opennav_docking/graceful_controller.hpp"
 
 namespace opennav_docking
 {
 /**
  * @class opennav_docking::Controller
- * @brief Default control law for approaching a dock target
+ * @brief Default controller based on GracefulController
+ * plugin interface.
  */
-class Controller
+class Controller : public GracefulController
 {
 public:
   /**
@@ -67,90 +65,6 @@ public:
   bool computeVelocityCommand(
     const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::Twist & cmd, bool is_docking,
     bool backward = false);
-
-  /**
-   * @brief Perform a command for in-place rotation.
-   * @param angular_distance_to_heading Angular distance to goal.
-   * @param current_velocity Current angular velocity.
-   * @param dt Control loop duration [s].
-   * @returns TwistStamped command for in-place rotation.
-   */
-  geometry_msgs::msg::Twist computeRotateToHeadingCommand(
-    const double & angular_distance_to_heading,
-    const geometry_msgs::msg::Twist & current_velocity,
-    const double & dt);
-
-protected:
-  /**
-   * @brief Check if a trajectory is collision free.
-   *
-   * @param target_pose Target pose, in robot centric coordinates.
-   * @param is_docking If true, robot is docking. If false, robot is undocking.
-   * @param backward If true, robot will drive backwards to goal.
-   * @return True if trajectory is collision free.
-   */
-  bool isTrajectoryCollisionFree(
-    const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward = false);
-
-  /**
-   * @brief Validate incoming parameter updates before applying them.
-   * This callback is triggered when one or more parameters are about to be updated.
-   * It checks the validity of parameter values and rejects updates that would lead
-   * to invalid or inconsistent configurations
-   * @param parameters List of parameters that are being updated.
-   * @return rcl_interfaces::msg::SetParametersResult Result indicating whether the update is accepted.
-   */
-  rcl_interfaces::msg::SetParametersResult validateParameterUpdatesCallback(
-    const std::vector<rclcpp::Parameter> & parameters);
-
-  /**
-   * @brief Apply parameter updates after validation
-   * This callback is executed when parameters have been successfully updated.
-   * It updates the internal configuration of the node with the new parameter values.
-   * @param parameters List of parameters that have been updated.
-   */
-  void updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters);
-
-  /**
-   * @brief Configure the collision checker.
-   *
-   * @param node Lifecycle node
-   * @param costmap_topic Costmap topic
-   * @param footprint_topic Footprint topic
-   * @param transform_tolerance Transform tolerance
-   */
-  void configureCollisionChecker(
-    const nav2::LifecycleNode::SharedPtr & node,
-    std::string costmap_topic, std::string footprint_topic, double transform_tolerance);
-
-  // Dynamic parameters handler
-  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_params_handler_;
-  std::mutex dynamic_params_lock_;
-
-  rclcpp::Logger logger_{rclcpp::get_logger("Controller")};
-  rclcpp::Clock::SharedPtr clock_;
-
-  // Smooth control law
-  std::unique_ptr<nav2_graceful_controller::SmoothControlLaw> control_law_;
-  double k_phi_, k_delta_, beta_, lambda_;
-  double slowdown_radius_, deceleration_max_, v_linear_min_, v_linear_max_, v_angular_max_;
-  double rotate_to_heading_angular_vel_, rotate_to_heading_max_angular_accel_;
-
-  // The trajectory of the robot while dock / undock for visualization / debug purposes
-  nav2::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
-
-  // Used for collision checking
-  bool use_collision_detection_;
-  double projection_time_;
-  double simulation_time_step_;
-  double dock_collision_threshold_;
-  double transform_tolerance_;
-  nav2::TransformBuffer::SharedPtr tf2_buffer_;
-  std::unique_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_sub_;
-  std::unique_ptr<nav2_costmap_2d::FootprintSubscriber> footprint_sub_;
-  std::shared_ptr<nav2_costmap_2d::CostmapTopicCollisionChecker> collision_checker_;
-  std::string fixed_frame_, base_frame_;
 };
 
 }  // namespace opennav_docking

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller.hpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2024 Open Navigation LLC
 // Copyright (c) 2024 Alberto J. Tudela Roldán
-// Copyright (c) 2026 Karinca Robotics
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nav2_docking/opennav_docking/include/opennav_docking/controller_base.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/controller_base.hpp
@@ -1,0 +1,278 @@
+// Copyright (c) 2024 Open Navigation LLC
+// Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENNAV_DOCKING__CONTROLLER_BASE_HPP_
+#define OPENNAV_DOCKING__CONTROLLER_BASE_HPP_
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_costmap_2d/footprint_subscriber.hpp"
+#include "nav2_costmap_2d/costmap_topic_collision_checker.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_ros_common/tf2_factories.hpp"
+#include "nav_msgs/msg/path.hpp"
+
+namespace opennav_docking
+{
+
+/**
+ * @struct TrajectoryOptions
+ * @brief Describes how the trajectory handed to ControllerBase::setTrajectory is to be driven.
+ */
+struct TrajectoryOptions
+{
+  /// @brief If true, the robot drives in reverse along the trajectory.
+  bool reverse{false};
+
+  /// @brief True while approaching a dock, false while undocking.
+  bool approaching{true};
+};
+
+/**
+ * @class opennav_docking::ControllerBase
+ * @brief Base class for docking controllers, and the pluginlib base type.
+ *
+ * A controller consumes a trajectory to the dock and produces velocity commands.
+ */
+class ControllerBase
+{
+public:
+  using Ptr = std::shared_ptr<ControllerBase>;
+
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~ControllerBase() = default;
+
+  /**
+   * @brief Configure the controller. Declares and reads ROS 2 parameters.
+   *
+   * @param parent Lifecycle node
+   * @param name The name of this controller instance; also its parameter namespace
+   * @param tf tf2_ros TF buffer
+   */
+  void configure(
+    const nav2::LifecycleNode::WeakPtr & parent,
+    const std::string & name, nav2::TransformBuffer::SharedPtr tf);
+
+  /**
+   * @brief Release the resources acquired in configure().
+   */
+  virtual void cleanup();
+
+  /**
+   * @brief Activate the trajectory publisher.
+   */
+  virtual void activate();
+
+  /**
+   * @brief Deactivate the trajectory publisher.
+   */
+  virtual void deactivate();
+
+  /**
+   * @brief Reset internal state.
+   *
+   * Called by the server once on entry to each control loop and once per docking retry.
+   */
+  virtual void reset() {}
+
+  /**
+   * @brief Set trajectory to follow.
+   *
+   * @param trajectory The trajectory to follow.
+   * @param options How the trajectory is to be driven.
+   */
+  virtual void setTrajectory(
+    const nav_msgs::msg::Path & trajectory,
+    const TrajectoryOptions & options = TrajectoryOptions());
+
+  /**
+   * @brief Compute a velocity command towards the end of the cached trajectory
+   *
+   * @param robot_pose Current pose of the robot.
+   * @param velocity Current velocity of the robot.
+   * @param dt Control loop duration [s].
+   * @param cmd Output command velocity.
+   * @returns True if the command is valid, false otherwise.
+   */
+  virtual bool computeVelocityCommands(
+    const geometry_msgs::msg::PoseStamped & robot_pose,
+    const geometry_msgs::msg::Twist & velocity,
+    double dt,
+    geometry_msgs::msg::Twist & cmd);
+
+  /**
+   * @brief Perform a command for in-place rotation.
+   *
+   * @param angular_distance_to_heading Angular distance to goal.
+   * @param current_velocity Current angular velocity.
+   * @param dt Control loop duration [s].
+   * @returns TwistStamped command for in-place rotation.
+   */
+  virtual geometry_msgs::msg::Twist computeRotateToHeadingCommand(
+    const double & angular_distance_to_heading,
+    const geometry_msgs::msg::Twist & current_velocity,
+    const double & dt);
+
+  /**
+   * @brief Gets the name of this controller instance
+   */
+  std::string getName() {return name_;}
+
+protected:
+  /**
+   * @brief Declare and read the parameters specific to the derived control law.
+   *
+   * Called by configure() after the shared parameters have been read and before the dynamic
+   * parameter callbacks are registered.
+   *
+   * @param node Lifecycle node
+   */
+  virtual void configureController(const nav2::LifecycleNode::SharedPtr & node) = 0;
+
+  /**
+   * @brief Apply the control law to produce a velocity command.
+   *
+   * Called with dynamic_params_lock_ held; implementations must not take it again.
+   *
+   * @param target Target pose, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @param dt Control loop duration [s].
+   * @returns Command velocity.
+   */
+  virtual geometry_msgs::msg::Twist computeCommand(
+    const geometry_msgs::msg::Pose & target, bool reverse, double dt) = 0;
+
+  /**
+   * @brief Forward-simulate one step of the control law, for collision checking.
+   *
+   * Called with dynamic_params_lock_ held; implementations must not take it again.
+   *
+   * @param dt Simulation time step [s].
+   * @param target Target pose, in robot centric coordinates.
+   * @param current Current pose along the projection, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @returns The pose one step further along the projection.
+   */
+  virtual geometry_msgs::msg::Pose predictNextPose(
+    double dt, const geometry_msgs::msg::Pose & target,
+    const geometry_msgs::msg::Pose & current, bool reverse) = 0;
+
+  /**
+   * @brief Apply one dynamic parameter update.
+   *
+   * Called with dynamic_params_lock_ held, once per updated parameter belonging to this
+   * controller's namespace. Derived overrides should call this base implementation so the
+   * shared parameters keep working.
+   *
+   * @param name The parameter name with this controller's namespace prefix stripped.
+   * @param parameter The parameter being updated.
+   */
+  virtual void updateParameter(const std::string & name, const rclcpp::Parameter & parameter);
+
+  /**
+   * @brief Check if a trajectory is collision free.
+   *
+   * @param target_pose Target pose, in robot centric coordinates.
+   * @param is_docking If true, robot is docking. If false, robot is undocking.
+   * @param backward If true, robot will drive backwards to goal.
+   * @return True if trajectory is collision free.
+   */
+  bool isTrajectoryCollisionFree(
+    const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward = false);
+
+  /**
+   * @brief Get the end of the trajectory expressed in the robot's base frame.
+   *
+   * @param target_pose Output target pose, in robot centric coordinates.
+   * @return True if the target pose could be resolved.
+   */
+  bool getTargetInBaseFrame(geometry_msgs::msg::Pose & target_pose);
+
+  /**
+   * @brief Validate incoming parameter updates before applying them.
+   * This callback is triggered when one or more parameters are about to be updated.
+   * It checks the validity of parameter values and rejects updates that would lead
+   * to invalid or inconsistent configurations
+   * @param parameters List of parameters that are being updated.
+   * @return rcl_interfaces::msg::SetParametersResult Result indicating whether the update is accepted.
+   */
+  virtual rcl_interfaces::msg::SetParametersResult validateParameterUpdatesCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
+
+  /**
+   * @brief Apply parameter updates after validation
+   * This callback is executed when parameters have been successfully updated.
+   * It updates the internal configuration of the node with the new parameter values.
+   * @param parameters List of parameters that have been updated.
+   */
+  void updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters);
+
+  /**
+   * @brief Configure the collision checker.
+   *
+   * @param node Lifecycle node
+   * @param costmap_topic Costmap topic
+   * @param footprint_topic Footprint topic
+   * @param transform_tolerance Transform tolerance
+   */
+  void configureCollisionChecker(
+    const nav2::LifecycleNode::SharedPtr & node,
+    std::string costmap_topic, std::string footprint_topic, double transform_tolerance);
+
+  // Dynamic parameters handler
+  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_params_handler_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_params_handler_;
+  std::mutex dynamic_params_lock_;
+
+  rclcpp::Logger logger_{rclcpp::get_logger("Controller")};
+  rclcpp::Clock::SharedPtr clock_;
+
+  // In-place rotation profile
+  double rotate_to_heading_angular_vel_, rotate_to_heading_max_angular_accel_;
+
+  // The trajectory to follow and how to drive it
+  nav_msgs::msg::Path trajectory_;
+  TrajectoryOptions trajectory_options_;
+
+  // The trajectory of the robot while dock / undock for visualization / debug purposes
+  nav2::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;
+
+  // Used for collision checking
+  bool use_collision_detection_;
+  double projection_time_;
+  double simulation_time_step_;
+  double dock_collision_threshold_;
+  double transform_tolerance_;
+  nav2::TransformBuffer::SharedPtr tf2_buffer_;
+  std::unique_ptr<nav2_costmap_2d::CostmapSubscriber> costmap_sub_;
+  std::unique_ptr<nav2_costmap_2d::FootprintSubscriber> footprint_sub_;
+  std::shared_ptr<nav2_costmap_2d::CostmapTopicCollisionChecker> collision_checker_;
+  std::string fixed_frame_, base_frame_;
+  std::string name_;
+};
+
+}  // namespace opennav_docking
+
+#endif  // OPENNAV_DOCKING__CONTROLLER_BASE_HPP_

--- a/nav2_docking/opennav_docking/include/opennav_docking/dock_database.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/dock_database.hpp
@@ -50,10 +50,12 @@ public:
    * @brief A setup function to populate database
    * @param parent Weakptr to the node to use to get interances and parameters
    * @param tf TF buffer
+   * @param valid_controller_ids Controller names the server loaded
    * @return If successful
    */
   bool initialize(
-    const nav2::LifecycleNode::WeakPtr & parent, nav2::TransformBuffer::SharedPtr tf);
+    const nav2::LifecycleNode::WeakPtr & parent, nav2::TransformBuffer::SharedPtr tf,
+    const std::vector<std::string> & valid_controller_ids = {});
 
   /**
    * @brief A destructor for opennav_docking::DockDatabase
@@ -113,6 +115,15 @@ protected:
   bool getDockInstances(const nav2::LifecycleNode::SharedPtr & node);
 
   /**
+   * @brief Check every controller name in the database against the loaded controllers.
+   *
+   * @param docks Dock instances to check, against the already-loaded dock plugins
+   * @return True if every name resolves and is present where required, or if no controller ids
+   *         were supplied
+   */
+  bool validateControllerNames(const DockMap & docks) const;
+
+  /**
    * @brief Find a dock instance in the database from ID
    * @param dock_id Id of dock to find
    * @return Dock pointer
@@ -133,6 +144,7 @@ protected:
   std::mutex & mutex_;  // Don't reload database while actively docking
   DockPluginMap dock_plugins_;
   DockMap dock_instances_;
+  std::vector<std::string> valid_controller_ids_;
   pluginlib::ClassLoader<opennav_docking_core::ChargingDock> dock_loader_;
   nav2::ServiceServer<nav2_msgs::srv::ReloadDockDatabase>::SharedPtr reload_db_service_;
 };

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -20,15 +20,17 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
+#include "pluginlib/class_loader.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_ros_common/node_utils.hpp"
 #include "nav2_ros_common/simple_action_server.hpp"
 #include "nav2_util/twist_publisher.hpp"
 #include "nav2_util/odometry_utils.hpp"
-#include "opennav_docking/controller.hpp"
+#include "opennav_docking/controller_base.hpp"
 #include "opennav_docking/utils.hpp"
 #include "opennav_docking/types.hpp"
 #include "opennav_docking/dock_database.hpp"
@@ -223,6 +225,19 @@ protected:
    */
   void undockRobot();
 
+  /**
+   * @brief Create the controller plugins listed in the `controllers` parameter.
+   * @param node Lifecycle node
+   * @return True if every controller was created and configured
+   */
+  bool loadControllerPlugins(const nav2::LifecycleNode::SharedPtr & node);
+
+  /**
+   * @brief Get the controller instance selected by the current request
+   * @return The controller, or nullptr if none is selected
+   */
+  ControllerBase::Ptr getController();
+
   // Parameter handler
   std::unique_ptr<opennav_docking::ParameterHandler> param_handler_;
   Parameters * params_;
@@ -240,8 +255,14 @@ protected:
 
   std::unique_ptr<DockDatabase> dock_db_;
   std::unique_ptr<Navigator> navigator_;
-  std::unique_ptr<Controller> controller_;
   std::string curr_dock_type_;
+
+  // Controller plugins. The loader is declared before the map so that it outlives the
+  // instances it created: members are destroyed in reverse declaration order.
+  using ControllerMap = std::unordered_map<std::string, ControllerBase::Ptr>;
+  pluginlib::ClassLoader<ControllerBase> controller_loader_;
+  ControllerMap controllers_;
+  std::string current_controller_;
 
   nav2::TransformBuffer::SharedPtr tf2_buffer_;
   nav2::TransformListener::SharedPtr tf2_listener_;

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -246,8 +246,8 @@ protected:
   /**
    * @brief Resolve which controller a dock instance drives with.
    *
-   * the dock instance's own `controller` if defined, then the controller
-   * named by its type, then the single-controller default.
+   * Precedence: the dock instance's own `controller` if defined, then the controller
+   * named by its type, then the single default controller.
    * @throw DockNotValid if the name does not resolve to a loaded controller
    */
   void selectControllerForDock(const Dock & dock);

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -228,13 +228,45 @@ protected:
   /**
    * @brief Create the controller plugins listed in the `controllers` parameter.
    * @param node Lifecycle node
+   * @param controller_ids Set to the instance names read from `controllers`.
    * @return True if every controller was created and configured
    */
-  bool loadControllerPlugins(const nav2::LifecycleNode::SharedPtr & node);
+  bool loadControllerPlugins(
+    const nav2::LifecycleNode::SharedPtr & node, std::vector<std::string> & controller_ids);
+
+  /**
+   * @brief Resolve a requested controller name against the loaded controllers.
+   *
+   * @param c_name Requested controller name, or "" for "no preference"
+   * @param current_controller Set to the resolved name on success
+   * @return True if the name resolved to a loaded controller
+   */
+  bool findControllerId(const std::string & c_name, std::string & current_controller);
+
+  /**
+   * @brief Resolve which controller a dock instance drives with.
+   *
+   * the dock instance's own `controller` if defined, then the controller
+   * named by its type, then the single-controller default.
+   * @throw DockNotValid if the name does not resolve to a loaded controller
+   */
+  void selectControllerForDock(const Dock & dock);
+
+  /**
+   * @brief Resolve which controller an undocking request drives with.
+   *
+   * @param dock_type The dock type being undocked from
+   * @param plugin The plugin for that type
+   * @throw DockNotValid if the name does not resolve to a loaded controller
+   */
+  void selectControllerForUndock(
+    const std::string & dock_type, const ChargingDock::Ptr & plugin);
 
   /**
    * @brief Get the controller instance selected by the current request
-   * @return The controller, or nullptr if none is selected
+   *
+   * @return The controller named by current_controller_
+   * @throw FailedToControl if that name does not resolve to a loaded controller
    */
   ControllerBase::Ptr getController();
 
@@ -256,12 +288,14 @@ protected:
   std::unique_ptr<DockDatabase> dock_db_;
   std::unique_ptr<Navigator> navigator_;
   std::string curr_dock_type_;
+  std::string curr_dock_controller_;
 
   // Controller plugins. The loader is declared before the map so that it outlives the
   // instances it created: members are destroyed in reverse declaration order.
   using ControllerMap = std::unordered_map<std::string, ControllerBase::Ptr>;
   pluginlib::ClassLoader<ControllerBase> controller_loader_;
   ControllerMap controllers_;
+  std::string controller_ids_concat_;
   std::string current_controller_;
 
   nav2::TransformBuffer::SharedPtr tf2_buffer_;

--- a/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/docking_server.hpp
@@ -290,8 +290,6 @@ protected:
   std::string curr_dock_type_;
   std::string curr_dock_controller_;
 
-  // Controller plugins. The loader is declared before the map so that it outlives the
-  // instances it created: members are destroyed in reverse declaration order.
   using ControllerMap = std::unordered_map<std::string, ControllerBase::Ptr>;
   pluginlib::ClassLoader<ControllerBase> controller_loader_;
   ControllerMap controllers_;

--- a/nav2_docking/opennav_docking/include/opennav_docking/graceful_controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/graceful_controller.hpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 Open Navigation LLC
+// Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENNAV_DOCKING__GRACEFUL_CONTROLLER_HPP_
+#define OPENNAV_DOCKING__GRACEFUL_CONTROLLER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "nav2_graceful_controller/smooth_control_law.hpp"
+#include "opennav_docking/controller_base.hpp"
+
+namespace opennav_docking
+{
+
+/**
+ * @class opennav_docking::GracefulController
+ * @brief Default control law for approaching a dock target
+ */
+class GracefulController : public ControllerBase
+{
+public:
+  /**
+   * @brief Release the smooth control law along with the shared resources.
+   */
+  void cleanup() override;
+
+protected:
+  /**
+   * @brief Declare the smooth control law parameters and construct the control law.
+   * @param node Lifecycle node
+   */
+  void configureController(const nav2::LifecycleNode::SharedPtr & node) override;
+
+  /**
+   * @brief Compute a velocity command using the smooth control law.
+   * @param target Target pose, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @param dt Control loop duration [s]. Unused: the smooth control law is a pure feedback law.
+   * @returns Command velocity.
+   */
+  geometry_msgs::msg::Twist computeCommand(
+    const geometry_msgs::msg::Pose & target, bool reverse, double dt) override;
+
+  /**
+   * @brief Forward-simulate one step of the smooth control law.
+   * @param dt Simulation time step [s].
+   * @param target Target pose, in robot centric coordinates.
+   * @param current Current pose along the projection, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @returns The pose one step further along the projection.
+   */
+  geometry_msgs::msg::Pose predictNextPose(
+    double dt, const geometry_msgs::msg::Pose & target,
+    const geometry_msgs::msg::Pose & current, bool reverse) override;
+
+  /**
+   * @brief Apply a dynamic parameter update to the smooth control law.
+   * @param name The parameter name with this controller's namespace prefix stripped.
+   * @param parameter The parameter being updated.
+   */
+  void updateParameter(const std::string & name, const rclcpp::Parameter & parameter) override;
+
+  // Smooth control law
+  std::unique_ptr<nav2_graceful_controller::SmoothControlLaw> control_law_;
+  double k_phi_, k_delta_, beta_, lambda_;
+  double slowdown_radius_, deceleration_max_, v_linear_min_, v_linear_max_, v_angular_max_;
+};
+
+}  // namespace opennav_docking
+
+#endif  // OPENNAV_DOCKING__GRACEFUL_CONTROLLER_HPP_

--- a/nav2_docking/opennav_docking/include/opennav_docking/pid_controller.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/pid_controller.hpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENNAV_DOCKING__PID_CONTROLLER_HPP_
+#define OPENNAV_DOCKING__PID_CONTROLLER_HPP_
+
+#include <string>
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "opennav_docking/controller_base.hpp"
+
+namespace opennav_docking
+{
+
+/**
+ * @class opennav_docking::PIDController
+ * @brief A docking controller implementing PID controller.
+ *
+ */
+class PIDController : public ControllerBase
+{
+public:
+  /**
+   * @brief Zero internal state.
+   *
+   * Called by the server on entry to each control loop and once per docking retry
+   */
+  void reset() override;
+
+protected:
+  /**
+   * @brief Declare and read the parameters.
+   * @param node Lifecycle node
+   */
+  void configureController(const nav2::LifecycleNode::SharedPtr & node) override;
+
+  /**
+   * @brief Apply the PID law to produce a velocity command.
+   *
+   * @param target Target pose, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @param dt Control loop sampling period.
+   * @returns Command velocity.
+   */
+  geometry_msgs::msg::Twist computeCommand(
+    const geometry_msgs::msg::Pose & target, bool reverse, double dt) override;
+
+  /**
+   * @brief Simulate one step of the PID law for collision checking.
+   *
+   * @param dt Simulation time step [s].
+   * @param target Target pose, in robot centric coordinates.
+   * @param current Current pose along the projection, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @returns The pose after one step forward.
+   */
+  geometry_msgs::msg::Pose predictNextPose(
+    double dt, const geometry_msgs::msg::Pose & target,
+    const geometry_msgs::msg::Pose & current, bool reverse) override;
+
+  /**
+   * @brief Dynamic parameter update.
+   * @param name The parameter name having controller's namespace prefix removed.
+   * @param parameter The parameter being updated.
+   */
+  void updateParameter(const std::string & name, const rclcpp::Parameter & parameter) override;
+
+  /**
+   * @struct ControllerState
+   * @brief One PID axis: its gains, its anti-windup bound and its running state.
+   */
+  struct ControllerState
+  {
+    double kp{0.0};
+    double ki{0.0};
+    double kd{0.0};
+    double i_clamp{0.0};
+
+    double integral{0.0};
+    double prev_error{0.0};
+    double derivative{0.0};
+
+    void reset()
+    {
+      integral = 0.0;
+      prev_error = 0.0;
+      derivative = 0.0;
+    }
+  };
+
+  /**
+   * @brief Evaluate one axis without touching its state.
+   *
+   * @param channel The controller state to evaluate.
+   * @param error Current error on this axis.
+   * @param integral Integrator value to use.
+   * @param derivative Derivative value to use.
+   * @returns The axis's contribution to the command.
+   */
+  static double evaluate(
+    const ControllerState & channel, double error, double integral, double derivative);
+
+  /**
+   * @brief Advance one axis's integrator and derivative by one step.
+   *
+   * @param channel The controller state to advance.
+   * @param error Current error on this axis.
+   * @param dt Time step [s]
+   */
+  double advance(ControllerState & channel, double error, double dt);
+
+  /**
+   * @brief Calculate target pose in polar coordinate.
+   *
+   * @param target Target pose, in robot centric coordinates.
+   * @param reverse If true, robot will drive backwards to the goal.
+   * @param lookahead Floor on denominator [m] in bearing calculation.
+   * @param rho Range to the target [m].
+   * @param alpha Bearing to the target, in (-pi/2, pi/2) [rad].
+   * @param alignment Line of sight relative to the target's axis [rad].
+   */
+  static void poseError(
+    const geometry_msgs::msg::Pose & target, bool reverse, double lookahead,
+    double & rho, double & alpha, double & alignment);
+
+  /// Hard floor under lookahead_distance_.
+  static constexpr double kMinLookahead = 1e-3;
+
+  ControllerState x_, y_, theta_;
+  double v_linear_max_{0.25}, v_angular_max_{0.75};
+  double lookahead_distance_{0.25};
+};
+
+}  // namespace opennav_docking
+
+#endif  // OPENNAV_DOCKING__PID_CONTROLLER_HPP_

--- a/nav2_docking/opennav_docking/include/opennav_docking/types.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/types.hpp
@@ -40,6 +40,7 @@ struct Dock
   std::string frame;
   std::string type;
   std::string id;
+  std::string controller_name;
   opennav_docking_core::ChargingDock::Ptr plugin{nullptr};
 };
 

--- a/nav2_docking/opennav_docking/include/opennav_docking/utils.hpp
+++ b/nav2_docking/opennav_docking/include/opennav_docking/utils.hpp
@@ -62,10 +62,11 @@ inline bool parseDockFile(
   }
 
   auto yaml_docks = yaml_file["docks"];
-  Dock curr_dock;
   for (const auto & yaml_dock : yaml_docks) {
     std::string dock_name = yaml_dock.first.as<std::string>();
     const YAML::Node & dock_attribs = yaml_dock.second;
+
+    Dock curr_dock;
 
     curr_dock.frame = "map";
     if (dock_attribs["frame"]) {
@@ -101,6 +102,10 @@ inline bool parseDockFile(
       curr_dock.id = dock_attribs["id"].as<std::string>();
     }
 
+    if (dock_attribs["controller"]) {
+      curr_dock.controller_name = dock_attribs["controller"].as<std::string>();
+    }
+
     // Insert into dock instance database
     dock_db.emplace(dock_name, curr_dock);
   }
@@ -119,9 +124,9 @@ inline bool parseDockParams(
   const nav2::LifecycleNode::SharedPtr & node,
   DockMap & dock_db)
 {
-  Dock curr_dock;
   std::vector<double> pose_arr;
   for (const auto & dock_name : docks_param) {
+    Dock curr_dock;
     curr_dock.frame = node->declare_or_get_parameter(dock_name + ".frame", std::string("map"));
 
     try {
@@ -147,6 +152,8 @@ inline bool parseDockParams(
     curr_dock.pose.orientation = orientationAroundZAxis(pose_arr[2]);
 
     curr_dock.id = node->declare_or_get_parameter(dock_name + ".id", std::string(""));
+    curr_dock.controller_name =
+      node->declare_or_get_parameter(dock_name + ".controller", std::string(""));
 
     // Insert into dock instance database
     dock_db.emplace(dock_name, curr_dock);

--- a/nav2_docking/opennav_docking/package.xml
+++ b/nav2_docking/opennav_docking/package.xml
@@ -14,6 +14,7 @@
 
   <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav2_costmap_2d</depend>
   <depend>nav2_graceful_controller</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>

--- a/nav2_docking/opennav_docking/plugins.xml
+++ b/nav2_docking/opennav_docking/plugins.xml
@@ -9,7 +9,7 @@
       <description>A simple non-charging dock plugin.</description>
     </class>
   </library>
-  <library path="controller">
+  <library path="graceful_controller_plugin">
     <class type="opennav_docking::GracefulController" base_class_type="opennav_docking::ControllerBase">
       <description>
         A docking controller using the smooth control law of nav2_graceful_controller.

--- a/nav2_docking/opennav_docking/plugins.xml
+++ b/nav2_docking/opennav_docking/plugins.xml
@@ -16,6 +16,13 @@
       </description>
     </class>
   </library>
+  <library path="pid_controller_plugin">
+    <class type="opennav_docking::PIDController" base_class_type="opennav_docking::ControllerBase">
+      <description>
+        A docking controller implementing PID controller.
+      </description>
+    </class>
+  </library>
   <library path="test_dock">
       <class type="opennav_docking::TestFailureDock"
             base_class_type="opennav_docking_core::ChargingDock">

--- a/nav2_docking/opennav_docking/plugins.xml
+++ b/nav2_docking/opennav_docking/plugins.xml
@@ -9,6 +9,13 @@
       <description>A simple non-charging dock plugin.</description>
     </class>
   </library>
+  <library path="controller">
+    <class type="opennav_docking::GracefulController" base_class_type="opennav_docking::ControllerBase">
+      <description>
+        A docking controller using the smooth control law of nav2_graceful_controller.
+      </description>
+    </class>
+  </library>
   <library path="test_dock">
       <class type="opennav_docking::TestFailureDock"
             base_class_type="opennav_docking_core::ChargingDock">

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2024 Open Navigation LLC
 // Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +15,14 @@
 // limitations under the License.
 
 #include <memory>
+#include <string>
+#include <utility>
 
-#include "rclcpp/rclcpp.hpp"
 #include "opennav_docking/controller.hpp"
-#include "nav2_util/geometry_utils.hpp"
-#include "nav2_ros_common/node_utils.hpp"
-#include "tf2/utils.hpp"
-#include "nav2_ros_common/tf2_factories.hpp"
 
-using rcl_interfaces::msg::ParameterType;
+#include "nav2_ros_common/node_utils.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace opennav_docking
 {
@@ -30,60 +30,15 @@ namespace opennav_docking
 Controller::Controller(
   const nav2::LifecycleNode::SharedPtr & node, nav2::TransformBuffer::SharedPtr tf,
   std::string fixed_frame, std::string base_frame)
-: tf2_buffer_(tf), fixed_frame_(fixed_frame), base_frame_(base_frame)
 {
-  logger_ = node->get_logger();
-  clock_ = node->get_clock();
+  // Seed the frames given by the caller into this instance's parameter namespace, so that
+  // configure() resolves them without the server having to set them itself.
+  nav2::declare_parameter_if_not_declared(
+    node, "controller.fixed_frame", rclcpp::ParameterValue(fixed_frame));
+  nav2::declare_parameter_if_not_declared(
+    node, "controller.base_frame", rclcpp::ParameterValue(base_frame));
 
-  std::string costmap_topic, footprint_topic;
-  k_phi_ = node->declare_or_get_parameter("controller.k_phi", 3.0);
-  k_delta_ = node->declare_or_get_parameter("controller.k_delta", 2.0);
-  beta_ = node->declare_or_get_parameter("controller.beta", 0.4);
-  lambda_ = node->declare_or_get_parameter("controller.lambda", 2.0);
-  v_linear_min_ = node->declare_or_get_parameter("controller.v_linear_min", 0.1);
-  v_linear_max_ = node->declare_or_get_parameter("controller.v_linear_max", 0.25);
-  v_angular_max_ = node->declare_or_get_parameter("controller.v_angular_max", 0.75);
-  slowdown_radius_ = node->declare_or_get_parameter("controller.slowdown_radius", 0.25);
-  deceleration_max_ = node->declare_or_get_parameter("controller.deceleration_max", 2.5);
-  rotate_to_heading_angular_vel_ = node->declare_or_get_parameter(
-    "controller.rotate_to_heading_angular_vel", 1.0);
-  rotate_to_heading_max_angular_accel_ = node->declare_or_get_parameter(
-    "controller.rotate_to_heading_max_angular_accel", 3.2);
-  use_collision_detection_ = node->declare_or_get_parameter(
-    "controller.use_collision_detection", true);
-  costmap_topic = node->declare_or_get_parameter("controller.costmap_topic",
-    std::string("local_costmap/costmap_raw"));
-  footprint_topic = node->declare_or_get_parameter("controller.footprint_topic",
-    std::string("local_costmap/published_footprint"));
-  transform_tolerance_ = node->declare_or_get_parameter(
-    "controller.transform_tolerance", 0.1);
-  projection_time_ = node->declare_or_get_parameter(
-    "controller.projection_time", 5.0);
-  simulation_time_step_ = node->declare_or_get_parameter(
-    "controller.simulation_time_step", 0.1);
-  dock_collision_threshold_ = node->declare_or_get_parameter(
-    "controller.dock_collision_threshold", 0.3);
-
-  control_law_ = std::make_unique<nav2_graceful_controller::SmoothControlLaw>(
-    k_phi_, k_delta_, beta_, lambda_, slowdown_radius_, deceleration_max_,
-    v_linear_min_, v_linear_max_, v_angular_max_);
-
-  // Add callback for dynamic parameters
-  post_set_params_handler_ = node->add_post_set_parameters_callback(
-    std::bind(
-      &Controller::updateParametersCallback,
-      this, std::placeholders::_1));
-  on_set_params_handler_ = node->add_on_set_parameters_callback(
-    std::bind(
-      &Controller::validateParameterUpdatesCallback,
-      this, std::placeholders::_1));
-
-  if (use_collision_detection_) {
-    configureCollisionChecker(node, costmap_topic, footprint_topic, transform_tolerance_);
-  }
-
-  trajectory_pub_ =
-    node->create_publisher<nav_msgs::msg::Path>("docking_trajectory");
+  configure(node, "controller", tf);
 }
 
 Controller::~Controller()
@@ -99,193 +54,24 @@ bool Controller::computeVelocityCommand(
   const geometry_msgs::msg::Pose & pose, geometry_msgs::msg::Twist & cmd, bool is_docking,
   bool backward)
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
-  cmd = control_law_->calculateRegularVelocity(pose, backward);
-  return isTrajectoryCollisionFree(pose, is_docking, backward);
-}
+  nav_msgs::msg::Path trajectory;
+  trajectory.header.frame_id = base_frame_;
 
-geometry_msgs::msg::Twist Controller::computeRotateToHeadingCommand(
-  const double & angular_distance_to_heading,
-  const geometry_msgs::msg::Twist & current_velocity,
-  const double & dt)
-{
-  geometry_msgs::msg::Twist cmd_vel;
-  const double sign = angular_distance_to_heading > 0.0 ? 1.0 : -1.0;
-  const double angular_vel = sign * rotate_to_heading_angular_vel_;
-  const double min_feasible_angular_speed =
-    current_velocity.angular.z - rotate_to_heading_max_angular_accel_ * dt;
-  const double max_feasible_angular_speed =
-    current_velocity.angular.z + rotate_to_heading_max_angular_accel_ * dt;
-  cmd_vel.angular.z =
-    std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+  geometry_msgs::msg::PoseStamped target;
+  target.header.frame_id = base_frame_;
+  target.pose = pose;
+  trajectory.poses.push_back(target);
 
-  // Check if we need to slow down to avoid overshooting
-  double max_vel_to_stop =
-    std::sqrt(2 * rotate_to_heading_max_angular_accel_ * fabs(angular_distance_to_heading));
-  if (fabs(cmd_vel.angular.z) > max_vel_to_stop) {
-    cmd_vel.angular.z = sign * max_vel_to_stop;
-  }
+  TrajectoryOptions options;
+  options.reverse = backward;
+  options.approaching = is_docking;
+  setTrajectory(trajectory, options);
 
-  return cmd_vel;
-}
-
-bool Controller::isTrajectoryCollisionFree(
-  const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward)
-{
-  // Visualization of the trajectory
-  auto trajectory = std::make_unique<nav_msgs::msg::Path>();
-  trajectory->header.frame_id = base_frame_;
-  trajectory->header.stamp = clock_->now();
-
-  // First pose
-  geometry_msgs::msg::PoseStamped next_pose;
-  next_pose.header.frame_id = base_frame_;
-  trajectory->poses.push_back(next_pose);
-
-  // Get the transform from base_frame to fixed_frame
-  geometry_msgs::msg::TransformStamped base_to_fixed_transform;
-  try {
-    base_to_fixed_transform = tf2_buffer_->lookupTransform(
-      fixed_frame_, base_frame_, trajectory->header.stamp,
-      tf2::durationFromSec(transform_tolerance_));
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_ERROR(
-      logger_, "Could not get transform from %s to %s: %s",
-      base_frame_.c_str(), fixed_frame_.c_str(), ex.what());
-    return false;
-  }
-
-  // Generate path
-  double distance = std::numeric_limits<double>::max();
-  unsigned int max_iter = static_cast<unsigned int>(ceil(projection_time_ / simulation_time_step_));
-
-  do{
-    // Apply velocities to calculate next pose
-    next_pose.pose = control_law_->calculateNextPose(
-      simulation_time_step_, target_pose, next_pose.pose, backward);
-
-    // Add the pose to the trajectory for visualization
-    trajectory->poses.push_back(next_pose);
-
-    // Transform pose from base_frame into fixed_frame
-    geometry_msgs::msg::PoseStamped local_pose = next_pose;
-    local_pose.header.stamp = trajectory->header.stamp;
-    tf2::doTransform(local_pose, local_pose, base_to_fixed_transform);
-
-    // Determine the distance at which to check for collisions
-    // Skip the final segment of the trajectory for docking
-    // and the initial segment for undocking
-    // This avoids false positives when the robot is at the dock
-    double dock_collision_distance = is_docking ?
-      nav2_util::geometry_utils::euclidean_distance(target_pose, next_pose.pose) :
-      std::hypot(next_pose.pose.position.x, next_pose.pose.position.y);
-
-    // If this distance is greater than the dock_collision_threshold, check for collisions
-    if (use_collision_detection_ &&
-      dock_collision_distance > dock_collision_threshold_ &&
-      !collision_checker_->isCollisionFree(local_pose.pose))
-    {
-      RCLCPP_WARN(
-        logger_, "Collision detected at pose: (%.2f, %.2f, %.2f) in frame %s",
-        local_pose.pose.position.x, local_pose.pose.position.y, local_pose.pose.position.z,
-        local_pose.header.frame_id.c_str());
-      trajectory_pub_->publish(std::move(trajectory));
-      return false;
-    }
-
-    // Check if we reach the goal
-    distance = nav2_util::geometry_utils::euclidean_distance(target_pose, next_pose.pose);
-  }while(distance > 1e-2 && trajectory->poses.size() < max_iter);
-
-  trajectory_pub_->publish(std::move(trajectory));
-
-  return true;
-}
-
-void Controller::configureCollisionChecker(
-  const nav2::LifecycleNode::SharedPtr & node,
-  std::string costmap_topic, std::string footprint_topic, double transform_tolerance)
-{
-  costmap_sub_ = std::make_unique<nav2_costmap_2d::CostmapSubscriber>(node, costmap_topic);
-  footprint_sub_ = std::make_unique<nav2_costmap_2d::FootprintSubscriber>(
-    node, footprint_topic, *tf2_buffer_, base_frame_, transform_tolerance);
-  collision_checker_ = std::make_shared<nav2_costmap_2d::CostmapTopicCollisionChecker>(
-    *costmap_sub_, *footprint_sub_, node->get_name());
-}
-
-rcl_interfaces::msg::SetParametersResult Controller::validateParameterUpdatesCallback(
-  const std::vector<rclcpp::Parameter> & parameters)
-{
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-  for (const auto & parameter : parameters) {
-    const auto & param_type = parameter.get_type();
-    const auto & param_name = parameter.get_name();
-    if (param_name.find("controller.") != 0) {
-      continue;
-    }
-    if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      if (parameter.as_double() < 0.0) {
-        RCLCPP_WARN(
-        logger_, "The value of parameter '%s' is incorrectly set to %f, "
-        "it should be >=0. Ignoring parameter update.",
-        param_name.c_str(), parameter.as_double());
-        result.successful = false;
-      }
-    }
-  }
-  return result;
-}
-
-void
-Controller::updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters)
-{
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
-
-  for (auto parameter : parameters) {
-    const auto & param_type = parameter.get_type();
-    const auto & param_name = parameter.get_name();
-    if (param_name.find("controller.") != 0) {
-      continue;
-    }
-    if (param_type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
-      if (param_name == "controller.k_phi") {
-        k_phi_ = parameter.as_double();
-      } else if (param_name == "controller.k_delta") {
-        k_delta_ = parameter.as_double();
-      } else if (param_name == "controller.beta") {
-        beta_ = parameter.as_double();
-      } else if (param_name == "controller.lambda") {
-        lambda_ = parameter.as_double();
-      } else if (param_name == "controller.v_linear_min") {
-        v_linear_min_ = parameter.as_double();
-      } else if (param_name == "controller.v_linear_max") {
-        v_linear_max_ = parameter.as_double();
-      } else if (param_name == "controller.v_angular_max") {
-        v_angular_max_ = parameter.as_double();
-      } else if (param_name == "controller.slowdown_radius") {
-        slowdown_radius_ = parameter.as_double();
-      } else if (param_name == "controller.deceleration_max") {
-        deceleration_max_ = parameter.as_double();
-      } else if (param_name == "controller.rotate_to_heading_angular_vel") {
-        rotate_to_heading_angular_vel_ = parameter.as_double();
-      } else if (param_name == "controller.rotate_to_heading_max_angular_accel") {
-        rotate_to_heading_max_angular_accel_ = parameter.as_double();
-      } else if (param_name == "controller.projection_time") {
-        projection_time_ = parameter.as_double();
-      } else if (param_name == "controller.simulation_time_step") {
-        simulation_time_step_ = parameter.as_double();
-      } else if (param_name == "controller.dock_collision_threshold") {
-        dock_collision_threshold_ = parameter.as_double();
-      }
-
-      // Update the smooth control law with the new params
-      control_law_->setCurvatureConstants(k_phi_, k_delta_, beta_, lambda_);
-      control_law_->setSlowdownRadius(slowdown_radius_);
-      control_law_->setMaxDeceleration(deceleration_max_);
-      control_law_->setSpeedLimit(v_linear_min_, v_linear_max_, v_angular_max_);
-    }
-  }
+  // The smooth control law is a pure feedback law: neither the robot pose nor its velocity nor
+  // the control period enter into it, so this legacy entry point has nothing to supply for them.
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = base_frame_;
+  return computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.0, cmd);
 }
 
 }  // namespace opennav_docking

--- a/nav2_docking/opennav_docking/src/controller.cpp
+++ b/nav2_docking/opennav_docking/src/controller.cpp
@@ -31,8 +31,9 @@ Controller::Controller(
   const nav2::LifecycleNode::SharedPtr & node, nav2::TransformBuffer::SharedPtr tf,
   std::string fixed_frame, std::string base_frame)
 {
-  // Seed the frames given by the caller into this instance's parameter namespace, so that
-  // configure() resolves them without the server having to set them itself.
+  // Seed the frames given into this instance's parameter namespace, so that
+  // configure() resolves them. Workaround to keep Controller class usable
+  // in its call sites.
   nav2::declare_parameter_if_not_declared(
     node, "controller.fixed_frame", rclcpp::ParameterValue(fixed_frame));
   nav2::declare_parameter_if_not_declared(
@@ -67,8 +68,6 @@ bool Controller::computeVelocityCommand(
   options.approaching = is_docking;
   setTrajectory(trajectory, options);
 
-  // The smooth control law is a pure feedback law: neither the robot pose nor its velocity nor
-  // the control period enter into it, so this legacy entry point has nothing to supply for them.
   geometry_msgs::msg::PoseStamped robot_pose;
   robot_pose.header.frame_id = base_frame_;
   return computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.0, cmd);

--- a/nav2_docking/opennav_docking/src/controller_base.cpp
+++ b/nav2_docking/opennav_docking/src/controller_base.cpp
@@ -72,11 +72,6 @@ void ControllerBase::configure(
   simulation_time_step_ = node->declare_or_get_parameter(name_ + ".simulation_time_step", 0.1);
   dock_collision_threshold_ = node->declare_or_get_parameter(
     name_ + ".dock_collision_threshold", 0.3);
-  auto publish_trajectory = node->declare_or_get_parameter(
-    name_ + ".publish_trajectory", false);
-  auto trajectory_topic = node->declare_or_get_parameter(
-    name_ + ".trajectory_topic", std::string("docking_trajectory"));
-
   // Let the derived control law declare its own parameters before any update can arrive
   configureController(node);
 
@@ -94,9 +89,7 @@ void ControllerBase::configure(
     configureCollisionChecker(node, costmap_topic, footprint_topic, transform_tolerance_);
   }
 
-  if (publish_trajectory) {
-    trajectory_pub_ = node->create_publisher<nav_msgs::msg::Path>(trajectory_topic);
-  }
+  trajectory_pub_ = node->create_publisher<nav_msgs::msg::Path>("docking_trajectory");
 }
 
 void ControllerBase::cleanup()
@@ -111,16 +104,12 @@ void ControllerBase::cleanup()
 
 void ControllerBase::activate()
 {
-  if (trajectory_pub_) {
-    trajectory_pub_->on_activate();
-  }
+  trajectory_pub_->on_activate();
 }
 
 void ControllerBase::deactivate()
 {
-  if (trajectory_pub_) {
-    trajectory_pub_->on_deactivate();
-  }
+  trajectory_pub_->on_deactivate();
 }
 
 void ControllerBase::setTrajectory(
@@ -218,29 +207,21 @@ geometry_msgs::msg::Twist ControllerBase::computeRotateToHeadingCommand(
 bool ControllerBase::isTrajectoryCollisionFree(
   const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward)
 {
-  const rclcpp::Time stamp = clock_->now();
-
-  // Visualization of the trajectory, only assembled when publishing is enabled
-  std::unique_ptr<nav_msgs::msg::Path> trajectory;
-  if (trajectory_pub_) {
-    trajectory = std::make_unique<nav_msgs::msg::Path>();
-    trajectory->header.frame_id = base_frame_;
-    trajectory->header.stamp = stamp;
-  }
+  // Visualization of the trajectory
+  auto trajectory = std::make_unique<nav_msgs::msg::Path>();
+  trajectory->header.frame_id = base_frame_;
+  trajectory->header.stamp = clock_->now();
 
   // First pose
   geometry_msgs::msg::PoseStamped next_pose;
   next_pose.header.frame_id = base_frame_;
-  if (trajectory) {
-    trajectory->poses.push_back(next_pose);
-  }
-  unsigned int num_poses = 1;
+  trajectory->poses.push_back(next_pose);
 
   // Get the transform from base_frame to fixed_frame
   geometry_msgs::msg::TransformStamped base_to_fixed_transform;
   try {
     base_to_fixed_transform = tf2_buffer_->lookupTransform(
-      fixed_frame_, base_frame_, stamp,
+      fixed_frame_, base_frame_, trajectory->header.stamp,
       tf2::durationFromSec(transform_tolerance_));
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(
@@ -259,14 +240,11 @@ bool ControllerBase::isTrajectoryCollisionFree(
       simulation_time_step_, target_pose, next_pose.pose, backward);
 
     // Add the pose to the trajectory for visualization
-    if (trajectory) {
-      trajectory->poses.push_back(next_pose);
-    }
-    ++num_poses;
+    trajectory->poses.push_back(next_pose);
 
     // Transform pose from base_frame into fixed_frame
     geometry_msgs::msg::PoseStamped local_pose = next_pose;
-    local_pose.header.stamp = stamp;
+    local_pose.header.stamp = trajectory->header.stamp;
     tf2::doTransform(local_pose, local_pose, base_to_fixed_transform);
 
     // Determine the distance at which to check for collisions
@@ -286,19 +264,15 @@ bool ControllerBase::isTrajectoryCollisionFree(
         logger_, "Collision detected at pose: (%.2f, %.2f, %.2f) in frame %s",
         local_pose.pose.position.x, local_pose.pose.position.y, local_pose.pose.position.z,
         local_pose.header.frame_id.c_str());
-      if (trajectory) {
-        trajectory_pub_->publish(std::move(trajectory));
-      }
+      trajectory_pub_->publish(std::move(trajectory));
       return false;
     }
 
     // Check if we reach the goal
     distance = nav2_util::geometry_utils::euclidean_distance(target_pose, next_pose.pose);
-  }while(distance > 1e-2 && num_poses < max_iter);
+  }while(distance > 1e-2 && trajectory->poses.size() < max_iter);
 
-  if (trajectory) {
-    trajectory_pub_->publish(std::move(trajectory));
-  }
+  trajectory_pub_->publish(std::move(trajectory));
 
   return true;
 }

--- a/nav2_docking/opennav_docking/src/controller_base.cpp
+++ b/nav2_docking/opennav_docking/src/controller_base.cpp
@@ -148,7 +148,7 @@ bool ControllerBase::getTargetInBaseFrame(geometry_msgs::msg::Pose & target_pose
     return false;
   }
 
-  // The trajectory's header frame is authoritative; per-pose frames are ignored
+  // The trajectory's header frame is authoritative
   geometry_msgs::msg::PoseStamped target;
   target.header = trajectory_.header;
   target.pose = trajectory_.poses.back().pose;
@@ -164,7 +164,7 @@ bool ControllerBase::getTargetInBaseFrame(geometry_msgs::msg::Pose & target_pose
     return true;
   }
 
-  // Use the latest available transform, as the docking server historically did
+  // Use the latest available transform, as the docking server previously did
   target.header.stamp = rclcpp::Time(0);
   try {
     tf2_buffer_->transform(target, target, base_frame_);

--- a/nav2_docking/opennav_docking/src/controller_base.cpp
+++ b/nav2_docking/opennav_docking/src/controller_base.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) 2024 Open Navigation LLC
+// Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "opennav_docking/controller_base.hpp"
+
+#include "nav2_ros_common/node_utils.hpp"
+#include "nav2_ros_common/tf2_factories.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/utils.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+using rcl_interfaces::msg::ParameterType;
+
+namespace opennav_docking
+{
+
+void ControllerBase::configure(
+  const nav2::LifecycleNode::WeakPtr & parent,
+  const std::string & name, nav2::TransformBuffer::SharedPtr tf)
+{
+  auto node = parent.lock();
+  if (!node) {
+    throw std::runtime_error{"Failed to lock node in docking controller " + name};
+  }
+
+  name_ = name;
+  tf2_buffer_ = tf;
+  logger_ = node->get_logger();
+  clock_ = node->get_clock();
+
+  // Frames may be overridden per controller instance; otherwise the server's frames are used
+  fixed_frame_ = node->declare_or_get_parameter(
+    name_ + ".fixed_frame", node->declare_or_get_parameter("fixed_frame", std::string("odom")));
+  base_frame_ = node->declare_or_get_parameter(
+    name_ + ".base_frame", node->declare_or_get_parameter("base_frame", std::string("base_link")));
+
+  rotate_to_heading_angular_vel_ = node->declare_or_get_parameter(
+    name_ + ".rotate_to_heading_angular_vel", 1.0);
+  rotate_to_heading_max_angular_accel_ = node->declare_or_get_parameter(
+    name_ + ".rotate_to_heading_max_angular_accel", 3.2);
+  use_collision_detection_ = node->declare_or_get_parameter(
+    name_ + ".use_collision_detection", true);
+  auto costmap_topic = node->declare_or_get_parameter(
+    name_ + ".costmap_topic", std::string("local_costmap/costmap_raw"));
+  auto footprint_topic = node->declare_or_get_parameter(
+    name_ + ".footprint_topic", std::string("local_costmap/published_footprint"));
+  transform_tolerance_ = node->declare_or_get_parameter(name_ + ".transform_tolerance", 0.1);
+  projection_time_ = node->declare_or_get_parameter(name_ + ".projection_time", 5.0);
+  simulation_time_step_ = node->declare_or_get_parameter(name_ + ".simulation_time_step", 0.1);
+  dock_collision_threshold_ = node->declare_or_get_parameter(
+    name_ + ".dock_collision_threshold", 0.3);
+  auto publish_trajectory = node->declare_or_get_parameter(
+    name_ + ".publish_trajectory", false);
+  auto trajectory_topic = node->declare_or_get_parameter(
+    name_ + ".trajectory_topic", std::string("docking_trajectory"));
+
+  // Let the derived control law declare its own parameters before any update can arrive
+  configureController(node);
+
+  // Add callback for dynamic parameters
+  post_set_params_handler_ = node->add_post_set_parameters_callback(
+    std::bind(
+      &ControllerBase::updateParametersCallback,
+      this, std::placeholders::_1));
+  on_set_params_handler_ = node->add_on_set_parameters_callback(
+    std::bind(
+      &ControllerBase::validateParameterUpdatesCallback,
+      this, std::placeholders::_1));
+
+  if (use_collision_detection_) {
+    configureCollisionChecker(node, costmap_topic, footprint_topic, transform_tolerance_);
+  }
+
+  if (publish_trajectory) {
+    trajectory_pub_ = node->create_publisher<nav_msgs::msg::Path>(trajectory_topic);
+  }
+}
+
+void ControllerBase::cleanup()
+{
+  post_set_params_handler_.reset();
+  on_set_params_handler_.reset();
+  trajectory_pub_.reset();
+  collision_checker_.reset();
+  costmap_sub_.reset();
+  footprint_sub_.reset();
+}
+
+void ControllerBase::activate()
+{
+  if (trajectory_pub_) {
+    trajectory_pub_->on_activate();
+  }
+}
+
+void ControllerBase::deactivate()
+{
+  if (trajectory_pub_) {
+    trajectory_pub_->on_deactivate();
+  }
+}
+
+void ControllerBase::setTrajectory(
+  const nav_msgs::msg::Path & trajectory,
+  const TrajectoryOptions & options)
+{
+  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  trajectory_ = trajectory;
+  trajectory_options_ = options;
+}
+
+bool ControllerBase::computeVelocityCommands(
+  const geometry_msgs::msg::PoseStamped & /*robot_pose*/,
+  const geometry_msgs::msg::Twist & /*velocity*/,
+  double dt,
+  geometry_msgs::msg::Twist & cmd)
+{
+  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
+  cmd = geometry_msgs::msg::Twist();
+
+  geometry_msgs::msg::Pose target_pose;
+  if (!getTargetInBaseFrame(target_pose)) {
+    return false;
+  }
+
+  cmd = computeCommand(target_pose, trajectory_options_.reverse, dt);
+  return isTrajectoryCollisionFree(
+    target_pose, trajectory_options_.approaching, trajectory_options_.reverse);
+}
+
+bool ControllerBase::getTargetInBaseFrame(geometry_msgs::msg::Pose & target_pose)
+{
+  if (trajectory_.poses.empty()) {
+    RCLCPP_ERROR(logger_, "Controller %s has no trajectory to follow!", name_.c_str());
+    return false;
+  }
+
+  // The trajectory's header frame is authoritative; per-pose frames are ignored
+  geometry_msgs::msg::PoseStamped target;
+  target.header = trajectory_.header;
+  target.pose = trajectory_.poses.back().pose;
+
+  if (target.header.frame_id.empty()) {
+    RCLCPP_ERROR(
+      logger_, "Controller %s was given a trajectory with no frame_id!", name_.c_str());
+    return false;
+  }
+
+  if (target.header.frame_id == base_frame_) {
+    target_pose = target.pose;
+    return true;
+  }
+
+  // Use the latest available transform, as the docking server historically did
+  target.header.stamp = rclcpp::Time(0);
+  try {
+    tf2_buffer_->transform(target, target, base_frame_);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger_, "Could not transform the trajectory from %s to %s: %s",
+      target.header.frame_id.c_str(), base_frame_.c_str(), ex.what());
+    return false;
+  }
+
+  target_pose = target.pose;
+  return true;
+}
+
+geometry_msgs::msg::Twist ControllerBase::computeRotateToHeadingCommand(
+  const double & angular_distance_to_heading,
+  const geometry_msgs::msg::Twist & current_velocity,
+  const double & dt)
+{
+  geometry_msgs::msg::Twist cmd_vel;
+  const double sign = angular_distance_to_heading > 0.0 ? 1.0 : -1.0;
+  const double angular_vel = sign * rotate_to_heading_angular_vel_;
+  const double min_feasible_angular_speed =
+    current_velocity.angular.z - rotate_to_heading_max_angular_accel_ * dt;
+  const double max_feasible_angular_speed =
+    current_velocity.angular.z + rotate_to_heading_max_angular_accel_ * dt;
+  cmd_vel.angular.z =
+    std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+
+  // Check if we need to slow down to avoid overshooting
+  double max_vel_to_stop =
+    std::sqrt(2 * rotate_to_heading_max_angular_accel_ * fabs(angular_distance_to_heading));
+  if (fabs(cmd_vel.angular.z) > max_vel_to_stop) {
+    cmd_vel.angular.z = sign * max_vel_to_stop;
+  }
+
+  return cmd_vel;
+}
+
+bool ControllerBase::isTrajectoryCollisionFree(
+  const geometry_msgs::msg::Pose & target_pose, bool is_docking, bool backward)
+{
+  const rclcpp::Time stamp = clock_->now();
+
+  // Visualization of the trajectory, only assembled when publishing is enabled
+  std::unique_ptr<nav_msgs::msg::Path> trajectory;
+  if (trajectory_pub_) {
+    trajectory = std::make_unique<nav_msgs::msg::Path>();
+    trajectory->header.frame_id = base_frame_;
+    trajectory->header.stamp = stamp;
+  }
+
+  // First pose
+  geometry_msgs::msg::PoseStamped next_pose;
+  next_pose.header.frame_id = base_frame_;
+  if (trajectory) {
+    trajectory->poses.push_back(next_pose);
+  }
+  unsigned int num_poses = 1;
+
+  // Get the transform from base_frame to fixed_frame
+  geometry_msgs::msg::TransformStamped base_to_fixed_transform;
+  try {
+    base_to_fixed_transform = tf2_buffer_->lookupTransform(
+      fixed_frame_, base_frame_, stamp,
+      tf2::durationFromSec(transform_tolerance_));
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger_, "Could not get transform from %s to %s: %s",
+      base_frame_.c_str(), fixed_frame_.c_str(), ex.what());
+    return false;
+  }
+
+  // Generate path
+  double distance = std::numeric_limits<double>::max();
+  unsigned int max_iter = static_cast<unsigned int>(ceil(projection_time_ / simulation_time_step_));
+
+  do{
+    // Apply velocities to calculate next pose
+    next_pose.pose = predictNextPose(
+      simulation_time_step_, target_pose, next_pose.pose, backward);
+
+    // Add the pose to the trajectory for visualization
+    if (trajectory) {
+      trajectory->poses.push_back(next_pose);
+    }
+    ++num_poses;
+
+    // Transform pose from base_frame into fixed_frame
+    geometry_msgs::msg::PoseStamped local_pose = next_pose;
+    local_pose.header.stamp = stamp;
+    tf2::doTransform(local_pose, local_pose, base_to_fixed_transform);
+
+    // Determine the distance at which to check for collisions
+    // Skip the final segment of the trajectory for docking
+    // and the initial segment for undocking
+    // This avoids false positives when the robot is at the dock
+    double dock_collision_distance = is_docking ?
+      nav2_util::geometry_utils::euclidean_distance(target_pose, next_pose.pose) :
+      std::hypot(next_pose.pose.position.x, next_pose.pose.position.y);
+
+    // If this distance is greater than the dock_collision_threshold, check for collisions
+    if (use_collision_detection_ &&
+      dock_collision_distance > dock_collision_threshold_ &&
+      !collision_checker_->isCollisionFree(local_pose.pose))
+    {
+      RCLCPP_WARN(
+        logger_, "Collision detected at pose: (%.2f, %.2f, %.2f) in frame %s",
+        local_pose.pose.position.x, local_pose.pose.position.y, local_pose.pose.position.z,
+        local_pose.header.frame_id.c_str());
+      if (trajectory) {
+        trajectory_pub_->publish(std::move(trajectory));
+      }
+      return false;
+    }
+
+    // Check if we reach the goal
+    distance = nav2_util::geometry_utils::euclidean_distance(target_pose, next_pose.pose);
+  }while(distance > 1e-2 && num_poses < max_iter);
+
+  if (trajectory) {
+    trajectory_pub_->publish(std::move(trajectory));
+  }
+
+  return true;
+}
+
+void ControllerBase::configureCollisionChecker(
+  const nav2::LifecycleNode::SharedPtr & node,
+  std::string costmap_topic, std::string footprint_topic, double transform_tolerance)
+{
+  costmap_sub_ = std::make_unique<nav2_costmap_2d::CostmapSubscriber>(node, costmap_topic);
+  footprint_sub_ = std::make_unique<nav2_costmap_2d::FootprintSubscriber>(
+    node, footprint_topic, *tf2_buffer_, base_frame_, transform_tolerance);
+  collision_checker_ = std::make_shared<nav2_costmap_2d::CostmapTopicCollisionChecker>(
+    *costmap_sub_, *footprint_sub_, node->get_name());
+}
+
+rcl_interfaces::msg::SetParametersResult ControllerBase::validateParameterUpdatesCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  const std::string prefix = name_ + ".";
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  for (const auto & parameter : parameters) {
+    const auto & param_type = parameter.get_type();
+    const auto & param_name = parameter.get_name();
+    if (param_name.find(prefix) != 0) {
+      continue;
+    }
+    if (param_type == ParameterType::PARAMETER_DOUBLE) {
+      if (parameter.as_double() < 0.0) {
+        RCLCPP_WARN(
+        logger_, "The value of parameter '%s' is incorrectly set to %f, "
+        "it should be >=0. Ignoring parameter update.",
+        param_name.c_str(), parameter.as_double());
+        result.successful = false;
+      }
+    }
+  }
+  return result;
+}
+
+void ControllerBase::updateParametersCallback(const std::vector<rclcpp::Parameter> & parameters)
+{
+  const std::string prefix = name_ + ".";
+  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
+  for (const auto & parameter : parameters) {
+    const auto & param_name = parameter.get_name();
+    if (param_name.find(prefix) != 0) {
+      continue;
+    }
+    updateParameter(param_name.substr(prefix.size()), parameter);
+  }
+}
+
+void ControllerBase::updateParameter(
+  const std::string & name, const rclcpp::Parameter & parameter)
+{
+  if (parameter.get_type() != ParameterType::PARAMETER_DOUBLE) {
+    return;
+  }
+
+  if (name == "rotate_to_heading_angular_vel") {
+    rotate_to_heading_angular_vel_ = parameter.as_double();
+  } else if (name == "rotate_to_heading_max_angular_accel") {
+    rotate_to_heading_max_angular_accel_ = parameter.as_double();
+  } else if (name == "projection_time") {
+    projection_time_ = parameter.as_double();
+  } else if (name == "simulation_time_step") {
+    simulation_time_step_ = parameter.as_double();
+  } else if (name == "dock_collision_threshold") {
+    dock_collision_threshold_ = parameter.as_double();
+  }
+}
+
+}  // namespace opennav_docking

--- a/nav2_docking/opennav_docking/src/dock_database.cpp
+++ b/nav2_docking/opennav_docking/src/dock_database.cpp
@@ -94,7 +94,7 @@ void DockDatabase::deactivate()
 bool DockDatabase::validateControllerNames(const DockMap & docks) const
 {
   if (valid_controller_ids_.empty()) {
-    // No controller ids were supplied to check against; nothing to validate.
+    // nothing to validate.
     return true;
   }
 

--- a/nav2_docking/opennav_docking/src/dock_database.cpp
+++ b/nav2_docking/opennav_docking/src/dock_database.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 #include "opennav_docking/dock_database.hpp"
 #include "nav2_ros_common/tf2_factories.hpp"
 
@@ -32,9 +36,11 @@ DockDatabase::~DockDatabase()
 
 bool DockDatabase::initialize(
   const nav2::LifecycleNode::WeakPtr & parent,
-  nav2::TransformBuffer::SharedPtr tf)
+  nav2::TransformBuffer::SharedPtr tf,
+  const std::vector<std::string> & valid_controller_ids)
 {
   node_ = parent;
+  valid_controller_ids_ = valid_controller_ids;
   auto node = node_.lock();
 
   if (!getDockPlugins(node, tf)) {
@@ -48,6 +54,10 @@ bool DockDatabase::initialize(
     RCLCPP_ERROR(
       node->get_logger(),
       "An error occurred while getting the dock instances!");
+    return false;
+  }
+
+  if (!validateControllerNames(dock_instances_)) {
     return false;
   }
 
@@ -81,6 +91,55 @@ void DockDatabase::deactivate()
   }
 }
 
+bool DockDatabase::validateControllerNames(const DockMap & docks) const
+{
+  if (valid_controller_ids_.empty()) {
+    // No controller ids were supplied to check against; nothing to validate.
+    return true;
+  }
+
+  auto node = node_.lock();
+  bool valid = true;
+
+  auto isLoaded = [this](const std::string & name) {
+      return std::find(valid_controller_ids_.begin(), valid_controller_ids_.end(), name) !=
+             valid_controller_ids_.end();
+    };
+
+  for (const auto & entry : dock_plugins_) {
+    const std::string name = entry.second->getControllerName();
+    if (name.empty()) {
+      if (valid_controller_ids_.size() > 1) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "Dock plugin '%s' names no controller, but %zu controllers are loaded so there is no "
+          "single default. Set `%s.controller`. Dock instances may still override it.",
+          entry.first.c_str(), valid_controller_ids_.size(), entry.first.c_str());
+        valid = false;
+      }
+    } else if (!isLoaded(name)) {
+      RCLCPP_ERROR(
+        node->get_logger(),
+        "Dock plugin '%s' names controller '%s', which is not loaded.",
+        entry.first.c_str(), name.c_str());
+      valid = false;
+    }
+  }
+
+  for (const auto & entry : docks) {
+    const std::string & name = entry.second.controller_name;
+    if (!name.empty() && !isLoaded(name)) {
+      RCLCPP_ERROR(
+        node->get_logger(),
+        "Dock '%s' names controller '%s', which is not loaded.",
+        entry.first.c_str(), name.c_str());
+      valid = false;
+    }
+  }
+
+  return valid;
+}
+
 void DockDatabase::reloadDbCb(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
   const std::shared_ptr<nav2_msgs::srv::ReloadDockDatabase::Request> request,
@@ -94,7 +153,9 @@ void DockDatabase::reloadDbCb(
 
   auto node = node_.lock();
   DockMap dock_instances;
-  if (utils::parseDockFile(request->filepath, node, dock_instances)) {
+  if (utils::parseDockFile(request->filepath, node, dock_instances) &&
+    validateControllerNames(dock_instances))
+  {
     dock_instances_ = dock_instances;
     response->success = true;
     RCLCPP_INFO(
@@ -174,6 +235,10 @@ bool DockDatabase::getDockPlugins(
         node->get_logger(), "Created charging dock plugin %s of type %s",
         docks_plugins[i].c_str(), plugin_type.c_str());
       dock->configure(node, docks_plugins[i], tf);
+      // Type-level controller selection. Empty means "no preference"; an individual dock
+      // instance may still override this, and the server falls back to its default.
+      dock->setControllerName(
+        node->declare_or_get_parameter(docks_plugins[i] + ".controller", std::string("")));
       dock_plugins_.insert({docks_plugins[i], dock});
     } catch (const std::exception & ex) {
       RCLCPP_FATAL(

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -25,8 +25,33 @@ using std::placeholders::_1;
 namespace opennav_docking
 {
 
+/**
+ * @brief Wrap a single target pose as a one-pose trajectory for a controller.
+ */
+static nav_msgs::msg::Path toTrajectory(const geometry_msgs::msg::PoseStamped & target)
+{
+  nav_msgs::msg::Path trajectory;
+  trajectory.header = target.header;
+  trajectory.poses.push_back(target);
+  return trajectory;
+}
+
+/**
+ * @brief The pose of a frame in itself, i.e. the identity.
+ */
+static geometry_msgs::msg::PoseStamped identityPose(
+  const std::string & frame, const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = frame;
+  pose.header.stamp = stamp;
+  pose.pose.orientation.w = 1.0;
+  return pose;
+}
+
 DockingServer::DockingServer(const rclcpp::NodeOptions & options)
-: nav2::LifecycleNode("docking_server", "", options)
+: nav2::LifecycleNode("docking_server", "", options),
+  controller_loader_("opennav_docking", "opennav_docking::ControllerBase")
 {
   RCLCPP_INFO(get_logger(), "Creating %s", get_name());
 }
@@ -61,8 +86,10 @@ DockingServer::on_configure(const rclcpp_lifecycle::State & state)
     true);
 
   // Create composed utilities
-  controller_ = std::make_unique<Controller>(node, tf2_buffer_, params_->fixed_frame,
-      params_->base_frame);
+  if (!loadControllerPlugins(node)) {
+    on_cleanup(state);
+    return nav2::CallbackReturn::FAILURE;
+  }
   navigator_ = std::make_unique<Navigator>(node);
   dock_db_ = std::make_unique<DockDatabase>(param_handler_->getMutex());
   if (!dock_db_->initialize(node, tf2_buffer_)) {
@@ -82,6 +109,9 @@ DockingServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
 
   tf2_listener_ = nav2::create_transform_listener(*tf2_buffer_, this, true);
   dock_db_->activate();
+  for (auto & controller : controllers_) {
+    controller.second->activate();
+  }
   navigator_->activate();
   vel_publisher_->on_activate();
   docking_action_server_->activate();
@@ -103,6 +133,9 @@ DockingServer::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   docking_action_server_->deactivate();
   undocking_action_server_->deactivate();
   dock_db_->deactivate();
+  for (auto & controller : controllers_) {
+    controller.second->deactivate();
+  }
   navigator_->deactivate();
   vel_publisher_->on_deactivate();
   param_handler_->deactivate();
@@ -124,7 +157,11 @@ DockingServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   dock_db_.reset();
   navigator_.reset();
   curr_dock_type_.clear();
-  controller_.reset();
+  for (auto & controller : controllers_) {
+    controller.second->cleanup();
+  }
+  controllers_.clear();
+  current_controller_.clear();
   vel_publisher_.reset();
   params_->dock_backwards.reset();
   odom_sub_.reset();
@@ -136,6 +173,70 @@ DockingServer::on_shutdown(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(get_logger(), "Shutting down %s", get_name());
   return nav2::CallbackReturn::SUCCESS;
+}
+
+bool DockingServer::loadControllerPlugins(const nav2::LifecycleNode::SharedPtr & node)
+{
+  const std::vector<std::string> default_controller_ids{"controller"};
+  const std::vector<std::string> controller_ids =
+    node->declare_or_get_parameter("controllers", default_controller_ids);
+
+  if (controller_ids == default_controller_ids) {
+    nav2::declare_parameter_if_not_declared(
+      node, "controller.plugin",
+      rclcpp::ParameterValue("opennav_docking::GracefulController"));
+  }
+
+  if (controller_ids.empty()) {
+    RCLCPP_ERROR(node->get_logger(), "Controllers empty! Must provide at least 1.");
+    return false;
+  }
+
+  for (size_t i = 0; i != controller_ids.size(); i++) {
+    if (controllers_.find(controller_ids[i]) != controllers_.end()) {
+      RCLCPP_FATAL(
+        node->get_logger(), "Controller %s is listed more than once in `controllers`.",
+        controller_ids[i].c_str());
+      return false;
+    }
+
+    try {
+      std::string plugin_type = nav2::get_plugin_type_param(node, controller_ids[i]);
+      ControllerBase::Ptr controller = controller_loader_.createSharedInstance(plugin_type);
+      RCLCPP_INFO(
+        node->get_logger(), "Created controller plugin %s of type %s",
+        controller_ids[i].c_str(), plugin_type.c_str());
+      controller->configure(node, controller_ids[i], tf2_buffer_);
+      controllers_.insert({controller_ids[i], controller});
+    } catch (const std::exception & ex) {
+      RCLCPP_FATAL(
+        node->get_logger(), "Failed to create controller plugin %s. Exception: %s",
+        controller_ids[i].c_str(), ex.what());
+      return false;
+    }
+  }
+
+  std::string controller_ids_concat;
+  for (const auto & controller_id : controller_ids) {
+    controller_ids_concat += controller_id + std::string(" ");
+  }
+  RCLCPP_INFO(
+    node->get_logger(), "Docking server has %s controllers available.",
+    controller_ids_concat.c_str());
+
+  // Until a request selects otherwise, drive with the first controller
+  current_controller_ = controller_ids.front();
+
+  return true;
+}
+
+ControllerBase::Ptr DockingServer::getController()
+{
+  auto it = controllers_.find(current_controller_);
+  if (it == controllers_.end()) {
+    throw opennav_docking_core::FailedToControl("No controller is selected");
+  }
+  return it->second;
 }
 
 template<typename ActionT>
@@ -439,6 +540,9 @@ void DockingServer::rotateToDock(const geometry_msgs::msg::PoseStamped & dock_po
   auto start = this->now();
   auto timeout = rclcpp::Duration::from_seconds(params_->rotate_to_dock_timeout);
 
+  auto controller = getController();
+  controller->reset();
+
   while (rclcpp::ok()) {
     auto robot_pose = getRobotPoseInFrame(dock_pose.header.frame_id);
     auto angular_distance_to_heading = angles::shortest_angular_distance(
@@ -452,7 +556,7 @@ void DockingServer::rotateToDock(const geometry_msgs::msg::PoseStamped & dock_po
 
     auto command = std::make_unique<geometry_msgs::msg::TwistStamped>();
     command->header = robot_pose.header;
-    command->twist = controller_->computeRotateToHeadingCommand(
+    command->twist = controller->computeRotateToHeadingCommand(
       angular_distance_to_heading, current_vel->twist, dt);
 
     vel_publisher_->publish(std::move(command));
@@ -468,9 +572,13 @@ void DockingServer::rotateToDock(const geometry_msgs::msg::PoseStamped & dock_po
 bool DockingServer::approachDock(
   Dock * dock, geometry_msgs::msg::PoseStamped & dock_pose, bool backward)
 {
+  const double dt = 1.0 / params_->controller_frequency;
   nav2::Rate loop_rate(this, params_->controller_frequency);
   auto start = this->now();
   auto timeout = rclcpp::Duration::from_seconds(params_->dock_approach_timeout);
+
+  auto controller = getController();
+  controller->reset();
 
   while (rclcpp::ok()) {
     publishDockingFeedback(DockRobot::Feedback::CONTROLLING);
@@ -516,7 +624,18 @@ bool DockingServer::approachDock(
     // Compute and publish controls
     auto command = std::make_unique<geometry_msgs::msg::TwistStamped>();
     command->header.stamp = now();
-    if (!controller_->computeVelocityCommand(target_pose.pose, command->twist, true, backward)) {
+    TrajectoryOptions options;
+    options.reverse = backward;
+    options.approaching = true;
+    controller->setTrajectory(toTrajectory(target_pose), options);
+
+    // The target is already expressed in the robot's own frame, so the robot pose the
+    // controller measures it against is the origin of that frame
+    // Currently it is a workaround for minimal change in docking server code.
+    if (!controller->computeVelocityCommands(
+        identityPose(params_->base_frame, command->header.stamp),
+        odom_sub_->getRawTwist(), dt, command->twist))
+    {
       throw opennav_docking_core::FailedToControl("Failed to get control");
     }
     vel_publisher_->publish(std::move(command));
@@ -569,6 +688,9 @@ bool DockingServer::resetApproach(
   nav2::Rate loop_rate(this, params_->controller_frequency);
   auto start = this->now();
   auto timeout = rclcpp::Duration::from_seconds(params_->dock_approach_timeout);
+
+  getController()->reset();
+
   while (rclcpp::ok()) {
     publishDockingFeedback(DockRobot::Feedback::INITIAL_PERCEPTION);
 
@@ -625,7 +747,18 @@ bool DockingServer::getCommandToPose(
   tf2_buffer_->transform(target_pose, target_pose, params_->base_frame);
 
   // Compute velocity command
-  if (!controller_->computeVelocityCommand(target_pose.pose, cmd, is_docking, backward)) {
+  TrajectoryOptions options;
+  options.reverse = backward;
+  options.approaching = is_docking;
+  auto controller = getController();
+  controller->setTrajectory(toTrajectory(target_pose), options);
+
+  // The target is already expressed in the robot's own frame, so the robot pose the
+  // controller measures it against is the origin of that frame
+  if (!controller->computeVelocityCommands(
+      identityPose(params_->base_frame, now()), odom_sub_->getRawTwist(),
+      1.0 / params_->controller_frequency, cmd))
+  {
     throw opennav_docking_core::FailedToControl("Failed to get control");
   }
 
@@ -703,6 +836,7 @@ void DockingServer::undockRobot()
 
     // Control robot to staging pose
     rclcpp::Time loop_start = this->now();
+    getController()->reset();
     while (rclcpp::ok()) {
       // Stop if we exceed max duration
       auto timeout = rclcpp::Duration::from_seconds(goal->max_undocking_time);

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -684,9 +684,9 @@ bool DockingServer::approachDock(
     options.approaching = true;
     controller->setTrajectory(toTrajectory(target_pose), options);
 
-    // The target is already expressed in the robot's own frame, so the robot pose the
-    // controller measures it against is the origin of that frame
-    // Currently it is a workaround for minimal change in docking server code.
+    // The target is already expressed in the robot's own frame
+    // Currently it is a workaround for keeping computeVelocityCommands
+    // signature consistent with the controller server's version.
     if (!controller->computeVelocityCommands(
         identityPose(params_->base_frame, command->header.stamp),
         odom_sub_->getRawTwist(), dt, command->twist))

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -86,13 +86,15 @@ DockingServer::on_configure(const rclcpp_lifecycle::State & state)
     true);
 
   // Create composed utilities
-  if (!loadControllerPlugins(node)) {
+  std::vector<std::string> controller_ids;
+  if (!loadControllerPlugins(node, controller_ids)) {
     on_cleanup(state);
     return nav2::CallbackReturn::FAILURE;
   }
   navigator_ = std::make_unique<Navigator>(node);
+
   dock_db_ = std::make_unique<DockDatabase>(param_handler_->getMutex());
-  if (!dock_db_->initialize(node, tf2_buffer_)) {
+  if (!dock_db_->initialize(node, tf2_buffer_, controller_ids)) {
     on_cleanup(state);
     return nav2::CallbackReturn::FAILURE;
   }
@@ -118,6 +120,7 @@ DockingServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   undocking_action_server_->activate();
   param_handler_->activate();
   curr_dock_type_.clear();
+  curr_dock_controller_.clear();
 
   // Create bond connection
   createBond();
@@ -157,6 +160,7 @@ DockingServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   dock_db_.reset();
   navigator_.reset();
   curr_dock_type_.clear();
+  curr_dock_controller_.clear();
   for (auto & controller : controllers_) {
     controller.second->cleanup();
   }
@@ -175,11 +179,11 @@ DockingServer::on_shutdown(const rclcpp_lifecycle::State &)
   return nav2::CallbackReturn::SUCCESS;
 }
 
-bool DockingServer::loadControllerPlugins(const nav2::LifecycleNode::SharedPtr & node)
+bool DockingServer::loadControllerPlugins(
+  const nav2::LifecycleNode::SharedPtr & node, std::vector<std::string> & controller_ids)
 {
   const std::vector<std::string> default_controller_ids{"controller"};
-  const std::vector<std::string> controller_ids =
-    node->declare_or_get_parameter("controllers", default_controller_ids);
+  controller_ids = node->declare_or_get_parameter("controllers", default_controller_ids);
 
   if (controller_ids == default_controller_ids) {
     nav2::declare_parameter_if_not_declared(
@@ -216,18 +220,66 @@ bool DockingServer::loadControllerPlugins(const nav2::LifecycleNode::SharedPtr &
     }
   }
 
-  std::string controller_ids_concat;
+  controller_ids_concat_.clear();
   for (const auto & controller_id : controller_ids) {
-    controller_ids_concat += controller_id + std::string(" ");
+    controller_ids_concat_ += controller_id + std::string(" ");
   }
   RCLCPP_INFO(
     node->get_logger(), "Docking server has %s controllers available.",
-    controller_ids_concat.c_str());
+    controller_ids_concat_.c_str());
 
   // Until a request selects otherwise, drive with the first controller
   current_controller_ = controller_ids.front();
 
   return true;
+}
+
+bool DockingServer::findControllerId(
+  const std::string & c_name, std::string & current_controller)
+{
+  if (controllers_.find(c_name) == controllers_.end()) {
+    if (controllers_.size() == 1 && c_name.empty()) {
+      RCLCPP_WARN_ONCE(
+        get_logger(),
+        "No controller was specified in the dock configuration. "
+        "Server will use only plugin %s. "
+        "This warning will appear once.", controller_ids_concat_.c_str());
+      current_controller = controllers_.begin()->first;
+    } else {
+      RCLCPP_ERROR(
+        get_logger(), "Dock requested controller '%s', which does not exist. "
+        "Available controllers are: %s.", c_name.c_str(), controller_ids_concat_.c_str());
+      return false;
+    }
+  } else {
+    RCLCPP_DEBUG(get_logger(), "Selected controller: %s.", c_name.c_str());
+    current_controller = c_name;
+  }
+
+  return true;
+}
+
+void DockingServer::selectControllerForDock(const Dock & dock)
+{
+  // Instance overrides type; type overrides the single-controller default.
+  const std::string name = dock.controller_name.empty() ?
+    dock.plugin->getControllerName() : dock.controller_name;
+  if (!findControllerId(name, current_controller_)) {
+    throw opennav_docking_core::DockNotValid(
+            "Dock names controller '" + name + "', which is not loaded");
+  }
+}
+
+void DockingServer::selectControllerForUndock(
+  const std::string & dock_type, const ChargingDock::Ptr & plugin)
+{
+  const std::string name =
+    (!curr_dock_controller_.empty() && dock_type == curr_dock_type_) ?
+    curr_dock_controller_ : plugin->getControllerName();
+  if (!findControllerId(name, current_controller_)) {
+    throw opennav_docking_core::DockNotValid(
+            "Undocking names controller '" + name + "', which is not loaded");
+  }
 }
 
 ControllerBase::Ptr DockingServer::getController()
@@ -311,6 +363,9 @@ void DockingServer::dockRobot()
         goal->dock_pose.pose.position.x, goal->dock_pose.pose.position.y);
       dock = generateGoalDock(goal);
     }
+
+    // Pick the controller this dock drives with before any motion is commanded.
+    selectControllerForDock(*dock);
 
     // Check if robot is docked or charging before proceeding, only applicable to charging docks
     if (dock->plugin->isCharger() && (dock->plugin->isDocked() || dock->plugin->isCharging())) {
@@ -478,6 +533,7 @@ void DockingServer::stashDockData(bool use_dock_id, Dock * dock, bool successful
 {
   if (dock && successful) {
     curr_dock_type_ = dock->type;
+    curr_dock_controller_ = current_controller_;
   }
 
   if (!use_dock_id && dock) {
@@ -804,6 +860,8 @@ void DockingServer::undockRobot()
       get_logger(),
       "Attempting to undock robot of dock type %s.", dock->getName().c_str());
 
+    selectControllerForUndock(dock_type, dock);
+
     // Check if the robot is docked before proceeding
     if (dock->isCharger() && (!dock->isDocked() && !dock->isCharging())) {
       RCLCPP_INFO(get_logger(), "Robot is not in the dock, no need to undock");
@@ -880,6 +938,7 @@ void DockingServer::undockRobot()
           RCLCPP_INFO(get_logger(), "Robot has undocked!");
           result->success = true;
           curr_dock_type_.clear();
+          curr_dock_controller_.clear();
           publishZeroVelocity();
           undocking_action_server_->succeeded_current(result);
           return;

--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -92,7 +92,6 @@ DockingServer::on_configure(const rclcpp_lifecycle::State & state)
     return nav2::CallbackReturn::FAILURE;
   }
   navigator_ = std::make_unique<Navigator>(node);
-
   dock_db_ = std::make_unique<DockDatabase>(param_handler_->getMutex());
   if (!dock_db_->initialize(node, tf2_buffer_, controller_ids)) {
     on_cleanup(state);

--- a/nav2_docking/opennav_docking/src/graceful_controller.cpp
+++ b/nav2_docking/opennav_docking/src/graceful_controller.cpp
@@ -20,7 +20,6 @@
 #include "opennav_docking/graceful_controller.hpp"
 
 #include "nav2_ros_common/node_utils.hpp"
-#include "pluginlib/class_list_macros.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using rcl_interfaces::msg::ParameterType;
@@ -101,5 +100,3 @@ void GracefulController::updateParameter(
 }
 
 }  // namespace opennav_docking
-
-PLUGINLIB_EXPORT_CLASS(opennav_docking::GracefulController, opennav_docking::ControllerBase)

--- a/nav2_docking/opennav_docking/src/graceful_controller.cpp
+++ b/nav2_docking/opennav_docking/src/graceful_controller.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Open Navigation LLC
+// Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "opennav_docking/graceful_controller.hpp"
+
+#include "nav2_ros_common/node_utils.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using rcl_interfaces::msg::ParameterType;
+
+namespace opennav_docking
+{
+
+void GracefulController::configureController(const nav2::LifecycleNode::SharedPtr & node)
+{
+  k_phi_ = node->declare_or_get_parameter(name_ + ".k_phi", 3.0);
+  k_delta_ = node->declare_or_get_parameter(name_ + ".k_delta", 2.0);
+  beta_ = node->declare_or_get_parameter(name_ + ".beta", 0.4);
+  lambda_ = node->declare_or_get_parameter(name_ + ".lambda", 2.0);
+  v_linear_min_ = node->declare_or_get_parameter(name_ + ".v_linear_min", 0.1);
+  v_linear_max_ = node->declare_or_get_parameter(name_ + ".v_linear_max", 0.25);
+  v_angular_max_ = node->declare_or_get_parameter(name_ + ".v_angular_max", 0.75);
+  slowdown_radius_ = node->declare_or_get_parameter(name_ + ".slowdown_radius", 0.25);
+  deceleration_max_ = node->declare_or_get_parameter(name_ + ".deceleration_max", 2.5);
+
+  control_law_ = std::make_unique<nav2_graceful_controller::SmoothControlLaw>(
+    k_phi_, k_delta_, beta_, lambda_, slowdown_radius_, deceleration_max_,
+    v_linear_min_, v_linear_max_, v_angular_max_);
+}
+
+void GracefulController::cleanup()
+{
+  ControllerBase::cleanup();
+  control_law_.reset();
+}
+
+geometry_msgs::msg::Twist GracefulController::computeCommand(
+  const geometry_msgs::msg::Pose & target, bool reverse, double /*dt*/)
+{
+  return control_law_->calculateRegularVelocity(target, reverse);
+}
+
+geometry_msgs::msg::Pose GracefulController::predictNextPose(
+  double dt, const geometry_msgs::msg::Pose & target,
+  const geometry_msgs::msg::Pose & current, bool reverse)
+{
+  return control_law_->calculateNextPose(dt, target, current, reverse);
+}
+
+void GracefulController::updateParameter(
+  const std::string & name, const rclcpp::Parameter & parameter)
+{
+  ControllerBase::updateParameter(name, parameter);
+
+  if (parameter.get_type() != ParameterType::PARAMETER_DOUBLE) {
+    return;
+  }
+
+  if (name == "k_phi") {
+    k_phi_ = parameter.as_double();
+  } else if (name == "k_delta") {
+    k_delta_ = parameter.as_double();
+  } else if (name == "beta") {
+    beta_ = parameter.as_double();
+  } else if (name == "lambda") {
+    lambda_ = parameter.as_double();
+  } else if (name == "v_linear_min") {
+    v_linear_min_ = parameter.as_double();
+  } else if (name == "v_linear_max") {
+    v_linear_max_ = parameter.as_double();
+  } else if (name == "v_angular_max") {
+    v_angular_max_ = parameter.as_double();
+  } else if (name == "slowdown_radius") {
+    slowdown_radius_ = parameter.as_double();
+  } else if (name == "deceleration_max") {
+    deceleration_max_ = parameter.as_double();
+  }
+
+  // Update the smooth control law with the new params
+  control_law_->setCurvatureConstants(k_phi_, k_delta_, beta_, lambda_);
+  control_law_->setSlowdownRadius(slowdown_radius_);
+  control_law_->setMaxDeceleration(deceleration_max_);
+  control_law_->setSpeedLimit(v_linear_min_, v_linear_max_, v_angular_max_);
+}
+
+}  // namespace opennav_docking
+
+PLUGINLIB_EXPORT_CLASS(opennav_docking::GracefulController, opennav_docking::ControllerBase)

--- a/nav2_docking/opennav_docking/src/graceful_controller_plugin.cpp
+++ b/nav2_docking/opennav_docking/src/graceful_controller_plugin.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pluginlib/class_list_macros.hpp"
+
+#include "opennav_docking/graceful_controller.hpp"
+
+// This translation unit exists only to register GracefulController with pluginlib,
+// and is built into a library of its own (graceful_controller_plugin) that nothing
+// links against.
+//
+// Once opennav_following is migrated off opennav_docking::Controller
+// this file can be moved back into graceful_controller.cpp.
+PLUGINLIB_EXPORT_CLASS(opennav_docking::GracefulController, opennav_docking::ControllerBase)

--- a/nav2_docking/opennav_docking/src/pid_controller.cpp
+++ b/nav2_docking/opennav_docking/src/pid_controller.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+#include "opennav_docking/pid_controller.hpp"
+
+#include "angles/angles.h"
+
+#include "nav2_util/geometry_utils.hpp"
+#include "tf2/utils.hpp"
+
+using rcl_interfaces::msg::ParameterType;
+
+namespace opennav_docking
+{
+
+void PIDController::configureController(const nav2::LifecycleNode::SharedPtr & node)
+{
+  x_.kp = node->declare_or_get_parameter(name_ + ".kp_x", 1.0);
+  x_.ki = node->declare_or_get_parameter(name_ + ".ki_x", 0.0);
+  x_.kd = node->declare_or_get_parameter(name_ + ".kd_x", 0.0);
+  x_.i_clamp = node->declare_or_get_parameter(name_ + ".i_clamp_x", 0.2);
+
+  y_.kp = node->declare_or_get_parameter(name_ + ".kp_y", 2.2);
+  y_.ki = node->declare_or_get_parameter(name_ + ".ki_y", 0.0);
+  y_.kd = node->declare_or_get_parameter(name_ + ".kd_y", 0.0);
+  y_.i_clamp = node->declare_or_get_parameter(name_ + ".i_clamp_y", 0.5);
+
+  theta_.kp = node->declare_or_get_parameter(name_ + ".kp_theta", 1.2);
+  theta_.ki = node->declare_or_get_parameter(name_ + ".ki_theta", 0.0);
+  theta_.kd = node->declare_or_get_parameter(name_ + ".kd_theta", 0.0);
+  theta_.i_clamp = node->declare_or_get_parameter(name_ + ".i_clamp_theta", 0.5);
+
+  v_linear_max_ = node->declare_or_get_parameter(name_ + ".v_linear_max", 0.25);
+  v_angular_max_ = node->declare_or_get_parameter(name_ + ".v_angular_max", 0.75);
+
+  lookahead_distance_ = std::max(
+    kMinLookahead, node->declare_or_get_parameter(name_ + ".lookahead_distance", 0.25));
+
+  reset();
+}
+
+void PIDController::reset()
+{
+  x_.reset();
+  y_.reset();
+  theta_.reset();
+}
+
+double PIDController::evaluate(
+  const ControllerState & channel, double error, double integral, double derivative)
+{
+  return channel.kp * error + channel.ki * integral + channel.kd * derivative;
+}
+
+double PIDController::advance(ControllerState & channel, double error, double dt)
+{
+  const double out = evaluate(channel, error, channel.integral, channel.derivative);
+
+  channel.integral =
+    std::clamp(channel.integral + error * dt, -channel.i_clamp, channel.i_clamp);
+  channel.derivative = (error - channel.prev_error) / dt;
+  channel.prev_error = error;
+  return out;
+}
+
+
+void PIDController::poseError(
+  const geometry_msgs::msg::Pose & target, bool reverse, double lookahead,
+  double & rho, double & alpha, double & alignment)
+{
+  const double sign = reverse ? -1.0 : 1.0;
+  const double e_x = sign * target.position.x;
+  const double e_y = sign * target.position.y;
+
+  rho = std::hypot(e_x, e_y);
+  alpha = std::atan2(e_y, std::max(e_x, lookahead));
+  alignment = angles::normalize_angle(alpha - tf2::getYaw(target.orientation));
+}
+
+geometry_msgs::msg::Twist PIDController::computeCommand(
+  const geometry_msgs::msg::Pose & target, bool reverse, double dt)
+{
+  double rho = 0.0, alpha = 0.0, alignment = 0.0;
+  poseError(target, reverse, lookahead_distance_, rho, alpha, alignment);
+
+  const double v_raw = advance(x_, rho, dt);
+  const double w_bearing = advance(y_, alpha, dt);
+  const double w_alignment = advance(theta_, alignment, dt);
+
+  const double v = std::clamp(v_raw, -v_linear_max_, v_linear_max_);
+  const double w = std::clamp(w_bearing + w_alignment, -v_angular_max_, v_angular_max_);
+
+  geometry_msgs::msg::Twist cmd;
+  cmd.linear.x = (reverse ? -1.0 : 1.0) * v;
+  cmd.angular.z = w;
+  return cmd;
+}
+
+geometry_msgs::msg::Pose PIDController::predictNextPose(
+  double dt, const geometry_msgs::msg::Pose & target,
+  const geometry_msgs::msg::Pose & current, bool reverse)
+{
+  const double dx = target.position.x - current.position.x;
+  const double dy = target.position.y - current.position.y;
+  const double yaw = tf2::getYaw(current.orientation);
+
+  const double cos_yaw = std::cos(yaw);
+  const double sin_yaw = std::sin(yaw);
+  geometry_msgs::msg::Pose relative;
+  relative.position.x = dx * cos_yaw + dy * sin_yaw;
+  relative.position.y = -dx * sin_yaw + dy * cos_yaw;
+  relative.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
+    angles::shortest_angular_distance(yaw, tf2::getYaw(target.orientation)));
+
+  double rho = 0.0, alpha = 0.0, alignment = 0.0;
+  poseError(relative, reverse, lookahead_distance_, rho, alpha, alignment);
+
+  const double v_raw = evaluate(x_, rho, x_.integral, x_.derivative);
+  const double w_raw =
+    evaluate(y_, alpha, y_.integral, y_.derivative) +
+    evaluate(theta_, alignment, theta_.integral, theta_.derivative);
+
+  const double v =
+    (reverse ? -1.0 : 1.0) * std::clamp(v_raw, -v_linear_max_, v_linear_max_);
+  const double w = std::clamp(w_raw, -v_angular_max_, v_angular_max_);
+
+  geometry_msgs::msg::Pose next = current;
+  next.position.x += v * cos_yaw * dt;
+  next.position.y += v * sin_yaw * dt;
+  next.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw + w * dt);
+  return next;
+}
+
+void PIDController::updateParameter(
+  const std::string & name, const rclcpp::Parameter & parameter)
+{
+  ControllerBase::updateParameter(name, parameter);
+
+  if (parameter.get_type() != ParameterType::PARAMETER_DOUBLE) {
+    return;
+  }
+  const double value = parameter.as_double();
+
+  if (name == "kp_x") {
+    x_.kp = value;
+  } else if (name == "ki_x") {
+    x_.ki = value;
+  } else if (name == "kd_x") {
+    x_.kd = value;
+  } else if (name == "i_clamp_x") {
+    x_.i_clamp = value;
+  } else if (name == "kp_y") {
+    y_.kp = value;
+  } else if (name == "ki_y") {
+    y_.ki = value;
+  } else if (name == "kd_y") {
+    y_.kd = value;
+  } else if (name == "i_clamp_y") {
+    y_.i_clamp = value;
+  } else if (name == "kp_theta") {
+    theta_.kp = value;
+  } else if (name == "ki_theta") {
+    theta_.ki = value;
+  } else if (name == "kd_theta") {
+    theta_.kd = value;
+  } else if (name == "i_clamp_theta") {
+    theta_.i_clamp = value;
+  } else if (name == "v_linear_max") {
+    v_linear_max_ = value;
+  } else if (name == "v_angular_max") {
+    v_angular_max_ = value;
+  } else if (name == "lookahead_distance") {
+    lookahead_distance_ = std::max(kMinLookahead, value);
+  }
+}
+
+}  // namespace opennav_docking

--- a/nav2_docking/opennav_docking/src/pid_controller_plugin.cpp
+++ b/nav2_docking/opennav_docking/src/pid_controller_plugin.cpp
@@ -14,9 +14,7 @@
 
 #include "pluginlib/class_list_macros.hpp"
 
-#include "opennav_docking/graceful_controller.hpp"
+#include "opennav_docking/pid_controller.hpp"
 
-// This translation is to register GracefulController with pluginlib,
-// Once opennav_following's dependency to opennav_docking::Controller is removed
-// this file can be moved back into graceful_controller.cpp.
-PLUGINLIB_EXPORT_CLASS(opennav_docking::GracefulController, opennav_docking::ControllerBase)
+// register PIDController with pluginlib
+PLUGINLIB_EXPORT_CLASS(opennav_docking::PIDController, opennav_docking::ControllerBase)

--- a/nav2_docking/opennav_docking/test/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/test/CMakeLists.txt
@@ -59,6 +59,7 @@ nav2_add_gtest(test_controller
   test_controller.cpp
 )
 target_link_libraries(test_controller
+  controller
   geometry_msgs::geometry_msgs
   ${library_name}
   rclcpp::rclcpp

--- a/nav2_docking/opennav_docking/test/CMakeLists.txt
+++ b/nav2_docking/opennav_docking/test/CMakeLists.txt
@@ -71,6 +71,27 @@ target_include_directories(test_controller
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
+# Test Graceful Controller plugin
+nav2_add_gtest(test_graceful_controller
+  test_graceful_controller.cpp
+)
+target_link_libraries(test_graceful_controller
+  controller
+  geometry_msgs::geometry_msgs
+  nav2_ros_common::nav2_ros_common
+  nav2_util::nav2_util_core
+  nav_msgs::nav_msgs
+  opennav_docking_core::opennav_docking_core
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+)
+target_include_directories(test_graceful_controller
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
 # Test Simple Dock
 nav2_add_gtest(test_simple_charging_dock
   test_simple_charging_dock.cpp

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -56,6 +56,17 @@ public:
   nav2::TransformBuffer::SharedPtr getTfBuffer() {return tf2_buffer_;}
 };
 
+// Test shim to expose the loaded controller plugins
+class DockingServerControllerShim : public DockingServerShim
+{
+public:
+  DockingServerControllerShim()
+  : DockingServerShim() {}
+
+  const ControllerMap & getControllers() {return controllers_;}
+  std::string getCurrentController() {return current_controller_;}
+};
+
 TEST(DockingServerTests, ObjectLifecycle)
 {
   auto node = std::make_shared<opennav_docking::DockingServer>();
@@ -524,6 +535,88 @@ TEST(DockingServerTests, HandlesPluginStartFailure)
 
   node->on_deactivate(rclcpp_lifecycle::State());
   node->on_cleanup(rclcpp_lifecycle::State());
+  node->shutdown();
+}
+
+// Declare base dock parameters required for on_configure() to return SUCCESS
+void declareTestDock(const std::shared_ptr<DockingServerControllerShim> & node)
+{
+  node->declare_parameter("docks", std::vector<std::string>{"test_dock"});
+  node->declare_parameter("test_dock.type", "test_plugin");
+  node->declare_parameter("test_dock.pose", std::vector<double>{0.0, 0.0, 0.0});
+  node->declare_parameter("dock_plugins", std::vector<std::string>{"test_plugin"});
+  node->declare_parameter("test_plugin.plugin", "opennav_docking::TestFailureDock");
+  node->declare_parameter("exception_to_throw", "");
+  node->declare_parameter("dock_action_called", false);
+}
+
+TEST(DockingServerTests, ControllerDefaultInstance)
+{
+  auto node = std::make_shared<DockingServerControllerShim>();
+  declareTestDock(node);
+
+  ASSERT_EQ(node->on_configure(rclcpp_lifecycle::State()), nav2::CallbackReturn::SUCCESS);
+
+  // With no `controllers` list, a single instance named `controller` is synthesized so that
+  // the `controller.*` namespace existing configuration files use keeps applying
+  EXPECT_EQ(node->getControllers().size(), 1u);
+  EXPECT_EQ(node->getCurrentController(), "controller");
+  EXPECT_EQ(
+    node->get_parameter("controller.plugin").as_string(),
+    "opennav_docking::GracefulController");
+  EXPECT_EQ(node->get_parameter("controller.k_phi").as_double(), 3.0);
+
+  node->on_cleanup(rclcpp_lifecycle::State());
+  EXPECT_TRUE(node->getControllers().empty());
+  node->shutdown();
+}
+
+TEST(DockingServerTests, ControllerNamedInstances)
+{
+  auto node = std::make_shared<DockingServerControllerShim>();
+  declareTestDock(node);
+  node->declare_parameter("controllers", std::vector<std::string>{"c1", "c2"});
+  node->declare_parameter("c1.plugin", "opennav_docking::GracefulController");
+  node->declare_parameter("c2.plugin", "opennav_docking::GracefulController");
+  node->declare_parameter("c2.k_phi", 5.0);
+
+  ASSERT_EQ(node->on_configure(rclcpp_lifecycle::State()), nav2::CallbackReturn::SUCCESS);
+
+  EXPECT_EQ(node->getControllers().size(), 2u);
+  EXPECT_NE(node->getControllers().find("c1"), node->getControllers().end());
+  EXPECT_NE(node->getControllers().find("c2"), node->getControllers().end());
+
+  // Each instance owns its own parameter namespace
+  EXPECT_EQ(node->get_parameter("c1.k_phi").as_double(), 3.0);
+  EXPECT_EQ(node->get_parameter("c2.k_phi").as_double(), 5.0);
+
+  // The default instance is not synthesized when an explicit list is given
+  EXPECT_FALSE(node->has_parameter("controller.plugin"));
+
+  node->on_cleanup(rclcpp_lifecycle::State());
+  node->shutdown();
+}
+
+TEST(DockingServerTests, ControllerMissingPluginFailsConfigure)
+{
+  auto node = std::make_shared<DockingServerControllerShim>();
+  declareTestDock(node);
+  node->declare_parameter("controllers", std::vector<std::string>{"c1"});
+
+  // `c1.plugin` is never set, so the plugin type cannot be resolved
+  EXPECT_EQ(node->on_configure(rclcpp_lifecycle::State()), nav2::CallbackReturn::FAILURE);
+  EXPECT_TRUE(node->getControllers().empty());
+  node->shutdown();
+}
+
+TEST(DockingServerTests, ControllerDuplicateNameFailsConfigure)
+{
+  auto node = std::make_shared<DockingServerControllerShim>();
+  declareTestDock(node);
+  node->declare_parameter("controllers", std::vector<std::string>{"c1", "c1"});
+  node->declare_parameter("c1.plugin", "opennav_docking::GracefulController");
+
+  EXPECT_EQ(node->on_configure(rclcpp_lifecycle::State()), nav2::CallbackReturn::FAILURE);
   node->shutdown();
 }
 

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -65,7 +65,6 @@ public:
 
   const ControllerMap & getControllers() {return controllers_;}
   std::string getCurrentController() {return current_controller_;}
-  DockDatabase * getDockDb() {return dock_db_.get();}
 };
 
 TEST(DockingServerTests, ObjectLifecycle)
@@ -578,8 +577,9 @@ TEST(DockingServerTests, ControllerNamedInstances)
   declareTestDock(node);
   node->declare_parameter("controllers", std::vector<std::string>{"c1", "c2"});
   node->declare_parameter("c1.plugin", "opennav_docking::GracefulController");
-  node->declare_parameter("c2.plugin", "opennav_docking::GracefulController");
+  node->declare_parameter("c2.plugin", "opennav_docking::PIDController");
   node->declare_parameter("c2.k_phi", 5.0);
+  node->declare_parameter("test_plugin.controller", "c1");
 
   ASSERT_EQ(node->on_configure(rclcpp_lifecycle::State()), nav2::CallbackReturn::SUCCESS);
 

--- a/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
+++ b/nav2_docking/opennav_docking/test/test_docking_server_unit.cpp
@@ -65,6 +65,7 @@ public:
 
   const ControllerMap & getControllers() {return controllers_;}
   std::string getCurrentController() {return current_controller_;}
+  DockDatabase * getDockDb() {return dock_db_.get();}
 };
 
 TEST(DockingServerTests, ObjectLifecycle)

--- a/nav2_docking/opennav_docking/test/test_graceful_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_graceful_controller.cpp
@@ -29,9 +29,6 @@
 #include "pluginlib/class_loader.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-// The control law itself lives in nav2_graceful_controller, which has over 98% test coverage.
-// These tests cover the plugin wrapper: parameter namespacing, frame resolution, and the
-// trajectory handling introduced by the opennav_docking::ControllerBase interface.
 
 namespace opennav_docking
 {
@@ -120,35 +117,6 @@ TEST(GracefulControllerTests, PluginIsDiscoverable)
   controller.reset();
 }
 
-TEST(GracefulControllerTests, ParameterNamespacesAreIsolated)
-{
-  auto node = std::make_shared<nav2::LifecycleNode>("test");
-  auto tf = nav2::create_transform_buffer(node);
-  tf->setUsingDedicatedThread(true);
-  setTransform(tf, "odom", "base_link", 0.0, 0.0);
-
-  nav2::declare_parameter_if_not_declared(
-    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
-  auto c1 = makeController(node, tf, "c1");
-  auto c2 = makeController(node, tf, "c2");
-
-  // Slow c1 down; c2 shares the node but must keep its defaults
-  node->set_parameters(
-    {rclcpp::Parameter("c1.v_linear_min", 0.01), rclcpp::Parameter("c1.v_linear_max", 0.05)});
-
-  auto trajectory = makePath("base_link", {{2.0, 0.0, 0.0}});
-  c1->setTrajectory(trajectory);
-  c2->setTrajectory(trajectory);
-
-  geometry_msgs::msg::PoseStamped robot_pose;
-  geometry_msgs::msg::Twist cmd1, cmd2;
-  EXPECT_TRUE(c1->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd1));
-  EXPECT_TRUE(c2->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd2));
-
-  EXPECT_NEAR(cmd1.linear.x, 0.05, 1e-6);
-  EXPECT_NEAR(cmd2.linear.x, 0.25, 1e-6);
-}
-
 TEST(GracefulControllerTests, FramePrecedencePrefersInstanceOverNode)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("test");
@@ -197,37 +165,6 @@ TEST(GracefulControllerTests, FramePrecedenceFallsBackToNode)
   EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
     cmd));
   EXPECT_GT(cmd.linear.x, 0.0);
-}
-
-TEST(GracefulControllerTests, TrajectoryIsTransformedIntoBaseFrame)
-{
-  auto node = std::make_shared<nav2::LifecycleNode>("test");
-  auto tf = nav2::create_transform_buffer(node);
-  tf->setUsingDedicatedThread(true);
-
-  // The robot sits 1m to the left of the odom origin, facing along +x
-  setTransform(tf, "odom", "base_link", 0.0, 1.0);
-  nav2::declare_parameter_if_not_declared(
-    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
-  auto controller = makeController(node, tf, "c");
-
-  geometry_msgs::msg::PoseStamped robot_pose;
-  geometry_msgs::msg::Twist cmd;
-
-  // A target on the odom x-axis lies 1m to the robot's right, so the robot must steer right.
-  // Reading the odom coordinates literally would place it straight ahead and steer nowhere.
-  controller->setTrajectory(makePath("odom", {{1.0, 0.0, 0.0}}));
-  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
-    cmd));
-  EXPECT_GT(cmd.linear.x, 0.0);
-  EXPECT_LT(cmd.angular.z, -1e-3);
-
-  // A target on the robot's own row is straight ahead, so it drives without steering
-  controller->setTrajectory(makePath("odom", {{2.0, 1.0, 0.0}}));
-  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
-    cmd));
-  EXPECT_GT(cmd.linear.x, 0.0);
-  EXPECT_NEAR(cmd.angular.z, 0.0, 1e-6);
 }
 
 TEST(GracefulControllerTests, LastPoseOfTrajectoryIsTheTarget)
@@ -326,58 +263,6 @@ TEST(GracefulControllerTests, RotateToHeadingUsesInstanceParameters)
   EXPECT_DOUBLE_EQ(cmd.linear.x, 0.0);
   EXPECT_GT(cmd.angular.z, 0.0);
   EXPECT_LE(cmd.angular.z, 0.5);
-}
-
-TEST(GracefulControllerTests, TrajectoryPublishingIsOffByDefault)
-{
-  auto node = std::make_shared<nav2::LifecycleNode>("test");
-  auto tf = nav2::create_transform_buffer(node);
-  tf->setUsingDedicatedThread(true);
-  nav2::declare_parameter_if_not_declared(
-    node, "c.use_collision_detection", rclcpp::ParameterValue(false));
-  setTransform(tf, "odom", "base_link", 0.0, 0.0);
-
-  auto controller = std::make_shared<TestableGracefulController>();
-  controller->configure(node, "c", tf);
-  EXPECT_FALSE(controller->hasTrajectoryPublisher());
-
-  // Activation, command computation and deactivation must all tolerate the absent publisher.
-  controller->activate();
-  controller->setTrajectory(makePath("base_link", {{1.0, -1.0, 0.0}}));
-  geometry_msgs::msg::PoseStamped robot_pose;
-  geometry_msgs::msg::Twist cmd;
-  EXPECT_TRUE(
-    controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd));
-  EXPECT_GT(cmd.linear.x, 0.0);
-  controller->deactivate();
-  controller->cleanup();
-}
-
-TEST(GracefulControllerTests, TrajectoryPublishingIsEnabledByTheFlag)
-{
-  auto node = std::make_shared<nav2::LifecycleNode>("test");
-  auto tf = nav2::create_transform_buffer(node);
-  tf->setUsingDedicatedThread(true);
-  nav2::declare_parameter_if_not_declared(
-    node, "c.use_collision_detection", rclcpp::ParameterValue(false));
-  nav2::declare_parameter_if_not_declared(
-    node, "c.publish_trajectory", rclcpp::ParameterValue(true));
-  setTransform(tf, "odom", "base_link", 0.0, 0.0);
-
-  auto controller = std::make_shared<TestableGracefulController>();
-  controller->configure(node, "c", tf);
-  EXPECT_TRUE(controller->hasTrajectoryPublisher());
-
-  controller->activate();
-  controller->setTrajectory(makePath("base_link", {{1.0, -1.0, 0.0}}));
-  geometry_msgs::msg::PoseStamped robot_pose;
-  geometry_msgs::msg::Twist cmd;
-  EXPECT_TRUE(
-    controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd));
-  EXPECT_GT(cmd.linear.x, 0.0);
-  controller->deactivate();
-  controller->cleanup();
-  EXPECT_FALSE(controller->hasTrajectoryPublisher());
 }
 
 }  // namespace opennav_docking

--- a/nav2_docking/opennav_docking/test/test_graceful_controller.cpp
+++ b/nav2_docking/opennav_docking/test/test_graceful_controller.cpp
@@ -1,0 +1,392 @@
+// Copyright (c) 2024 Open Navigation LLC
+// Copyright (c) 2024 Alberto J. Tudela Roldán
+// Copyright (c) 2026 Karinca Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "nav2_ros_common/node_utils.hpp"
+#include "nav2_ros_common/tf2_factories.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "opennav_docking/graceful_controller.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+// The control law itself lives in nav2_graceful_controller, which has over 98% test coverage.
+// These tests cover the plugin wrapper: parameter namespacing, frame resolution, and the
+// trajectory handling introduced by the opennav_docking::ControllerBase interface.
+
+namespace opennav_docking
+{
+
+/// @brief Build a path in the given frame from a list of (x, y, yaw) triples.
+nav_msgs::msg::Path makePath(
+  const std::string & frame, const std::vector<std::array<double, 3>> & points)
+{
+  nav_msgs::msg::Path path;
+  path.header.frame_id = frame;
+  for (const auto & point : points) {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.frame_id = frame;
+    pose.pose.position.x = point[0];
+    pose.pose.position.y = point[1];
+    pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(point[2]);
+    path.poses.push_back(pose);
+  }
+  return path;
+}
+
+/// @brief Insert a static transform directly into the buffer, so no spinning is required.
+void setTransform(
+  const nav2::TransformBuffer::SharedPtr & tf,
+  const std::string & parent, const std::string & child, double x, double y)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = parent;
+  transform.child_frame_id = child;
+  transform.transform.translation.x = x;
+  transform.transform.translation.y = y;
+  transform.transform.rotation.w = 1.0;
+  tf->setTransform(transform, "test", true);
+}
+
+/// @brief Exposes protected state so the trajectory publisher can be inspected directly.
+class TestableGracefulController : public GracefulController
+{
+public:
+  bool hasTrajectoryPublisher() const {return trajectory_pub_ != nullptr;}
+};
+
+/// @brief Configure a controller instance with collision detection disabled.
+std::shared_ptr<GracefulController> makeController(
+  const nav2::LifecycleNode::SharedPtr & node, const nav2::TransformBuffer::SharedPtr & tf,
+  const std::string & name)
+{
+  nav2::declare_parameter_if_not_declared(
+    node, name + ".use_collision_detection", rclcpp::ParameterValue(false));
+  auto controller = std::make_shared<GracefulController>();
+  controller->configure(node, name, tf);
+  return controller;
+}
+
+TEST(GracefulControllerTests, PluginIsDiscoverable)
+{
+  pluginlib::ClassLoader<opennav_docking::ControllerBase> loader(
+    "opennav_docking", "opennav_docking::ControllerBase");
+  EXPECT_TRUE(loader.isClassAvailable("opennav_docking::GracefulController"));
+
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  nav2::declare_parameter_if_not_declared(
+    node, "c.use_collision_detection", rclcpp::ParameterValue(false));
+  nav2::declare_parameter_if_not_declared(
+    node, "c.base_frame", rclcpp::ParameterValue(std::string("base_link")));
+  nav2::declare_parameter_if_not_declared(
+    node, "c.fixed_frame", rclcpp::ParameterValue(std::string("base_link")));
+
+  auto controller = loader.createSharedInstance("opennav_docking::GracefulController");
+  controller->configure(node, "c", tf);
+  EXPECT_EQ(controller->getName(), "c");
+
+  controller->setTrajectory(makePath("base_link", {{1.0, 0.0, 0.0}}));
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+
+  controller->reset();
+  controller->activate();
+  controller->deactivate();
+  controller->cleanup();
+  controller.reset();
+}
+
+TEST(GracefulControllerTests, ParameterNamespacesAreIsolated)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  auto c1 = makeController(node, tf, "c1");
+  auto c2 = makeController(node, tf, "c2");
+
+  // Slow c1 down; c2 shares the node but must keep its defaults
+  node->set_parameters(
+    {rclcpp::Parameter("c1.v_linear_min", 0.01), rclcpp::Parameter("c1.v_linear_max", 0.05)});
+
+  auto trajectory = makePath("base_link", {{2.0, 0.0, 0.0}});
+  c1->setTrajectory(trajectory);
+  c2->setTrajectory(trajectory);
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd1, cmd2;
+  EXPECT_TRUE(c1->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd1));
+  EXPECT_TRUE(c2->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd2));
+
+  EXPECT_NEAR(cmd1.linear.x, 0.05, 1e-6);
+  EXPECT_NEAR(cmd2.linear.x, 0.25, 1e-6);
+}
+
+TEST(GracefulControllerTests, FramePrecedencePrefersInstanceOverNode)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "my_base", 0.0, 0.0);
+
+  // The node-level frames name something that does not exist in the TF tree
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("bogus_fixed")));
+  nav2::declare_parameter_if_not_declared(
+    node, "base_frame", rclcpp::ParameterValue(std::string("bogus_base")));
+  nav2::declare_parameter_if_not_declared(
+    node, "c.fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  nav2::declare_parameter_if_not_declared(
+    node, "c.base_frame", rclcpp::ParameterValue(std::string("my_base")));
+
+  auto controller = makeController(node, tf, "c");
+  controller->setTrajectory(makePath("odom", {{1.0, 0.0, 0.0}}));
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+}
+
+TEST(GracefulControllerTests, FramePrecedenceFallsBackToNode)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "my_base", 0.0, 0.0);
+
+  // No per-instance override: the server's frames must be picked up
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  nav2::declare_parameter_if_not_declared(
+    node, "base_frame", rclcpp::ParameterValue(std::string("my_base")));
+
+  auto controller = makeController(node, tf, "c");
+  controller->setTrajectory(makePath("odom", {{1.0, 0.0, 0.0}}));
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+}
+
+TEST(GracefulControllerTests, TrajectoryIsTransformedIntoBaseFrame)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+
+  // The robot sits 1m to the left of the odom origin, facing along +x
+  setTransform(tf, "odom", "base_link", 0.0, 1.0);
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  auto controller = makeController(node, tf, "c");
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+
+  // A target on the odom x-axis lies 1m to the robot's right, so the robot must steer right.
+  // Reading the odom coordinates literally would place it straight ahead and steer nowhere.
+  controller->setTrajectory(makePath("odom", {{1.0, 0.0, 0.0}}));
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+  EXPECT_LT(cmd.angular.z, -1e-3);
+
+  // A target on the robot's own row is straight ahead, so it drives without steering
+  controller->setTrajectory(makePath("odom", {{2.0, 1.0, 0.0}}));
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+  EXPECT_NEAR(cmd.angular.z, 0.0, 1e-6);
+}
+
+TEST(GracefulControllerTests, LastPoseOfTrajectoryIsTheTarget)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  auto controller = makeController(node, tf, "c");
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist single, multi;
+
+  controller->setTrajectory(makePath("base_link", {{1.0, 0.5, 0.0}}));
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    single));
+
+  controller->setTrajectory(makePath("base_link", {{5.0, -3.0, 1.0}, {1.0, 0.5, 0.0}}));
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    multi));
+
+  EXPECT_EQ(single, multi);
+}
+
+TEST(GracefulControllerTests, ReverseDrivesBackwards)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  auto controller = makeController(node, tf, "c");
+
+  opennav_docking::TrajectoryOptions options;
+  options.reverse = true;
+  controller->setTrajectory(makePath("base_link", {{-1.0, 0.0, M_PI}}), options);
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_LT(cmd.linear.x, 0.0);
+}
+
+TEST(GracefulControllerTests, InvalidTrajectoriesFailWithoutCrashing)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+  nav2::declare_parameter_if_not_declared(
+    node, "fixed_frame", rclcpp::ParameterValue(std::string("odom")));
+  auto controller = makeController(node, tf, "c");
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd, zero;
+
+  // Never given a trajectory at all
+  EXPECT_FALSE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_EQ(cmd, zero);
+
+  // An empty path
+  controller->setTrajectory(makePath("base_link", {}));
+  EXPECT_FALSE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_EQ(cmd, zero);
+
+  // A path with no frame at all
+  controller->setTrajectory(makePath("", {{1.0, 0.0, 0.0}}));
+  EXPECT_FALSE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_EQ(cmd, zero);
+
+  // A path in a frame that is not in the TF tree
+  controller->setTrajectory(makePath("nowhere", {{1.0, 0.0, 0.0}}));
+  EXPECT_FALSE(controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1,
+    cmd));
+  EXPECT_EQ(cmd, zero);
+}
+
+TEST(GracefulControllerTests, RotateToHeadingUsesInstanceParameters)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  nav2::declare_parameter_if_not_declared(
+    node, "c.rotate_to_heading_angular_vel", rclcpp::ParameterValue(0.5));
+  auto controller = makeController(node, tf, "c");
+
+  geometry_msgs::msg::Twist current_velocity;
+  auto cmd = controller->computeRotateToHeadingCommand(1.0, current_velocity, 0.1);
+  EXPECT_DOUBLE_EQ(cmd.linear.x, 0.0);
+  EXPECT_GT(cmd.angular.z, 0.0);
+  EXPECT_LE(cmd.angular.z, 0.5);
+}
+
+TEST(GracefulControllerTests, TrajectoryPublishingIsOffByDefault)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  nav2::declare_parameter_if_not_declared(
+    node, "c.use_collision_detection", rclcpp::ParameterValue(false));
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+
+  auto controller = std::make_shared<TestableGracefulController>();
+  controller->configure(node, "c", tf);
+  EXPECT_FALSE(controller->hasTrajectoryPublisher());
+
+  // Activation, command computation and deactivation must all tolerate the absent publisher.
+  controller->activate();
+  controller->setTrajectory(makePath("base_link", {{1.0, -1.0, 0.0}}));
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(
+    controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+  controller->deactivate();
+  controller->cleanup();
+}
+
+TEST(GracefulControllerTests, TrajectoryPublishingIsEnabledByTheFlag)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("test");
+  auto tf = nav2::create_transform_buffer(node);
+  tf->setUsingDedicatedThread(true);
+  nav2::declare_parameter_if_not_declared(
+    node, "c.use_collision_detection", rclcpp::ParameterValue(false));
+  nav2::declare_parameter_if_not_declared(
+    node, "c.publish_trajectory", rclcpp::ParameterValue(true));
+  setTransform(tf, "odom", "base_link", 0.0, 0.0);
+
+  auto controller = std::make_shared<TestableGracefulController>();
+  controller->configure(node, "c", tf);
+  EXPECT_TRUE(controller->hasTrajectoryPublisher());
+
+  controller->activate();
+  controller->setTrajectory(makePath("base_link", {{1.0, -1.0, 0.0}}));
+  geometry_msgs::msg::PoseStamped robot_pose;
+  geometry_msgs::msg::Twist cmd;
+  EXPECT_TRUE(
+    controller->computeVelocityCommands(robot_pose, geometry_msgs::msg::Twist(), 0.1, cmd));
+  EXPECT_GT(cmd.linear.x, 0.0);
+  controller->deactivate();
+  controller->cleanup();
+  EXPECT_FALSE(controller->hasTrajectoryPublisher());
+}
+
+}  // namespace opennav_docking
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
+++ b/nav2_docking/opennav_docking_core/include/opennav_docking_core/charging_dock.hpp
@@ -155,8 +155,23 @@ public:
 
   std::string getName() {return name_;}
 
+  /**
+   * @brief Get the name of the controller every dock of this type drives with.
+   *
+   * @return std::string The configured controller name, or "" if unset.
+   */
+  std::string getControllerName() {return controller_name_;}
+
+  /**
+   * @brief Set the name of the controller every dock of this type drives with.
+   *
+   * @param name Controller name, or "" to express no preference.
+   */
+  void setControllerName(const std::string & name) {controller_name_ = name;}
+
 protected:
   std::string name_;
+  std::string controller_name_;
   DockDirection dock_direction_{DockDirection::UNKNOWN};
   bool rotate_to_dock_{false};
 };


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6468 |
| Primary OS tested on | Ubuntu (24.04.4 Noble, ROS 2 Jazzy) |
| Robotic platform tested on | TurtleBot3 on Gazebo |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |


---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* Adds `opennav_docking::ControllerBase` as a pluginlib base
* Moves existing smooth control law out as `opennav_docking::GracefulController` plugin.
* `DockingServer` now loads a `controllers` list via pluginlib and resolves which one to use
* Adds `opennav_docking::PIDController` as a second plugin
* No existing YAML needs editing. When `controllers` is not set a single instance named `controller` of type `GracefulController` is instantiated.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

* `nav2_docking/README.md` gains configuration documentation for `controllers`,  `<dock plugin>.controller` and `<dock>.controller`.
* Base controller and plugin classes will add entries on doxygen API docs

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

* Added several unit tests, (but currently does not cover all features).
* Tested in Gazebo on TurtleBot3 simulation with two dock instances at the same pose selecting different controllers. Working example can be found at [https://github.com/odemirs/nav2_dock_tests](https://github.com/odemirs/nav2_dock_tests).

**Note**: Test environment uses jazzy base on Ubuntu 24.04, but Nav2 stack and BehaviorTree.CPP are compiled from source. Steps to build test environment is explained in [https://github.com/odemirs/nav2_dock_tests#build](https://github.com/odemirs/nav2_dock_tests#build).

A test result is given below for 6 separate trials starting from random initial poses. The graphs below compares the base_link to dock pose difference by time starting from the staging pose for the PID and graceful controllers.

<img width="1540" height="1120" alt="convergence_nominal" src="https://github.com/user-attachments/assets/030f7f16-10c1-4d2c-b3dd-2815557f587d" />

PID controller's results are comparable to Graceful's when the [parameter set in test package](https://github.com/odemirs/nav2_dock_tests/blob/afe8c76c83e447302cdb678fe0e85053284e315e/params/nav2_dock_tests_params.yaml#L511) is used. However, the PID controller may, fail (diverges) when lateral offset at the staging pose is large. Its strength mainly lies in the final contact phase when the lateral offset is small, it adjusts the robot's pose to the dock more precisely. This motivates the proposed controller switch in the Future work section below.  The graceful controller closes lateral offset and PID controller performs the final alignment.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->


* Add intermediate waypoints between the staging pose and docking pose to improve alignment precision.
* Switching of controllers (or gain scheduling) across waypoints to optimize accuracy near the target.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
