### PR TITLE
fix(theta_star_planner): charge traversal cost per unit distance

### DIFF
--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -33,17 +33,23 @@ The parameters were set to - `w_euc_cost: 1.0`, `w_traversal_cost: 5.0` and the 
 
 **euc_cost(a,b)** - euclidean distance between the node type 'a' and type 'b'
 
-**costmap_cost(a,b)** - the costmap traversal cost (ranges from 0 - 252, 255 = unknown value) between the node type 'a' and type 'b'
+**costmap_cost(a)** - the costmap traversal cost of the cell at node 'a' (ranges from 0 - 252, 255 = unknown value)
 
 ### Cost function
 ```
-g(neigh) = g(curr) + w_euc_cost*euc_cost(curr, neigh) + w_traversal_cost*(costmap_cost(curr,neigh)/LETHAL_COST)^2
+g(neigh) = g(curr) + [w_euc_cost + w_traversal_cost*(costmap_cost(neigh)/LETHAL_COST)^2] * euc_cost(curr, neigh)
 h(neigh) = w_heuristic_cost * euc_cost(neigh, goal)
 f(neigh) = g(neigh) + h(neigh)
 ```
-Because of how the program works when the 'neigh' init_rclcpp is to be expanded, depending
+Because of how the program works when the 'neigh' node is to be expanded, depending
 on the result of the LOS check, (if the LOS check returns true) the value of g(neigh) might change to `g(par) +
-w1*euc_cost(par, neigh) + w2*(costmap(par,neigh)/LETHAL_COST)^2`
+[w_euc_cost + w_traversal_cost*mean_over_cells((costmap_cost/LETHAL_COST)^2)] * euc_cost(par, neigh)`,
+where the mean is taken over the cells the Bresenham trace from 'par' to 'neigh' visits, each
+weighted by the length of the step across it. It is a sampled average rather than an exact
+integral: a cell the line clips but the trace steps past is not charged.
+
+Both terms are charged per unit distance, so neither depends on the direction of travel
+relative to the grid axes.
 
 ## Parameters
 The parameters of the planner are :
@@ -65,7 +71,7 @@ planner_server:
 ## Usage Notes
 
 ### Tuning the Parameters
-Before starting off, do note that the costmap_cost(curr,neigh) component after being operated (ie before being multiplied to its parameter and being substituted in g(init_rclcpp)) varies from 0 to 1.
+Before starting off, do note that the costmap_cost(neigh) component after being operated (ie before being multiplied to its parameter and being substituted in g(neigh)) varies from 0 to 1.
 
 This planner uses the costs associated with each cell from the `global_costmap` as a measure of the point's proximity to the obstacles. Providing a gentle potential field that covers the entirety of the region (thus leading to only small pocket like regions of cost = 0) is recommended in order to achieve paths that pass through the middle of the spaces. A good starting point could be to set the `inflation_layer`'s parameters as - `cost_scaling_factor: 10.0`, `inflation_radius: 5.5` and then decrease the value of `cost_scaling_factor` to achieve the said potential field.
 

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -80,13 +80,21 @@ public:
   bool generatePath(std::vector<coordsW> & raw_path, std::function<bool()> cancel_checker);
 
   /**
+   * @brief this function checks whether a costmap cost is less than or equal to the MAX_NON_OBSTACLE_COST
+   * @return the result of the check
+   */
+  inline bool isSafe(const unsigned char & cost) const
+  {
+    return (cost == UNKNOWN_COST && params_->allow_unknown) || cost <= MAX_NON_OBSTACLE_COST;
+  }
+
+  /**
    * @brief this function checks whether the cost of a point(cx, cy) on the costmap is less than or equal to the MAX_NON_OBSTACLE_COST
    * @return the result of the check
    */
   inline bool isSafe(const int & cx, const int & cy) const
   {
-    return (costmap_->getCost(cx, cy) == UNKNOWN_COST && params_->allow_unknown) ||
-           costmap_->getCost(cx, cy) <= MAX_NON_OBSTACLE_COST;
+    return isSafe(costmap_->getCost(cx, cy));
   }
 
   /**
@@ -180,47 +188,57 @@ protected:
   void backtrace(std::vector<coordsW> & raw_points, const tree_node * curr_n) const;
 
   /**
-   * @brief it is an overloaded function to ease the cost calculations while performing the LOS check
-   * @param cost denotes the total straight line traversal cost; it adds the traversal cost for the node (cx, cy) at every instance; it is also being returned
-   * @return false if the traversal cost is greater than the MAX_NON_OBSTACLE_COST and true otherwise
-   */
-  bool isSafe(const int & cx, const int & cy, double & cost) const
-  {
-    const double curr_cost = getCost(cx, cy);
-    if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && params_->allow_unknown) ||
-      curr_cost <= MAX_NON_OBSTACLE_COST)
-    {
-      cost += params_->w_traversal_cost * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
-        MAX_NON_OBSTACLE_COST;
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  /**
    * @brief this function scales the costmap cost by shifting the origin to 25 and then multiply
    *           the actual costmap cost by 0.9 to keep the output in the range of [25, 255)
    *           an unknown cell is charged as near-obstacle, so that traversing one is discouraged
    *           wherever allow_unknown permits it at all
    * @return the scaled cost thus obtained
    */
-  inline double getCost(const int & cx, const int & cy) const
+  inline double getCost(const unsigned char & cost) const
   {
-    const unsigned char cost = costmap_->getCost(cx, cy);
     return 26 + 0.9 * (cost == UNKNOWN_COST ? OCCUPIED_COST - 1 : cost);
   }
 
   /**
-   * @brief for the point(cx, cy), its traversal cost is calculated by
-   *                    <parameter>*(<actual_traversal_cost_from_costmap>)^2/(<max_cost>)^2
+   * @brief this function scales the cost of the cell at the point(cx, cy)
+   * @return the scaled cost thus obtained
+   */
+  inline double getCost(const int & cx, const int & cy) const
+  {
+    return getCost(costmap_->getCost(cx, cy));
+  }
+
+  /**
+   * @brief the traversal cost of a step of the given length across a cell of the given cost,
+   *                    <parameter>*(<actual_traversal_cost_from_costmap>)^2/(<max_cost>)^2*<length>
+   *           the squared term is a cost per unit distance, so it is charged over the step
    * @return the traversal cost thus calculated
    */
-  inline double getTraversalCost(const int & cx, const int & cy)
+  inline double getTraversalCost(const unsigned char & cost, const double & length) const
   {
-    double curr_cost = getCost(cx, cy);
+    const double curr_cost = getCost(cost);
     return params_->w_traversal_cost * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
-           MAX_NON_OBSTACLE_COST;
+           MAX_NON_OBSTACLE_COST * length;
+  }
+
+  /**
+   * @brief for the point(cx, cy), its traversal cost density is calculated by
+   *                    <parameter>*(<actual_traversal_cost_from_costmap>)^2/(<max_cost>)^2
+   * @return the traversal cost density thus calculated
+   */
+  inline double getTraversalCost(const int & cx, const int & cy) const
+  {
+    return getTraversalCost(costmap_->getCost(cx, cy), 1.0);
+  }
+
+  /**
+   * @brief calculates the cost of travelling the given length by
+   *                    <euc_cost_parameter>*<length>
+   * @return the cost thus calculated
+   */
+  inline double getEuclideanCost(const double & length) const
+  {
+    return params_->w_euc_cost * length;
   }
 
   /**
@@ -230,7 +248,7 @@ protected:
    */
   inline double getEuclideanCost(const int & ax, const int & ay, const int & bx, const int & by)
   {
-    return params_->w_euc_cost * std::hypot(ax - bx, ay - by);
+    return getEuclideanCost(std::hypot(ax - bx, ay - by));
   }
 
   /**

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -110,16 +110,17 @@ void ThetaStar::setNeighbors(const tree_node * curr_data)
     mx = curr_data->x + moves[i].x;
     my = curr_data->y + moves[i].y;
 
-    if (withinLimits(mx, my)) {
-      if (!isSafe(mx, my)) {
-        continue;
-      }
-    } else {
+    if (!withinLimits(mx, my)) {
       continue;
     }
 
-    g_cost = curr_data->g + getEuclideanCost(curr_data->x, curr_data->y, mx, my) +
-      getTraversalCost(mx, my);
+    const unsigned char cost = costmap_->getCost(mx, my);
+    if (!isSafe(cost)) {
+      continue;
+    }
+
+    const double step_length = (moves[i].x != 0 && moves[i].y != 0) ? M_SQRT2 : 1.0;
+    g_cost = curr_data->g + getEuclideanCost(step_length) + getTraversalCost(cost, step_length);
 
     m_id = getIndex(mx, my);
 
@@ -178,13 +179,19 @@ bool ThetaStar::losCheck(
   int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
   int dy = abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
   int cx = x0, cy = y0, e = dx - dy;
+  double stepped_length = 0.0;
 
   while (cx != x1 || cy != y1) {
-    if (!isSafe(cx, cy, sl_cost)) {
+    const unsigned char cost = costmap_->getCost(cx, cy);
+    if (!isSafe(cost)) {
       return false;
     }
-    int e2 = 2 * e;
-    if (e2 > -dy && e2 <= dx) {
+    const int e2 = 2 * e;
+    const bool diagonal = e2 > -dy && e2 <= dx;
+    const double step_length = diagonal ? M_SQRT2 : 1.0;
+    sl_cost += getTraversalCost(cost, step_length);
+    stepped_length += step_length;
+    if (diagonal) {
       if (!isSafe(cx + sx, cy) || !isSafe(cx, cy + sy)) {
         return false;
       }
@@ -198,6 +205,11 @@ bool ThetaStar::losCheck(
       cy += sy;
       e += dx;
     }
+  }
+
+  // The steps sum to the staircase length rather than the chord, so normalize the total.
+  if (stepped_length > 0.0) {
+    sl_cost *= std::hypot(dx, dy) / stepped_length;
   }
 
   return true;

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -286,6 +286,32 @@ TEST(ThetaStarTest, test_unknown_cost_agrees_between_cost_sites) {
   delete planner_->costmap_;
 }
 
+// Traversal cost is charged per unit distance, so equal-length lines cost the same at any bearing
+TEST(ThetaStarTest, test_los_cost_is_direction_independent) {
+  auto node = std::make_shared<nav2::LifecycleNode>("ThetaStarDirectionTestNode");
+  auto plugin_name = std::string("test");
+  auto param_handler = std::make_unique<nav2_theta_star_planner::ParameterHandler>(
+    node, plugin_name, node->get_logger());
+  param_handler->activate();
+  auto params = param_handler->getParams();
+  auto planner_ = std::make_unique<test_theta_star>(params);
+
+  planner_->costmap_ = new nav2_costmap_2d::Costmap2D(10, 10, 1.0, 0.0, 0.0, 100);
+  params->w_traversal_cost = 2.0;
+
+  const int len = 8;
+  double axial = 0.0, diagonal = 0.0, oblique = 0.0;
+  ASSERT_TRUE(planner_->ulosCheck(1, 1, 1 + len, 1, axial));
+  ASSERT_TRUE(planner_->ulosCheck(1, 1, 1 + len, 1 + len, diagonal));
+  // the staircase equals the chord at 0 and 45 degrees, so an oblique bearing is needed too
+  ASSERT_TRUE(planner_->ulosCheck(1, 1, 1 + len, 1 + len / 2, oblique));
+
+  EXPECT_NEAR(axial / len, diagonal / std::hypot(len, len), 1e-9);
+  EXPECT_NEAR(axial / len, oblique / std::hypot(len, len / 2), 1e-9);
+
+  delete planner_->costmap_;
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | na |
| Primary OS tested on | ubuntu |
| Robotic platform tested on | custom |
| Does this PR contain AI generated software? | yes |
| Was this PR description generated by AI software? | no |

---

## Description of contribution in a few bullet points

Updates the traversal cost to be applied per distance instead of per step.

- Diagonal steps cover a distance of √2 while axial steps covered a distance of 1, so the previous formulation under charged diagonal steps by 29%
- In setNeighbors, the step length is now passed into the getTraversalCost method
- In losCheck the traversal charge is normalized against the chord length
- New overloads of isSafe, getCost, getTraversalCost, and getEuclideanCost are provided to remove redundant std::hypot calculations and costmap lookups.
- Added a new unit test to ensure the LOS cost was consistent independent of direction in a uniform cost field.

## Description of documentation updates required from your changes

The included readme has been updated.

## Description of how this change was tested

This change was originally tested on kilted, where the lack of other fixes rendered the change more impactful. 

Here is a before/after screenshot that was generated on kilted. Caveat that it wasn't code exact, but the fix shown here was equivalent to what is in this PR.

Kilted before:
<img width="1611" height="1211" alt="kilted-bearing22_5-before" src="https://github.com/user-attachments/assets/f7d0542f-8423-4d1d-9da1-637d0d3e58c4" />

Kilted after:
<img width="1168" height="999" alt="kilted-bearing22_5-after" src="https://github.com/user-attachments/assets/3ce616be-53e8-4813-bd94-3a2bd514055d" />

Here is a several screenshots tested on this exact changeset to show the effects of this change. The harness launch file used to generate these is also included:

[thetastar_viz.launch.py](https://github.com/user-attachments/files/31965917/thetastar_viz.launch.py)

Each picture shows the before and after for a few fixed cases. You will note that for the circle case the cost is changed just enough to change which is of the circle we choose.

<img width="2048" height="920" alt="obstacle_pair" src="https://github.com/user-attachments/assets/d9559742-3e40-4398-ad33-6506e0a425eb" />
<img width="2048" height="920" alt="circle_pair" src="https://github.com/user-attachments/assets/c158ca3e-1348-4c4d-853c-a954e19fbf2c" />
<img width="2048" height="920" alt="north_pair" src="https://github.com/user-attachments/assets/9da06ff9-3fe0-49e2-832a-425d679176c9" />
<img width="2048" height="920" alt="bearing45_pair" src="https://github.com/user-attachments/assets/7343dd1b-03d0-4f79-9a71-00a3d8fe3c69" />
<img width="2048" height="920" alt="bearing22_5_pair" src="https://github.com/user-attachments/assets/fa99c539-5c09-4765-b10f-28ca70323d10" />

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
