### PR TITLE
Standardize boolean literals to lowercase

### DIFF
--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -3,7 +3,7 @@
 geometry_msgs/Point target
 float32 speed
 builtin_interfaces/Duration time_allowance
-bool disable_collision_checks False
+bool disable_collision_checks false
 ---
 #result definition
 

--- a/nav2_msgs/action/DockRobot.action
+++ b/nav2_msgs/action/DockRobot.action
@@ -1,13 +1,13 @@
 #goal definition
 
-bool use_dock_id True  # Whether to use the dock_id or dock_pose fields
+bool use_dock_id true  # Whether to use the dock_id or dock_pose fields
 string dock_id  # Dock name or ID to dock at, from given dock database
 
 geometry_msgs/PoseStamped dock_pose  # Dock pose
 string dock_type  # If using dock_pose, what type of dock it is. Not necessary if only using one type of dock.
 
 float32 max_staging_time 1000.0  # Maximum time for navigation to get to the dock's staging pose.
-bool navigate_to_staging_pose True  # Whether or not to navigate to staging pose or assume robot is already at staging pose within tolerance to execute behavior
+bool navigate_to_staging_pose true  # Whether or not to navigate to staging pose or assume robot is already at staging pose within tolerance to execute behavior
 
 ---
 #result definition
@@ -26,7 +26,7 @@ uint16 FAILED_TO_CHARGE=906
 uint16 TIMEOUT=907
 uint16 UNKNOWN=999
 
-bool success True  # docking success status
+bool success true  # docking success status
 uint16 error_code 0  # Contextual error code, if any
 uint16 num_retries 0  # Number of retries attempted
 string error_msg

--- a/nav2_msgs/action/DriveOnHeading.action
+++ b/nav2_msgs/action/DriveOnHeading.action
@@ -3,7 +3,7 @@
 geometry_msgs/Point target
 float32 speed
 builtin_interfaces/Duration time_allowance
-bool disable_collision_checks False
+bool disable_collision_checks false
 ---
 #result definition
 

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -1,7 +1,7 @@
 #goal definition
 float32 target_yaw
 builtin_interfaces/Duration time_allowance
-bool disable_collision_checks False
+bool disable_collision_checks false
 ---
 #result definition
 

--- a/nav2_msgs/action/UndockRobot.action
+++ b/nav2_msgs/action/UndockRobot.action
@@ -21,7 +21,7 @@ uint16 FAILED_TO_CONTROL=905
 uint16 TIMEOUT=907
 uint16 UNKNOWN=999
 
-bool success True  # docking success status
+bool success true  # docking success status
 uint16 error_code 0  # Contextual error code, if any
 string error_msg
 ---


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
This PR standardizes the default boolean literals across several .action files in nav2_msgs (e.g., DockRobot.action, UndockRobot.action, BackUp.action, Spin.action, DriveOnHeading.action) to use strict lowercase (true/false).

While the official ROS 2 Python parser ([rosidl_adapter](https://github.com/ros2/rosidl/blob/61aebc6362f495e377ac27178343c8f074e7eaf5/rosidl_adapter/rosidl_adapter/parser.py#L748)) evaluates boolean constants case-insensitively using `if value_string.lower() not in (true_values + false_values`):, strict parsers and code generators in other ecosystems (such as roslibrust) fail to parse these files because standard ROS 2 boolean literals must be strictly lowercase. The following error is shown: 
`error Failed to generate ROS messages from .msg files: SimpleError { err: "Failed to parse a literal value in a message file to the corresponding rust type: True to bool, expected value at line 1 column 1" }`

I've also noted that nav2_msgs is also currently internally inconsistent, e.g. msg/ExclusionZoneDescription.msg uses lowercase true/false in its declarations, while some fo the action files use capitalized True/False. This PR does a simple standardization of it.

## Description of documentation updates required from your changes
N/A

## Description of how this change was tested
I've run `colcon build --packages-select nav2_msgs` and `colcon build --packages-above nav2_msgs` to ensure it compiles correctly. 
I also verified that rosidl_generator_py still correctly translates the lowercase literals back into native Python keywords by
running `python3 -c "from nav2_msgs.action import DockRobot; goal = DockRobot.Goal(); print(f'Type: {type(goal.use_dock_id)} | Value: {goal.use_dock_id}')"`

Let me know if there's anything else I should be trying!

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
