### PR TITLE
Fix feasible path costmap access race

### DIFF
--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -210,6 +210,8 @@ nav_msgs::msg::Path FeasiblePathHandler::transformLocalPlan(
   // Find the furthest relevant pose on the path to consider within costmap
   // bounds
   // Transforming it to the costmap frame in the same loop
+  std::lock_guard<nav2_costmap_2d::Costmap2D::mutex_t> costmap_lock(
+    *(costmap_ros_->getCostmap()->getMutex()));
   for (auto global_plan_pose = closest_point; global_plan_pose != pruned_plan_end;
     ++global_plan_pose)
   {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #6478|
| Primary OS tested on |Ubuntu 26.04.1 LTS|
| Robotic platform tested on | tb3 loopback simulation |
| Does this PR contain AI generated software? | No|
| Was this PR description generated by AI software? | No|

---

## Description of contribution in a few bullet points

* Adds locking around the `Costmap2D::worldToMap()` call in `FeasiblePathHandler::transformLocalPlan()`.
* Prevents controller-side reads of costmap geometry from racing with rolling-window costmap origin updates.
* Keeps the lock scope limited to the costmap bounds check.

## Description of documentation updates required from your changes

* No documentation updates required. The fix does not change user-facing behavior or configuration.


## Description of how this change was tested

* Built `nav2_controller` with tests enabled:
  * `colcon build --base-paths src/navigation2 --packages-select nav2_controller --cmake-force-configure --cmake-args -DBUILD_TESTING=ON`
* Ran `nav2_controller` package tests:
  * `colcon test --base-paths src/navigation2 --packages-select nav2_controller --event-handlers console_direct+`
* Checked test results:
  * `colcon test-result --test-result-base build/nav2_controller --verbose`
  * Result: `138 tests, 0 errors, 0 failures, 26 skipped`

---

## Future work that may be required in bullet points

* No additional future work is currently planned.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
