### PR TITLE
Proper cleanup in asymmetric_inflation_tests

### DIFF
--- a/nav2_costmap_2d/test/integration/asymmetric_inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/asymmetric_inflation_tests.cpp
@@ -82,13 +82,6 @@ public:
   }
 };
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {rclcpp::init(0, nullptr);}
-  ~RclCppFixture() {rclcpp::shutdown();}
-};
-RclCppFixture g_rclcpp_fixture;
 
 // ============================================================
 // Helper: build a default valid parameter set for initialize()
@@ -295,6 +288,15 @@ protected:
     pose.pose.position.y = 2.0;
     path->poses.push_back(pose);
     layer_->injectPath(path);
+  }
+
+  void TearDown() override
+  {
+    layer_.reset();
+    layers_.reset();
+    tf_.reset();
+    node_->shutdown();
+    node_.reset();
   }
 
   nav2::LifecycleNode::SharedPtr node_;
@@ -825,6 +827,9 @@ TEST_F(AsymmetricInflationIntegrationTest, update_parameters_callback_filters_ba
 
 int main(int argc, char ** argv)
 {
+  rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

Without this fix it hangs for me with Zenoh

```
[       OK ] AsymmetricInflationIntegrationTest.update_parameters_callback_filters_base_cost_scaling (1 ms)
[----------] 24 tests from AsymmetricInflationIntegrationTest (37 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (50 ms total)
[  PASSED  ] 31 tests.

thread '<unnamed>' (814155) panicked at /root/.cargo/git/checkouts/zenoh-960d3fab753191f7/8e2bdda/commons/zenoh-runtime/src/lib.rs:154:21:
The Thread Local Storage inside Tokio is destroyed. This might happen when Zenoh API is called at process exit, e.g. in the atexit handler. Calling the Zenoh API at process exit is not supported and should be avoided.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Stack trace (most recent call last):
#25   Object "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", at 0xffffffffffffffff, in 
```

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
