### PR TITLE
nav2_common: Depend on osrf_pycommon system package in Lyrical+

### DIFF
--- a/nav2_common/package.xml
+++ b/nav2_common/package.xml
@@ -10,7 +10,8 @@
   <depend>backward_ros</depend>
   <depend>launch</depend>
   <depend>launch_ros</depend>
-  <depend>osrf_pycommon</depend>
+  <depend condition="$ROS_DISTRO == jazzy">osrf_pycommon</depend>
+  <depend condition="$ROS_DISTRO != jazzy">python3-osrf-pycommon</depend>
   <depend>rclpy</depend>
   <depend>python3-yaml</depend>
   <depend>python3-types-pyyaml</depend>


### PR DESCRIPTION
In Lyrical, all core packages depend on system `python3-osrf-pycommon` instead of ROS package `osrf_pycommon` (see https://github.com/ros2/launch/pull/817).

Do the same here to avoid potential (but unlikely) conflict in versions of these packages. This is also useful for package managers like Nix, which are more strict about dependency conflicts.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
