### PR TITLE
Fix costmap shutdown flag data race

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -388,7 +388,7 @@ protected:
    * @brief Function on timer for costmap update
    */
   void mapUpdateLoop(double frequency);
-  bool map_update_thread_shutdown_{false};
+  std::atomic<bool> map_update_thread_shutdown_{false};  // [AI generated]
   std::atomic<bool> stop_updates_{false};
   std::atomic<bool> initialized_{false};
   std::atomic<bool> stopped_{true};


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #6450 |
| Primary OS tested on | Ubuntu 26.04.1 LTS|
| Robotic platform tested on | Local x86_64 PC only; no physical robot|
| Does this PR contain AI generated software? | Yes and it is marked inline in the code|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->


* Changed the costmap map update shutdown flag to use `std::atomic<bool>`.
* Fixes a data race between lifecycle deactivation and the map update loop.


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

No documentation updates are required. This is an internal thread-safety fix.

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
* Built `nav2_costmap_2d` with tests enabled.
* Ran the `nav2_costmap_2d` test suite successfully.
* Test result: 0 errors and 0 failures.
* Benchmark tests were skipped by default.
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

* None currently planned.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
