### PR TITLE
Convert ~/triggering_points to Pointcloud2

### DIFF
--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -85,6 +85,41 @@ For `stop`, `slowdown`, and `limit` polygons, temporal debounce can be tuned wit
 A value of `1/1` behaves like the historical behavior (single-cycle trigger/release). In practice, values larger than `1` are recommended to reduce sensor noise flicker while keeping response times reasonable.
 
 
+### Triggering Points
+
+Both nodes publish `sensor_msgs/msg/PointCloud2` on `~/triggering_points` when
+subscribed. This replaces the previous `MarkerArray` topic without a compatibility
+publisher. The separate `~/collision_points_marker` debug topic is unchanged.
+
+Each point occupies 24 bytes, with these scalar fields in order:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `x`, `y`, `z` | FLOAT32 | Coordinates in `base_frame_id`, in metres |
+| `source_id` | UINT32 | Zero-based index in the node's `observation_sources` array |
+| `polygon_id` | UINT32 | Zero-based index in the node's `polygons` array |
+| `action_type` | UINT32 | 0: none, 1: stop, 2: slowdown, 3: approach, 4: limit |
+
+IDs are assigned at lifecycle configuration and remain stable until reconfiguration.
+Reordering either parameter array changes its IDs; mappings are local to each node.
+Unknown source or polygon names use `4294967295` (`UINT32_MAX`). Inspect the arrays
+with `ros2 param get /collision_monitor observation_sources` and
+`ros2 param get /collision_monitor polygons` (substitute the detector node name as
+needed). Keep the matching configuration with recordings to interpret the IDs.
+Source IDs identify Nav2 observation sources: an already-merged input cloud remains
+one source, and any incoming `source_id` field is not propagated.
+
+The monitor publishes points for the selected action. The detector publishes points
+for every detected polygon, always with `action_type = 0`; a point in overlapping
+polygons appears once per polygon. Nonfinite coordinates are omitted from the
+output only, without changing collision decisions. The header uses the processing
+timestamp and `base_frame_id`. Empty clouds clear the previous triggering output.
+
+In RViz, use a PointCloud2 display with the Intensity color transformer and
+`source_id` channel (or `polygon_id` / `action_type`), and zero decay time.
+The cloud can use the recorder's existing Cloudini PointCloud2 codec; no extra
+conversion node is needed.
+
 ### Metrics
 
 Designed to be used in wide variety of robots (incl. moving fast) and have a high level of reliability, Collision Monitor node should operate at fast rates.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_detector_node.hpp
@@ -31,6 +31,7 @@
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include "nav2_collision_monitor/types.hpp"
+#include "nav2_collision_monitor/triggering_cloud.hpp"
 #include "nav2_collision_monitor/polygon.hpp"
 #include "nav2_collision_monitor/circle.hpp"
 #include "nav2_collision_monitor/velocity_polygon.hpp"
@@ -137,12 +138,12 @@ protected:
   void publishVisualizations() const;
 
   /**
-   * @brief Publishes the points inside each detected polygon as markers,
-   * bucketed by polygon name and per-point source.
+  * @brief Publishes points inside each detected polygon with source and polygon fields.
    * @param all_triggering_points Map from polygon name to its triggering points.
    */
   void publishTriggeringPoints(
-    const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points);
+    const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points,
+    const rclcpp::Time & stamp);
 
   // ----- Variables -----
 
@@ -162,9 +163,10 @@ protected:
   /// @brief Collision points marker publisher
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_pub_;
-  /// @brief Triggering points marker publisher (points inside each detected polygon)
-  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+  /// @brief Triggering points cloud publisher (points inside each detected polygon)
+  nav2::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr
     triggering_points_pub_;
+  TriggeringCloud triggering_cloud_;
   /// @brief timer that runs actions
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -35,6 +35,7 @@
 #include "nav2_msgs/srv/toggle.hpp"
 
 #include "nav2_collision_monitor/types.hpp"
+#include "nav2_collision_monitor/triggering_cloud.hpp"
 #include "nav2_collision_monitor/polygon.hpp"
 #include "nav2_collision_monitor/circle.hpp"
 #include "nav2_collision_monitor/velocity_polygon.hpp"
@@ -202,10 +203,10 @@ protected:
   void publishVisualizations() const;
 
   /**
-   * @brief Publishes action.triggering_points as markers, colour-coded by action type.
+  * @brief Publishes triggering points with source, polygon and action fields.
    * @param action Current robot action
    */
-  void publishTriggeringPoints(const Action & action);
+  void publishTriggeringPoints(const Action & action, const rclcpp::Time & stamp);
 
   /**
    * @brief Enable/disable collision monitor service callback
@@ -244,9 +245,10 @@ protected:
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     collision_points_marker_pub_;
 
-  /// @brief Triggering points marker publisher (points inside the active triggering zone)
-  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+  /// @brief Triggering points cloud publisher (points inside the active triggering zone)
+  nav2::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr
     triggering_points_pub_;
+  TriggeringCloud triggering_cloud_;
 
   /// @brief Enable/disable collision monitor service
   nav2::ServiceServer<nav2_msgs::srv::Toggle>::SharedPtr toggle_cm_service_;

--- a/nav2_collision_monitor/include/nav2_collision_monitor/triggering_cloud.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/triggering_cloud.hpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Dexory
+
+#ifndef NAV2_COLLISION_MONITOR__TRIGGERING_CLOUD_HPP_
+#define NAV2_COLLISION_MONITOR__TRIGGERING_CLOUD_HPP_
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/point_cloud2_iterator.hpp"
+#include "nav2_collision_monitor/types.hpp"
+
+namespace nav2_collision_monitor
+{
+
+class TriggeringCloud
+{
+public:
+  void configure(
+    const std::vector<std::string> & sources, const std::vector<std::string> & polygons)
+  {
+    sources_.clear();
+    polygons_.clear();
+    for (size_t index = 0; index < sources.size(); ++index) {
+      sources_.emplace(sources[index], index);
+    }
+    for (size_t index = 0; index < polygons.size(); ++index) {
+      polygons_.emplace(polygons[index], index);
+    }
+  }
+
+  sensor_msgs::msg::PointCloud2 create(const std_msgs::msg::Header & header) const
+  {
+    sensor_msgs::msg::PointCloud2 cloud;
+    cloud.header = header;
+    cloud.height = 1;
+    cloud.is_dense = true;
+    const uint16_t endian = 1;
+    cloud.is_bigendian = *reinterpret_cast<const uint8_t *>(&endian) == 0;
+    sensor_msgs::PointCloud2Modifier modifier(cloud);
+    using Field = sensor_msgs::msg::PointField;
+    modifier.setPointCloud2Fields(
+      6, "x", 1, Field::FLOAT32, "y", 1, Field::FLOAT32, "z", 1, Field::FLOAT32,
+      "source_id", 1, Field::UINT32, "polygon_id", 1, Field::UINT32,
+      "action_type", 1, Field::UINT32);
+    return cloud;
+  }
+
+  void append(
+    sensor_msgs::msg::PointCloud2 & cloud, const std::vector<Point> & points,
+    const std::string & polygon, ActionType action) const
+  {
+    const size_t offset = cloud.width;
+    sensor_msgs::PointCloud2Modifier modifier(cloud);
+    modifier.resize(offset + points.size());
+    if (points.empty()) {
+      return;
+    }
+    sensor_msgs::PointCloud2Iterator<float> xpos(cloud, "x");
+    sensor_msgs::PointCloud2Iterator<float> ypos(cloud, "y");
+    sensor_msgs::PointCloud2Iterator<float> zpos(cloud, "z");
+    sensor_msgs::PointCloud2Iterator<uint32_t> source_id(cloud, "source_id");
+    sensor_msgs::PointCloud2Iterator<uint32_t> polygon_id(cloud, "polygon_id");
+    sensor_msgs::PointCloud2Iterator<uint32_t> action_type(cloud, "action_type");
+    xpos += offset;
+    ypos += offset;
+    zpos += offset;
+    source_id += offset;
+    polygon_id += offset;
+    action_type += offset;
+    size_t kept = offset;
+    for (const auto & point : points) {
+      const float coord_x = static_cast<float>(point.x);
+      const float coord_y = static_cast<float>(point.y);
+      const float coord_z = static_cast<float>(point.z);
+      if (!std::isfinite(coord_x) || !std::isfinite(coord_y) || !std::isfinite(coord_z)) {
+        continue;
+      }
+      *xpos = coord_x;
+      *ypos = coord_y;
+      *zpos = coord_z;
+      *source_id = lookup(sources_, point.source);
+      *polygon_id = lookup(polygons_, polygon);
+      *action_type = static_cast<uint32_t>(action);
+      ++xpos;
+      ++ypos;
+      ++zpos;
+      ++source_id;
+      ++polygon_id;
+      ++action_type;
+      ++kept;
+    }
+    modifier.resize(kept);
+  }
+
+private:
+  static uint32_t lookup(
+    const std::unordered_map<std::string, uint32_t> & mapping, const std::string & name)
+  {
+    const auto found = mapping.find(name);
+    return found == mapping.end() ? std::numeric_limits<uint32_t>::max() : found->second;
+  }
+
+  std::unordered_map<std::string, uint32_t> sources_;
+  std::unordered_map<std::string, uint32_t> polygons_;
+};
+
+}  // namespace nav2_collision_monitor
+
+#endif  // NAV2_COLLISION_MONITOR__TRIGGERING_CLOUD_HPP_

--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -52,7 +52,7 @@ CollisionDetector::on_configure(const rclcpp_lifecycle::State & state)
   collision_points_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/collision_points_marker");
 
-  triggering_points_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+  triggering_points_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
     "~/triggering_points");
 
   // Obtaining ROS parameters
@@ -60,6 +60,16 @@ CollisionDetector::on_configure(const rclcpp_lifecycle::State & state)
     on_cleanup(state);
     return nav2::CallbackReturn::FAILURE;
   }
+
+  std::vector<std::string> source_names;
+  std::vector<std::string> polygon_names;
+  for (const auto & source : sources_) {
+    source_names.push_back(source->getSourceName());
+  }
+  for (const auto & polygon : polygons_) {
+    polygon_names.push_back(polygon->getName());
+  }
+  triggering_cloud_.configure(source_names, polygon_names);
 
   return nav2::CallbackReturn::SUCCESS;
 }
@@ -401,7 +411,7 @@ void CollisionDetector::process()
   state_pub_->publish(std::move(state_msg));
 
   if (triggering_points_pub_->get_subscription_count() > 0) {
-    publishTriggeringPoints(all_triggering_points);
+    publishTriggeringPoints(all_triggering_points, curr_time);
   }
 
   // Publish polygons and exclusion zones for better visualization
@@ -409,49 +419,20 @@ void CollisionDetector::process()
 }
 
 void CollisionDetector::publishTriggeringPoints(
-  const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points)
+  const std::unordered_map<std::string, std::vector<Point>> & all_triggering_points,
+  const rclcpp::Time & stamp)
 {
-  auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
-
-  // Clear markers from previous cycle.
-  visualization_msgs::msg::Marker clear;
-  clear.action = visualization_msgs::msg::Marker::DELETEALL;
-  marker_array->markers.push_back(clear);
-
-  std::unordered_map<std::string, size_t> marker_index;
-  for (const auto & [polygon_name, points] : all_triggering_points) {
-    for (const auto & p : points) {
-      const std::string key = polygon_name + "/" + p.source;
-      auto [it, new_source] = marker_index.try_emplace(key, marker_array->markers.size());
-
-      if (new_source) {
-        visualization_msgs::msg::Marker marker;
-        marker.header.frame_id = base_frame_id_;
-        marker.header.stamp = rclcpp::Time(0, 0);
-        marker.ns = key;
-        marker.id = 0;
-        marker.type = visualization_msgs::msg::Marker::POINTS;
-        marker.action = visualization_msgs::msg::Marker::ADD;
-        marker.scale.x = 0.05;
-        marker.scale.y = 0.05;
-        marker.color.r = 1.0f;
-        marker.color.g = 0.0f;
-        marker.color.b = 0.0f;
-        marker.color.a = 1.0f;
-        marker.lifetime = rclcpp::Duration(0, 0);
-        marker.frame_locked = true;
-        marker_array->markers.push_back(std::move(marker));
-      }
-
-      geometry_msgs::msg::Point gp;
-      gp.x = p.x;
-      gp.y = p.y;
-      gp.z = p.z;
-      marker_array->markers[it->second].points.push_back(gp);
+  std_msgs::msg::Header header;
+  header.frame_id = base_frame_id_;
+  header.stamp = stamp;
+  auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>(triggering_cloud_.create(header));
+  for (const auto & polygon : polygons_) {
+    const auto found = all_triggering_points.find(polygon->getName());
+    if (found != all_triggering_points.end()) {
+      triggering_cloud_.append(*cloud, found->second, polygon->getName(), DO_NOTHING);
     }
   }
-
-  triggering_points_pub_->publish(std::move(marker_array));
+  triggering_points_pub_->publish(std::move(cloud));
 }
 
 void CollisionDetector::publishVisualizations() const

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -79,7 +79,16 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
   collision_points_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/collision_points_marker");
 
-  triggering_points_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+  std::vector<std::string> source_names;
+  std::vector<std::string> polygon_names;
+  for (const auto & source : sources_) {
+    source_names.push_back(source->getSourceName());
+  }
+  for (const auto & polygon : polygons_) {
+    polygon_names.push_back(polygon->getName());
+  }
+  triggering_cloud_.configure(source_names, polygon_names);
+  triggering_points_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
     "~/triggering_points");
 
   // Toggle service initialization
@@ -524,7 +533,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   }
 
   if (triggering_points_pub_->get_subscription_count() > 0) {
-    publishTriggeringPoints(robot_action);
+    publishTriggeringPoints(robot_action, curr_time);
   }
 
   if ((robot_action.polygon_name != robot_action_prev_.polygon_name) && enabled_) {
@@ -685,56 +694,15 @@ void CollisionMonitor::notifyActionState(
   }
 }
 
-void CollisionMonitor::publishTriggeringPoints(const Action & action)
+void CollisionMonitor::publishTriggeringPoints(const Action & action, const rclcpp::Time & stamp)
 {
-  auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
-
-  // Clear markers from previous cycle.
-  visualization_msgs::msg::Marker clear;
-  clear.action = visualization_msgs::msg::Marker::DELETEALL;
-  marker_array->markers.push_back(clear);
-
-  if (!action.triggering_points.empty()) {
-    // Colour by action type: STOP=red, SLOWDOWN=yellow, APPROACH=blue, LIMIT=orange
-    float r = 0.0f, g = 0.0f, b = 0.0f;
-    switch (action.action_type) {
-      case STOP:     r = 1.0f; g = 0.0f; b = 0.0f; break;
-      case SLOWDOWN: r = 1.0f; g = 1.0f; b = 0.0f; break;
-      case APPROACH: r = 0.0f; g = 0.5f; b = 1.0f; break;
-      case LIMIT:    r = 1.0f; g = 0.5f; b = 0.0f; break;
-      default: break;
-    }
-
-    std::unordered_map<std::string, size_t> marker_index;
-    for (const auto & p : action.triggering_points) {
-      auto [it, new_source] = marker_index.try_emplace(p.source, marker_array->markers.size());
-
-      if (new_source) {
-        visualization_msgs::msg::Marker marker;
-        marker.header.frame_id = base_frame_id_;
-        marker.header.stamp = rclcpp::Time(0, 0);
-        marker.ns = action.polygon_name + "/" + p.source;
-        marker.id = 0;
-        marker.type = visualization_msgs::msg::Marker::POINTS;
-        marker.action = visualization_msgs::msg::Marker::ADD;
-        marker.scale.x = 0.05;
-        marker.scale.y = 0.05;
-        marker.color.r = r;
-        marker.color.g = g;
-        marker.color.b = b;
-        marker.color.a = 1.0f;
-        marker.lifetime = rclcpp::Duration(0, 0);
-        marker.frame_locked = true;
-        marker_array->markers.push_back(std::move(marker));
-      }
-      geometry_msgs::msg::Point gp;
-      gp.x = p.x;
-      gp.y = p.y;
-      gp.z = p.z;
-      marker_array->markers[it->second].points.push_back(gp);
-    }
-  }
-  triggering_points_pub_->publish(std::move(marker_array));
+  std_msgs::msg::Header header;
+  header.frame_id = base_frame_id_;
+  header.stamp = stamp;
+  auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>(triggering_cloud_.create(header));
+  triggering_cloud_.append(
+    *cloud, action.triggering_points, action.polygon_name, action.action_type);
+  triggering_points_pub_->publish(std::move(cloud));
 }
 
 void CollisionMonitor::publishVisualizations() const

--- a/nav2_collision_monitor/test/CMakeLists.txt
+++ b/nav2_collision_monitor/test/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Kinematics test
+nav2_add_gtest(triggering_cloud_test triggering_cloud_test.cpp)
+target_include_directories(triggering_cloud_test PRIVATE ../include)
+target_link_libraries(triggering_cloud_test sensor_msgs::sensor_msgs)
+
 nav2_add_gtest(kinematics_test kinematics_test.cpp)
 target_link_libraries(kinematics_test
   ${monitor_library_name}

--- a/nav2_collision_monitor/test/collision_detector_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_detector_node_test.cpp
@@ -158,7 +158,7 @@ public:
   bool waitCollisionPointsMarker(const std::chrono::nanoseconds & timeout);
   void collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
   bool waitTriggeringPoints(const std::chrono::nanoseconds & timeout);
-  void triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
+  void triggeringPointsCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
 protected:
   // CollisionDetector node
@@ -185,10 +185,10 @@ protected:
     collision_points_marker_sub_;
   visualization_msgs::msg::MarkerArray::ConstSharedPtr collision_points_marker_msg_;
 
-  // CollisionDetector triggering points markers
-  nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
+  // CollisionDetector triggering points cloud
+  nav2::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
     triggering_points_sub_;
-  visualization_msgs::msg::MarkerArray::ConstSharedPtr triggering_points_msg_;
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr triggering_points_msg_;
 };  // Tester
 
 Tester::Tester()
@@ -221,7 +221,7 @@ Tester::Tester()
     COLLISION_POINTS_MARKERS_TOPIC,
     std::bind(&Tester::collisionPointsMarkerCallback, this, std::placeholders::_1));
 
-  triggering_points_sub_ = cd_->create_subscription<visualization_msgs::msg::MarkerArray>(
+  triggering_points_sub_ = cd_->create_subscription<sensor_msgs::msg::PointCloud2>(
     TRIGGERING_POINTS_TOPIC,
     std::bind(&Tester::triggeringPointsCallback, this, std::placeholders::_1));
 }
@@ -295,7 +295,7 @@ void Tester::collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray:
   collision_points_marker_msg_ = msg;
 }
 
-void Tester::triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
+void Tester::triggeringPointsCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   triggering_points_msg_ = msg;
 }
@@ -893,7 +893,7 @@ TEST_F(Tester, testCollisionPointsMarkers)
   cd_->stop();
 }
 
-TEST_F(Tester, testTriggeringPointsMarkers)
+TEST_F(Tester, testTriggeringPointsCloud)
 {
   rclcpp::Time curr_time = cd_->now();
 
@@ -906,15 +906,10 @@ TEST_F(Tester, testTriggeringPointsMarkers)
   cd_->start();
   sendTransforms(curr_time);
 
-  // No obstacle: nothing detected, marker array contains only the DELETEALL clear marker.
   ASSERT_TRUE(waitTriggeringPoints(500ms));
-  ASSERT_EQ(triggering_points_msg_->markers.size(), 1u);
-  EXPECT_EQ(
-    triggering_points_msg_->markers[0].action,
-    visualization_msgs::msg::Marker::DELETEALL);
+  EXPECT_EQ(triggering_points_msg_->width, 0u);
+  EXPECT_TRUE(triggering_points_msg_->data.empty());
 
-  // Obstacle inside the detection polygon: marker array must contain the
-  // clear marker plus one POINTS marker for the Scan source.
   publishScan(0.5, curr_time);
   ASSERT_TRUE(waitData(0.5, 500ms, curr_time));
   ASSERT_TRUE(waitTriggeringPoints(500ms));
@@ -922,27 +917,29 @@ TEST_F(Tester, testTriggeringPointsMarkers)
   ASSERT_NE(state_msg_->detections.size(), 0u);
   ASSERT_EQ(state_msg_->detections[0], true);
 
-  ASSERT_EQ(triggering_points_msg_->markers.size(), 2u);
-  EXPECT_EQ(
-    triggering_points_msg_->markers[0].action,
-    visualization_msgs::msg::Marker::DELETEALL);
-
-  const auto & points_marker = triggering_points_msg_->markers[1];
-  EXPECT_EQ(points_marker.type, visualization_msgs::msg::Marker::POINTS);
-  EXPECT_EQ(points_marker.action, visualization_msgs::msg::Marker::ADD);
-  EXPECT_EQ(points_marker.ns, std::string("DetectionRegion/") + SCAN_NAME);
-  EXPECT_EQ(points_marker.header.frame_id, BASE_FRAME_ID);
-  EXPECT_TRUE(points_marker.frame_locked);
-  EXPECT_FLOAT_EQ(points_marker.color.r, 1.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.g, 0.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.b, 0.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.a, 1.0f);
-
-  ASSERT_FALSE(points_marker.points.empty());
-  for (const auto & p : points_marker.points) {
-    EXPECT_LE(std::abs(p.x), 1.0 + EPSILON);
-    EXPECT_LE(std::abs(p.y), 1.0 + EPSILON);
+  const auto & cloud = *triggering_points_msg_;
+  EXPECT_EQ(cloud.header.frame_id, BASE_FRAME_ID);
+  EXPECT_GE(rclcpp::Time(cloud.header.stamp), curr_time);
+  EXPECT_EQ(cloud.point_step, 24u);
+  EXPECT_EQ(cloud.row_step, cloud.width * cloud.point_step);
+  ASSERT_GT(cloud.width, 0u);
+  sensor_msgs::PointCloud2ConstIterator<float> xpos(cloud, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> ypos(cloud, "y");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> source(cloud, "source_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> polygon(cloud, "polygon_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> action(cloud, "action_type");
+  for (; xpos != xpos.end(); ++xpos, ++ypos, ++source, ++polygon, ++action) {
+    EXPECT_LE(std::abs(*xpos), 1.0 + EPSILON);
+    EXPECT_LE(std::abs(*ypos), 1.0 + EPSILON);
+    EXPECT_EQ(*source, 0u);
+    EXPECT_EQ(*polygon, 0u);
+    EXPECT_EQ(*action, static_cast<uint32_t>(nav2_collision_monitor::DO_NOTHING));
   }
+
+  publishScan(2.0, curr_time);
+  ASSERT_TRUE(waitData(2.0, 500ms, curr_time));
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  EXPECT_EQ(triggering_points_msg_->width, 0u);
 
   cd_->stop();
 }

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -199,7 +199,7 @@ protected:
   void cmdVelOutCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
   void actionStateCallback(nav2_msgs::msg::CollisionMonitorState::ConstSharedPtr msg);
   void collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
-  void triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
+  void triggeringPointsCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
   // CollisionMonitor node
   std::shared_ptr<CollisionMonitorWrapper> cm_;
@@ -231,10 +231,10 @@ protected:
     collision_points_marker_sub_;
   visualization_msgs::msg::MarkerArray::ConstSharedPtr collision_points_marker_msg_;
 
-  // CollisionMonitor triggering points markers
-  nav2::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr
+  // CollisionMonitor triggering points cloud
+  nav2::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
     triggering_points_sub_;
-  visualization_msgs::msg::MarkerArray::ConstSharedPtr triggering_points_msg_;
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr triggering_points_msg_;
 
   // Service client for setting CollisionMonitor parameters
   nav2::ServiceClient<rcl_interfaces::srv::SetParameters>::SharedPtr parameters_client_;
@@ -280,7 +280,7 @@ Tester::Tester()
   collision_points_marker_sub_ = cm_->create_subscription<visualization_msgs::msg::MarkerArray>(
     COLLISION_POINTS_MARKERS_TOPIC,
     std::bind(&Tester::collisionPointsMarkerCallback, this, std::placeholders::_1));
-  triggering_points_sub_ = cm_->create_subscription<visualization_msgs::msg::MarkerArray>(
+  triggering_points_sub_ = cm_->create_subscription<sensor_msgs::msg::PointCloud2>(
     TRIGGERING_POINTS_TOPIC,
     std::bind(&Tester::triggeringPointsCallback, this, std::placeholders::_1));
   parameters_client_ =
@@ -827,7 +827,7 @@ void Tester::collisionPointsMarkerCallback(visualization_msgs::msg::MarkerArray:
   collision_points_marker_msg_ = msg;
 }
 
-void Tester::triggeringPointsCallback(visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
+void Tester::triggeringPointsCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   triggering_points_msg_ = msg;
 }
@@ -1612,7 +1612,7 @@ TEST_F(Tester, testCollisionPointsMarkers)
   cm_->stop();
 }
 
-TEST_F(Tester, testTriggeringPointsMarkers)
+TEST_F(Tester, testTriggeringPointsCloud)
 {
   rclcpp::Time curr_time = cm_->now();
 
@@ -1625,16 +1625,11 @@ TEST_F(Tester, testTriggeringPointsMarkers)
   cm_->start();
   sendTransforms(curr_time);
 
-  // No obstacle: triggering_points should contain only the DELETEALL clear marker.
   publishCmdVel(0.5, 0.0, 0.0);
   ASSERT_TRUE(waitTriggeringPoints(500ms));
-  ASSERT_EQ(triggering_points_msg_->markers.size(), 1u);
-  EXPECT_EQ(
-    triggering_points_msg_->markers[0].action,
-    visualization_msgs::msg::Marker::DELETEALL);
+  EXPECT_EQ(triggering_points_msg_->width, 0u);
+  EXPECT_TRUE(triggering_points_msg_->data.empty());
 
-  // Obstacle inside the Stop polygon: STOP action triggers, marker array must
-  // contain the clear marker plus one POINTS marker for the Scan source.
   publishScan(0.5, curr_time);
   ASSERT_TRUE(waitData(0.5, 500ms, curr_time));
   publishCmdVel(0.5, 0.0, 0.0);
@@ -1642,28 +1637,30 @@ TEST_F(Tester, testTriggeringPointsMarkers)
   ASSERT_TRUE(waitActionState(500ms));
   ASSERT_EQ(action_state_->action_type, STOP);
 
-  ASSERT_EQ(triggering_points_msg_->markers.size(), 2u);
-  EXPECT_EQ(
-    triggering_points_msg_->markers[0].action,
-    visualization_msgs::msg::Marker::DELETEALL);
-
-  const auto & points_marker = triggering_points_msg_->markers[1];
-  EXPECT_EQ(points_marker.type, visualization_msgs::msg::Marker::POINTS);
-  EXPECT_EQ(points_marker.action, visualization_msgs::msg::Marker::ADD);
-  EXPECT_EQ(points_marker.ns, std::string("Stop/") + SCAN_NAME);
-  EXPECT_EQ(points_marker.header.frame_id, BASE_FRAME_ID);
-  EXPECT_TRUE(points_marker.frame_locked);
-  // STOP colour: red.
-  EXPECT_FLOAT_EQ(points_marker.color.r, 1.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.g, 0.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.b, 0.0f);
-  EXPECT_FLOAT_EQ(points_marker.color.a, 1.0f);
-
-  ASSERT_FALSE(points_marker.points.empty());
-  for (const auto & p : points_marker.points) {
-    EXPECT_LE(std::abs(p.x), 1.0 + EPSILON);
-    EXPECT_LE(std::abs(p.y), 1.0 + EPSILON);
+  const auto & cloud = *triggering_points_msg_;
+  EXPECT_EQ(cloud.header.frame_id, BASE_FRAME_ID);
+  EXPECT_GE(rclcpp::Time(cloud.header.stamp), curr_time);
+  EXPECT_EQ(cloud.point_step, 24u);
+  EXPECT_EQ(cloud.row_step, cloud.width * cloud.point_step);
+  ASSERT_GT(cloud.width, 0u);
+  sensor_msgs::PointCloud2ConstIterator<float> xpos(cloud, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> ypos(cloud, "y");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> source(cloud, "source_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> polygon(cloud, "polygon_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> action(cloud, "action_type");
+  for (; xpos != xpos.end(); ++xpos, ++ypos, ++source, ++polygon, ++action) {
+    EXPECT_LE(std::abs(*xpos), 1.0 + EPSILON);
+    EXPECT_LE(std::abs(*ypos), 1.0 + EPSILON);
+    EXPECT_EQ(*source, 0u);
+    EXPECT_EQ(*polygon, 0u);
+    EXPECT_EQ(*action, static_cast<uint32_t>(STOP));
   }
+
+  publishScan(2.0, curr_time);
+  ASSERT_TRUE(waitData(2.0, 500ms, curr_time));
+  publishCmdVel(0.5, 0.0, 0.0);
+  ASSERT_TRUE(waitTriggeringPoints(500ms));
+  EXPECT_EQ(triggering_points_msg_->width, 0u);
 
   cm_->stop();
 }

--- a/nav2_collision_monitor/test/triggering_cloud_test.cpp
+++ b/nav2_collision_monitor/test/triggering_cloud_test.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Dexory
+
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "nav2_collision_monitor/triggering_cloud.hpp"
+
+using nav2_collision_monitor::TriggeringCloud;
+using nav2_collision_monitor::STOP;
+using nav2_collision_monitor::DO_NOTHING;
+
+TEST(TriggeringCloud, EmptyAndTaggedPoints)
+{
+  TriggeringCloud builder;
+  builder.configure({"front", "rear"}, {"stop", "slow"});
+  std_msgs::msg::Header header;
+  header.frame_id = "base_link";
+  header.stamp.sec = 42;
+  auto cloud = builder.create(header);
+  EXPECT_EQ(cloud.header, header);
+  EXPECT_EQ(cloud.width, 0u);
+  EXPECT_EQ(cloud.height, 1u);
+  EXPECT_EQ(cloud.point_step, 24u);
+  builder.append(cloud, {{1, 2, 3, "rear"}, {4, 5, 6, "front"}}, "slow", STOP);
+  builder.append(cloud, {{1, 2, 3, "rear"}}, "stop", DO_NOTHING);
+  ASSERT_EQ(cloud.width, 3u);
+  EXPECT_EQ(cloud.row_step, 72u);
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> source(cloud, "source_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> polygon(cloud, "polygon_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> action(cloud, "action_type");
+  sensor_msgs::PointCloud2ConstIterator<float> height(cloud, "z");
+  EXPECT_EQ(source[0], 1u);
+  EXPECT_EQ(*polygon, 1u);
+  EXPECT_EQ(*action, static_cast<uint32_t>(STOP));
+  EXPECT_FLOAT_EQ(*height, 3);
+  ++source;
+  ++polygon;
+  ++action;
+  EXPECT_EQ(*source, 0u);
+  ++source;
+  ++polygon;
+  ++action;
+  EXPECT_EQ(*source, 1u);
+  EXPECT_EQ(*polygon, 0u);
+  EXPECT_EQ(*action, static_cast<uint32_t>(DO_NOTHING));
+}
+
+TEST(TriggeringCloud, DropsNonfiniteAndResetsMapping)
+{
+  TriggeringCloud builder;
+  builder.configure({"old"}, {"old"});
+  builder.configure({"new"}, {"new"});
+  auto cloud = builder.create(std_msgs::msg::Header{});
+  builder.append(cloud, {{0, 0, std::numeric_limits<double>::infinity(), "new"},
+      {0, 0, 1, "old"}}, "old", STOP);
+  ASSERT_EQ(cloud.width, 1u);
+  EXPECT_TRUE(cloud.is_dense);
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> source(cloud, "source_id");
+  sensor_msgs::PointCloud2ConstIterator<uint32_t> polygon(cloud, "polygon_id");
+  EXPECT_EQ(*source, std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(*polygon, std::numeric_limits<uint32_t>::max());
+}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu 26 |
| Robotic platform tested on | Dexory Simulation & Robot |
| Does this PR contain AI generated software? | Yes |
| Was this PR description generated by AI software? | Yes but revised by human |

## Description of contribution in a few bullet points

* `~/triggering_points` on Collision Monitor and Collision Detector is now `sensor_msgs/msg/PointCloud2` instead of `visualization_msgs/msg/MarkerArray` (introduced in #6133)
* Fields: `x`,`y`,`z` FLOAT32 in `base_frame_id`; `source_id`, `polygon_id`, `action_type` UINT32. IDs are zero-based indices into `observation_sources` / `polygons`; `action_type` follows `CollisionMonitorState` constants (always `DO_NOTHING` on the Detector).
* Shared `TriggeringCloud` builder (`triggering_cloud.hpp`) used by both nodes; ID maps built from the configured `sources_`/`polygons_` at `on_configure`.

## Description of documentation updates required from your changes

* Release notes

## Description of how this change was tested


## Future work that may be required in bullet points
