### PR TITLE
Lock costmap service response generation

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -287,6 +287,8 @@ Costmap2DPublisher::costmap_service_callback(
   tf2::Quaternion quaternion;
   quaternion.setRPY(0.0, 0.0, 0.0);
 
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));  // [AI generated]
+
   auto size_x = costmap_->getSizeInCellsX();
   auto size_y = costmap_->getSizeInCellsY();
   auto data_length = size_x * size_y;

--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -287,7 +287,7 @@ Costmap2DPublisher::costmap_service_callback(
   tf2::Quaternion quaternion;
   quaternion.setRPY(0.0, 0.0, 0.0);
 
-  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));  // [AI generated]
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
 
   auto size_x = costmap_->getSizeInCellsX();
   auto size_y = costmap_->getSizeInCellsY();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  Fixes #6466 |
| Primary OS tested on | Ubuntu 26.04.1 LTS |
| Robotic platform tested on | Local x86_64 PC only |
| Does this PR contain AI generated software? | Yes and it is marked inline in the code |
| Was this PR description generated by AI software? | No|

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* Added locking around the `GetCostmap` service response generation.
* Protects costmap metadata and raw map data reads with the existing `Costmap2D` mutex.
* Fixes a data race between costmap updates and service requests.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

No documentation updates are required. This is an internal thread-safety fix.


## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

* Built `nav2_costmap_2d` with tests enabled.
* Ran the `nav2_costmap_2d` test suite successfully.
* Test result: 475 tests, 0 errors, 0 failures, 114 skipped.
* Benchmark tests were skipped by default.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

* None currently planned.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
