### PR TITLE
Feat/stale tf check bt and navigators

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -93,6 +93,7 @@ controller_server:
   ros__parameters:
     controller_frequency: 20.0
     costmap_update_timeout: 0.30
+    transform_staleness_threshold: 0.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001

--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -181,14 +181,15 @@ protected:
 
   /**
    * @brief Refreshes transformed_global_plan_ and transformed_end_pose_ for the current cycle
-   *
+   * @param current_robot_pose Pose of the robot to be used as reference
    * @throw nav2_core::ControllerTFError if the robot pose or end pose cannot be obtained
    */
-  void transformedPlanAndGoal();
+  void transformedPlanAndGoal(const geometry_msgs::msg::PoseStamped & current_robot_pose);
   /**
    * @brief Calculates velocity and publishes to "cmd_vel" topic
+   * @param current_robot_pose Pose of the robot to be used as reference
    */
-  void computeAndPublishVelocity();
+  void computeAndPublishVelocity(const geometry_msgs::msg::PoseStamped & current_robot_pose);
   /**
    * @brief Calls setPlannerPath method with an updated path received from
    * action server
@@ -215,15 +216,16 @@ protected:
   double waitForCostmap();
   /**
    * @brief Checks if goal is reached
+   * @param current_robot_pose The robot pose to be used as reference
    * @return true or false
    */
-  bool isGoalReached();
+  bool isGoalReached(const geometry_msgs::msg::PoseStamped & current_robot_pose);
   /**
-   * @brief Obtain current pose of the robot in costmap's frame
-   * @param pose To store current pose of the robot
-   * @return true if able to obtain current pose of the robot, else false
+   * @brief Obtain the current pose of the robot in the costmap frame
+   * @return Current robot pose
+   * @throw nav2_core::ControllerTFError if the pose cannot be obtained or its transform is stale
    */
-  bool getRobotPose(geometry_msgs::msg::PoseStamped & pose);
+  geometry_msgs::msg::PoseStamped getCurrentRobotPose();
 
   /**
    * @brief get the thresholded velocity

--- a/nav2_controller/include/nav2_controller/parameter_handler.hpp
+++ b/nav2_controller/include/nav2_controller/parameter_handler.hpp
@@ -40,6 +40,7 @@ struct Parameters
   bool use_realtime_priority;
   bool publish_zero_velocity;
   rclcpp::Duration costmap_update_timeout{0, 0};
+  double transform_staleness_threshold{0.0};
   std::string odom_topic;
   double odom_duration;
   double search_window;

--- a/nav2_controller/include/nav2_controller/plugins/pose_progress_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/pose_progress_checker.hpp
@@ -56,7 +56,7 @@ public:
    * @param current_pose Current pose of the robot
    * @return true, if the robot has moved enough, false otherwise
    */
-  bool check(geometry_msgs::msg::PoseStamped & current_pose) override;
+  bool check(const geometry_msgs::msg::PoseStamped & current_pose) override;
 
 protected:
   /**

--- a/nav2_controller/include/nav2_controller/plugins/simple_progress_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/simple_progress_checker.hpp
@@ -58,7 +58,7 @@ public:
    * @param current_pose Current pose of the robot
    * @return true, if the robot has moved enough, false otherwise
    */
-  bool check(geometry_msgs::msg::PoseStamped & current_pose) override;
+  bool check(const geometry_msgs::msg::PoseStamped & current_pose) override;
 
   /**
    * @brief Reset the progress checker state

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -207,6 +207,19 @@ nav_msgs::msg::Path FeasiblePathHandler::transformLocalPlan(
   transformed_plan.header.frame_id = costmap_ros_->getGlobalFrameID();
   transformed_plan.header.stamp = global_pose_.header.stamp;
   unsigned int mx, my;
+  geometry_msgs::msg::TransformStamped plan_to_costmap;
+  try {
+    plan_to_costmap = tf_->lookupTransform(
+      costmap_ros_->getGlobalFrameID(),
+      global_plan_.header.frame_id,
+      global_pose_.header.stamp,
+      tf2::durationFromSec(transform_tolerance_));
+  } catch (const tf2::TransformException & ex) {
+    throw nav2_core::ControllerTFError(
+      std::string("Unable to transform global plan into costmap frame: ") +
+      ex.what());
+  }
+
   // Find the furthest relevant pose on the path to consider within costmap
   // bounds
   // Transforming it to the costmap frame in the same loop
@@ -215,21 +228,17 @@ nav_msgs::msg::Path FeasiblePathHandler::transformLocalPlan(
   for (auto global_plan_pose = closest_point; global_plan_pose != pruned_plan_end;
     ++global_plan_pose)
   {
-    // Transform from global plan frame to costmap frame
+    geometry_msgs::msg::PoseStamped plan_pose = *global_plan_pose;
+    plan_pose.header = global_pose_.header;
     geometry_msgs::msg::PoseStamped costmap_plan_pose;
-    global_plan_pose->header.stamp = global_pose_.header.stamp;
-    global_plan_pose->header.frame_id = global_plan_.header.frame_id;
-    nav2_util::transformPoseInTargetFrame(*global_plan_pose, costmap_plan_pose, *tf_,
-      costmap_ros_->getGlobalFrameID(), transform_tolerance_);
-
-    // Check if pose is inside the costmap
+    tf2::doTransform(plan_pose, costmap_plan_pose, plan_to_costmap);
     if (!costmap_ros_->getCostmap()->worldToMap(
-        costmap_plan_pose.pose.position.x, costmap_plan_pose.pose.position.y, mx, my))
+        costmap_plan_pose.pose.position.x,
+        costmap_plan_pose.pose.position.y, mx, my))
     {
       break;
     }
 
-    // Filling the transformed plan to return with the transformed pose
     transformed_plan.poses.push_back(costmap_plan_pose);
   }
 

--- a/nav2_controller/plugins/pose_progress_checker.cpp
+++ b/nav2_controller/plugins/pose_progress_checker.cpp
@@ -68,7 +68,7 @@ void PoseProgressChecker::initialize(
       this, std::placeholders::_1));
 }
 
-bool PoseProgressChecker::check(geometry_msgs::msg::PoseStamped & current_pose)
+bool PoseProgressChecker::check(const geometry_msgs::msg::PoseStamped & current_pose)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
   // relies on short circuit evaluation to not call is_robot_moved_enough if

--- a/nav2_controller/plugins/simple_progress_checker.cpp
+++ b/nav2_controller/plugins/simple_progress_checker.cpp
@@ -67,7 +67,7 @@ void SimpleProgressChecker::initialize(
       this, std::placeholders::_1));
 }
 
-bool SimpleProgressChecker::check(geometry_msgs::msg::PoseStamped & current_pose)
+bool SimpleProgressChecker::check(const geometry_msgs::msg::PoseStamped & current_pose)
 {
   std::lock_guard<std::mutex> lock_reinit(mutex_);
   // relies on short circuit evaluation to not call is_robot_moved_enough if

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -564,15 +564,17 @@ void ControllerServer::computeControl()
 
       updateGlobalPath();
 
-      // Refresh the transformed plan and goal together so they share a single map->odom snapshot
-      transformedPlanAndGoal();
+      const auto current_robot_pose = getCurrentRobotPose();
 
-      if (isGoalReached()) {
+      // Refresh the transformed plan and goal together so they share a single map->odom snapshot
+      transformedPlanAndGoal(current_robot_pose);
+
+      if (isGoalReached(current_robot_pose)) {
         RCLCPP_INFO(get_logger(), "Reached the goal!");
         break;
       }
 
-      computeAndPublishVelocity();
+      computeAndPublishVelocity(current_robot_pose);
 
       auto cycle_duration = this->now() - start_time;
       if (!loop_rate.sleep()) {
@@ -708,15 +710,10 @@ void ControllerServer::setPlannerPath(const nav_msgs::msg::Path & path)
   current_path_ = path;
 }
 
-void ControllerServer::transformedPlanAndGoal()
+void ControllerServer::transformedPlanAndGoal(
+  const geometry_msgs::msg::PoseStamped & current_robot_pose)
 {
-  geometry_msgs::msg::PoseStamped pose;
-
-  if (!getRobotPose(pose)) {
-    throw nav2_core::ControllerTFError("Failed to obtain robot pose");
-  }
-
-  end_pose_.header.stamp = pose.header.stamp;
+  end_pose_.header.stamp = current_robot_pose.header.stamp;
   if (!nav2_util::transformPoseInTargetFrame(
       end_pose_, transformed_end_pose_, *costmap_ros_->getTfBuffer(),
       costmap_ros_->getGlobalFrameID(), transform_tolerance_))
@@ -725,7 +722,7 @@ void ControllerServer::transformedPlanAndGoal()
   }
 
   auto [closest_point, pruned_plan_end] =
-    path_handlers_[current_path_handler_]->findPlanSegment(pose);
+    path_handlers_[current_path_handler_]->findPlanSegment(current_robot_pose);
   transformed_global_plan_ =
     path_handlers_[current_path_handler_]->transformLocalPlan(closest_point, pruned_plan_end);
 
@@ -735,16 +732,13 @@ void ControllerServer::transformedPlanAndGoal()
   }
 }
 
-void ControllerServer::computeAndPublishVelocity()
+void ControllerServer::computeAndPublishVelocity(
+  const geometry_msgs::msg::PoseStamped & current_robot_pose)
 {
-  geometry_msgs::msg::PoseStamped pose;
-
-  if (!getRobotPose(pose)) {
-    throw nav2_core::ControllerTFError("Failed to obtain robot pose");
-  }
-
   if (!current_progress_checker_.empty()) {
-    if (!progress_checkers_[current_progress_checker_]->check(pose)) {
+    // TODO(marco): Make the check input pose const in a future API revision.
+    auto progress_check_pose = current_robot_pose;
+    if (!progress_checkers_[current_progress_checker_]->check(progress_check_pose)) {
       throw nav2_core::FailedToMakeProgress("Failed to make progress");
     }
   }
@@ -752,14 +746,14 @@ void ControllerServer::computeAndPublishVelocity()
   geometry_msgs::msg::Twist twist = getThresholdedTwist(odom_sub_->getRawTwist());
 
   geometry_msgs::msg::PoseStamped goal =
-    path_handlers_[current_path_handler_]->getTransformedGoal(pose.header.stamp);
+    path_handlers_[current_path_handler_]->getTransformedGoal(current_robot_pose.header.stamp);
 
   geometry_msgs::msg::TwistStamped cmd_vel_2d;
 
   try {
     cmd_vel_2d =
       controllers_[current_controller_]->computeVelocityCommands(
-      pose,
+      current_robot_pose,
       twist,
       goal_checkers_[current_goal_checker_].get(),
       transformed_global_plan_,
@@ -797,12 +791,12 @@ void ControllerServer::computeAndPublishVelocity()
 
   if (current_path_.poses.size() >= 2) {
     double current_distance_to_goal = nav2_util::geometry_utils::euclidean_distance(
-      pose, transformed_end_pose_);
+      current_robot_pose, transformed_end_pose_);
 
     // Transform robot pose to path frame for path tracking calculations
     geometry_msgs::msg::PoseStamped robot_pose_in_path_frame;
     if (!nav2_util::transformPoseInTargetFrame(
-        pose, robot_pose_in_path_frame, *costmap_ros_->getTfBuffer(),
+        current_robot_pose, robot_pose_in_path_frame, *costmap_ros_->getTfBuffer(),
         current_path_.header.frame_id, transform_tolerance_))
     {
       throw nav2_core::ControllerTFError("Failed to transform robot pose to path frame");
@@ -831,11 +825,11 @@ void ControllerServer::computeAndPublishVelocity()
 
     // Create tracking error message
     auto tracking_feedback_msg = std::make_unique<nav2_msgs::msg::TrackingFeedback>();
-    tracking_feedback_msg->header = pose.header;
+    tracking_feedback_msg->header = current_robot_pose.header;
     tracking_feedback_msg->position_tracking_error = path_search_result.distance;
     tracking_feedback_msg->heading_tracking_error = heading_tracking_error;
     tracking_feedback_msg->current_path_index = path_search_result.closest_segment_index;
-    tracking_feedback_msg->robot_pose = pose;
+    tracking_feedback_msg->robot_pose = current_robot_pose;
     tracking_feedback_msg->distance_to_goal = current_distance_to_goal;
     tracking_feedback_msg->speed = std::hypot(twist.linear.x, twist.linear.y);
     start_index_ = path_search_result.closest_segment_index;
@@ -959,29 +953,35 @@ void ControllerServer::onGoalExit(bool force_stop)
   }
 }
 
-bool ControllerServer::isGoalReached()
+bool ControllerServer::isGoalReached(const geometry_msgs::msg::PoseStamped & current_robot_pose)
 {
-  geometry_msgs::msg::PoseStamped pose;
-
-  if (!getRobotPose(pose)) {
-    return false;
-  }
-
   geometry_msgs::msg::Twist velocity = getThresholdedTwist(odom_sub_->getRawTwist());
 
   return goal_checkers_[current_goal_checker_]->isGoalReached(
-    pose.pose, transformed_end_pose_.pose,
+    current_robot_pose.pose, transformed_end_pose_.pose,
     velocity, transformed_global_plan_);
 }
 
-bool ControllerServer::getRobotPose(geometry_msgs::msg::PoseStamped & pose)
+geometry_msgs::msg::PoseStamped ControllerServer::getCurrentRobotPose()
 {
-  geometry_msgs::msg::PoseStamped current_pose;
-  if (!costmap_ros_->getRobotPose(current_pose)) {
-    return false;
+  geometry_msgs::msg::PoseStamped pose;
+  if (!costmap_ros_->getRobotPose(pose)) {
+    throw nav2_core::ControllerTFError("Failed to obtain robot pose");
   }
-  pose = current_pose;
-  return true;
+
+  const auto threshold = params_->transform_staleness_threshold;
+  if (threshold > 0.0) {
+    const auto transform_age = (now() - pose.header.stamp).seconds();
+    if (transform_age > threshold) {
+      throw nav2_core::ControllerTFError(
+              "Robot pose transform from frame '" + costmap_ros_->getBaseFrameID() +
+              "' to frame '" + costmap_ros_->getGlobalFrameID() + "' is stale: age " +
+              std::to_string(transform_age) +
+              "s exceeds threshold " + std::to_string(threshold) + "s");
+    }
+  }
+
+  return pose;
 }
 
 void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::ConstSharedPtr & msg)

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -736,9 +736,7 @@ void ControllerServer::computeAndPublishVelocity(
   const geometry_msgs::msg::PoseStamped & current_robot_pose)
 {
   if (!current_progress_checker_.empty()) {
-    // TODO(marco): Make the check input pose const in a future API revision.
-    auto progress_check_pose = current_robot_pose;
-    if (!progress_checkers_[current_progress_checker_]->check(progress_check_pose)) {
+    if (!progress_checkers_[current_progress_checker_]->check(current_robot_pose)) {
       throw nav2_core::FailedToMakeProgress("Failed to make progress");
     }
   }

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -564,6 +564,8 @@ void ControllerServer::computeControl()
 
       updateGlobalPath();
 
+      // The last known pose in the local map frame is retrieved without waiting.
+      // Its value and timestamp are reused across this control cycle.
       const auto current_robot_pose = getCurrentRobotPose();
 
       // Refresh the transformed plan and goal together so they share a single map->odom snapshot
@@ -962,24 +964,14 @@ bool ControllerServer::isGoalReached(const geometry_msgs::msg::PoseStamped & cur
 
 geometry_msgs::msg::PoseStamped ControllerServer::getCurrentRobotPose()
 {
-  geometry_msgs::msg::PoseStamped pose;
-  if (!costmap_ros_->getRobotPose(pose)) {
-    throw nav2_core::ControllerTFError("Failed to obtain robot pose");
+  try {
+    return nav2_util::getPoseWithStalenessCheck(
+      *costmap_ros_->getTfBuffer(), costmap_ros_->getGlobalFrameID(),
+      costmap_ros_->getBaseFrameID(), now(),
+      params_->transform_staleness_threshold);
+  } catch (const tf2::TransformException & ex) {
+    throw nav2_core::ControllerTFError("Failed to obtain robot pose: " + std::string(ex.what()));
   }
-
-  const auto threshold = params_->transform_staleness_threshold;
-  if (threshold > 0.0) {
-    const auto transform_age = (now() - pose.header.stamp).seconds();
-    if (transform_age > threshold) {
-      throw nav2_core::ControllerTFError(
-              "Robot pose transform from frame '" + costmap_ros_->getBaseFrameID() +
-              "' to frame '" + costmap_ros_->getGlobalFrameID() + "' is stale: age " +
-              std::to_string(transform_age) +
-              "s exceeds threshold " + std::to_string(threshold) + "s");
-    }
-  }
-
-  return pose;
 }
 
 void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::ConstSharedPtr & msg)

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -965,10 +965,11 @@ bool ControllerServer::isGoalReached(const geometry_msgs::msg::PoseStamped & cur
 geometry_msgs::msg::PoseStamped ControllerServer::getCurrentRobotPose()
 {
   try {
-    return nav2_util::getPoseWithStalenessCheck(
+    const auto transform = nav2_util::lookupTransformWithStalenessCheck(
       *costmap_ros_->getTfBuffer(), costmap_ros_->getGlobalFrameID(),
       costmap_ros_->getBaseFrameID(), now(),
       params_->transform_staleness_threshold);
+    return nav2_util::transformToPoseStamped(transform);
   } catch (const tf2::TransformException & ex) {
     throw nav2_core::ControllerTFError("Failed to obtain robot pose: " + std::string(ex.what()));
   }

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -964,15 +964,17 @@ bool ControllerServer::isGoalReached(const geometry_msgs::msg::PoseStamped & cur
 
 geometry_msgs::msg::PoseStamped ControllerServer::getCurrentRobotPose()
 {
-  try {
-    const auto transform = nav2_util::lookupTransformWithStalenessCheck(
+  geometry_msgs::msg::TransformStamped transform;
+  if (!nav2_util::lookupTransformWithStalenessCheck(
       *costmap_ros_->getTfBuffer(), costmap_ros_->getGlobalFrameID(),
       costmap_ros_->getBaseFrameID(), now(),
-      params_->transform_staleness_threshold);
-    return nav2_util::transformToPoseStamped(transform);
-  } catch (const tf2::TransformException & ex) {
-    throw nav2_core::ControllerTFError("Failed to obtain robot pose: " + std::string(ex.what()));
+      params_->transform_staleness_threshold, transform))
+  {
+    throw nav2_core::ControllerTFError(
+            "Failed to obtain robot pose in frame '" + costmap_ros_->getGlobalFrameID() +
+            "' for base frame '" + costmap_ros_->getBaseFrameID() + "'");
   }
+  return nav2_util::transformToPoseStamped(transform);
 }
 
 void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::ConstSharedPtr & msg)

--- a/nav2_controller/src/parameter_handler.cpp
+++ b/nav2_controller/src/parameter_handler.cpp
@@ -47,6 +47,8 @@ ParameterHandler::ParameterHandler(
   double costmap_update_timeout_dbl = node->declare_or_get_parameter("costmap_update_timeout",
     0.30);
   params_.costmap_update_timeout = rclcpp::Duration::from_seconds(costmap_update_timeout_dbl);
+  params_.transform_staleness_threshold =
+    node->declare_or_get_parameter("transform_staleness_threshold", 0.0);
   params_.odom_topic = node->declare_or_get_parameter("odom_topic", std::string("odom"));
   params_.odom_duration = node->declare_or_get_parameter("odom_duration", 0.3);
   params_.search_window = node->declare_or_get_parameter("search_window", 2.0);
@@ -207,6 +209,8 @@ ParameterHandler::updateParametersCallback(
         params_.failure_tolerance = parameter.as_double();
       } else if (param_name == "search_window") {
         params_.search_window = parameter.as_double();
+      } else if (param_name == "transform_staleness_threshold") {
+        params_.transform_staleness_threshold = parameter.as_double();
       }
     }
     mutex_.unlock();

--- a/nav2_controller/test/test_controller_server.cpp
+++ b/nav2_controller/test/test_controller_server.cpp
@@ -33,7 +33,12 @@ public:
   using nav2_controller::ControllerServer::ControllerServer;
 
   void setEndPoseFrame(const std::string & frame) {end_pose_.header.frame_id = frame;}
-  void callTransformedPlanAndGoal() {transformedPlanAndGoal();}
+  void callTransformedPlanAndGoal(
+    const geometry_msgs::msg::PoseStamped & current_robot_pose)
+  {
+    transformedPlanAndGoal(current_robot_pose);
+  }
+  geometry_msgs::msg::PoseStamped callGetCurrentRobotPose() {return getCurrentRobotPose();}
   nav2::TransformBuffer & getTfBuffer() {return *costmap_ros_->getTfBuffer();}
 };
 
@@ -61,8 +66,83 @@ TEST(ControllerServerTest, TransformedPlanAndGoalThrowsOnTfFailure)
   tf_msg.transform.rotation.w = 1.0;
   server->getTfBuffer().setTransform(tf_msg, "test", true);
 
+  geometry_msgs::msg::PoseStamped current_robot_pose;
+  current_robot_pose.header.stamp = server->now();
+  current_robot_pose.header.frame_id = "map";
+  current_robot_pose.pose.orientation.w = 1.0;
+
   server->setEndPoseFrame("nonexistent_frame_xyz");
-  EXPECT_THROW(server->callTransformedPlanAndGoal(), nav2_core::ControllerTFError);
+  EXPECT_THROW(
+    server->callTransformedPlanAndGoal(current_robot_pose), nav2_core::ControllerTFError);
+  server->cleanup();
+}
+
+TEST(ControllerServerTest, RejectsStaleRobotPoseTransform)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("transform_staleness_threshold", 0.1),
+    rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("goal_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("controller_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("path_handler_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("filters", std::vector<std::string>{}),
+  });
+
+  auto server = std::make_shared<ControllerServerShim>(options);
+  ASSERT_EQ(
+    server->configure().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  geometry_msgs::msg::TransformStamped tf_msg;
+  tf_msg.header.stamp = server->now() - rclcpp::Duration::from_seconds(1.0);
+  tf_msg.header.frame_id = "map";
+  tf_msg.child_frame_id = "base_link";
+  tf_msg.transform.rotation.w = 1.0;
+  server->getTfBuffer().setTransform(tf_msg, "test", false);
+
+  try {
+    server->callGetCurrentRobotPose();
+    FAIL() << "Expected stale robot pose transform to throw";
+  } catch (const nav2_core::ControllerTFError & exception) {
+    const std::string error_message = exception.what();
+    EXPECT_NE(error_message.find("base_link"), std::string::npos);
+    EXPECT_NE(error_message.find("map"), std::string::npos);
+  }
+
+  tf_msg.header.stamp = server->now();
+  server->getTfBuffer().setTransform(tf_msg, "test", false);
+  EXPECT_NO_THROW(server->callGetCurrentRobotPose());
+  server->cleanup();
+}
+
+TEST(ControllerServerTest, SkipsRobotPoseTransformStalenessCheckWhenDisabled)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("transform_staleness_threshold", -1.0),
+    rclcpp::Parameter("progress_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("goal_checker_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("controller_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("path_handler_plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("plugins", std::vector<std::string>{}),
+    rclcpp::Parameter("filters", std::vector<std::string>{}),
+  });
+
+  auto server = std::make_shared<ControllerServerShim>(options);
+  ASSERT_EQ(
+    server->configure().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  geometry_msgs::msg::TransformStamped tf_msg;
+  tf_msg.header.stamp = server->now() - rclcpp::Duration::from_seconds(1.0);
+  tf_msg.header.frame_id = "map";
+  tf_msg.child_frame_id = "base_link";
+  tf_msg.transform.rotation.w = 1.0;
+  server->getTfBuffer().setTransform(tf_msg, "test", false);
+
+  EXPECT_NO_THROW(server->callGetCurrentRobotPose());
   server->cleanup();
 }
 

--- a/nav2_controller/test/test_controller_server.cpp
+++ b/nav2_controller/test/test_controller_server.cpp
@@ -209,7 +209,8 @@ TEST(ControllerServerTest, test_dynamic_parameters)
       rclcpp::Parameter("min_y_velocity_threshold", 100.0),
       rclcpp::Parameter("min_theta_velocity_threshold", 100.0),
       rclcpp::Parameter("failure_tolerance", 5.0),
-      rclcpp::Parameter("search_window", 10.0)});
+      rclcpp::Parameter("search_window", 10.0),
+      rclcpp::Parameter("transform_staleness_threshold", 1.0)});
 
   rclcpp::spin_until_future_complete(
     node->get_node_base_interface(),
@@ -220,6 +221,7 @@ TEST(ControllerServerTest, test_dynamic_parameters)
   EXPECT_EQ(params_->min_theta_velocity_threshold, 100.0);
   EXPECT_EQ(params_->failure_tolerance, 5.0);
   EXPECT_EQ(params_->search_window, 10.0);
+  EXPECT_EQ(params_->transform_staleness_threshold, 1.0);
 
   results = rec_param->set_parameters_atomically(
     {rclcpp::Parameter("min_x_velocity_threshold", -1.0)});

--- a/nav2_core/include/nav2_core/progress_checker.hpp
+++ b/nav2_core/include/nav2_core/progress_checker.hpp
@@ -51,7 +51,7 @@ public:
    * @param current_pose Current pose of the robot
    * @return True if progress is made
    */
-  virtual bool check(geometry_msgs::msg::PoseStamped & current_pose) = 0;
+  virtual bool check(const geometry_msgs::msg::PoseStamped & current_pose) = 0;
   /**
    * @brief Reset class state upon calling
    */

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -147,19 +147,8 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
   // Add proper orientations to plan, if needed
   validateOrientations(transformed_plan.poses);
 
-  // Transform local frame to global frame to use in collision checking
-  geometry_msgs::msg::TransformStamped costmap_transform;
-  try {
-    costmap_transform = tf_buffer_->lookupTransform(
-      costmap_ros_->getGlobalFrameID(), costmap_ros_->getBaseFrameID(),
-      tf2::TimePointZero);
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_ERROR(
-      logger_, "Could not transform %s to %s: %s",
-      costmap_ros_->getBaseFrameID().c_str(), costmap_ros_->getGlobalFrameID().c_str(),
-      ex.what());
-    throw ex;
-  }
+  geometry_msgs::msg::TransformStamped costmap_transform = nav2_util::poseToTransformStamped(pose,
+      costmap_ros_->getBaseFrameID());
 
   // Compute distance to goal as the path's integrated distance to account for path curvatures
   double dist_to_goal = nav2_util::geometry_utils::calculate_path_length(transformed_plan);

--- a/nav2_graceful_controller/src/graceful_controller.cpp
+++ b/nav2_graceful_controller/src/graceful_controller.cpp
@@ -147,6 +147,8 @@ geometry_msgs::msg::TwistStamped GracefulController::computeVelocityCommands(
   // Add proper orientations to plan, if needed
   validateOrientations(transformed_plan.poses);
 
+  // ControllerServer supplies pose in the local costmap's global frame, so it already
+  // represents the transform from the robot base frame to the costmap's global frame.
   geometry_msgs::msg::TransformStamped costmap_transform = nav2_util::poseToTransformStamped(pose,
       costmap_ros_->getBaseFrameID());
 

--- a/nav2_graceful_controller/test/test_graceful_controller.cpp
+++ b/nav2_graceful_controller/test/test_graceful_controller.cpp
@@ -644,6 +644,54 @@ TEST(GracefulControllerTest, computeVelocityCommandRegular) {
   EXPECT_EQ(cmd_vel.twist.angular.z, 0.0);
 }
 
+TEST(GracefulControllerTest, computeVelocityCommandReusesProvidedPoseForCollisionChecking) {
+  auto node = std::make_shared<nav2::LifecycleNode>("testGracefulPoseTransform");
+  auto tf = nav2::create_transform_buffer(node);
+
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
+  costmap_ros->declare_parameter("global_frame", rclcpp::ParameterValue("test_global_frame"));
+  costmap_ros->declare_parameter("robot_base_frame", rclcpp::ParameterValue("test_robot_frame"));
+  costmap_ros->declare_parameter("width", rclcpp::ParameterValue(10));
+  costmap_ros->declare_parameter("height", rclcpp::ParameterValue(10));
+  costmap_ros->declare_parameter("resolution", rclcpp::ParameterValue(0.1));
+  costmap_ros->on_configure(rclcpp_lifecycle::State());
+
+  auto controller = std::make_shared<GMControllerFixture>();
+  controller->configure(node, "test", tf, costmap_ros);
+  controller->activate();
+
+  geometry_msgs::msg::PoseStamped robot_pose;
+  robot_pose.header.frame_id = "test_global_frame";
+  robot_pose.header.stamp = rclcpp::Time(10, 0);
+  robot_pose.pose.orientation.w = 1.0;
+
+  nav_msgs::msg::Path transformed_global_plan;
+  transformed_global_plan.header.frame_id = "test_robot_frame";
+  transformed_global_plan.header.stamp = robot_pose.header.stamp;
+  transformed_global_plan.poses.resize(3);
+  for (size_t i = 0; i < transformed_global_plan.poses.size(); ++i) {
+    transformed_global_plan.poses[i].header = transformed_global_plan.header;
+    transformed_global_plan.poses[i].pose.position.x = static_cast<double>(i);
+    transformed_global_plan.poses[i].pose.orientation.w = 1.0;
+  }
+
+  geometry_msgs::msg::PoseStamped goal;
+  goal.header = robot_pose.header;
+  goal.pose.position.x = 2.0;
+  goal.pose.orientation.w = 1.0;
+  geometry_msgs::msg::Twist robot_velocity;
+  nav2_controller::SimpleGoalChecker checker;
+  checker.initialize(node, "checker", costmap_ros);
+
+  // No transform is installed in the buffer. Collision checking must use robot_pose instead of
+  // independently looking up the latest global-to-base transform.
+  geometry_msgs::msg::TwistStamped cmd_vel;
+  EXPECT_NO_THROW(
+    cmd_vel = controller->computeVelocityCommands(
+      robot_pose, robot_velocity, &checker, transformed_global_plan, goal));
+  EXPECT_GT(cmd_vel.twist.linear.x, 0.0);
+}
+
 TEST(GracefulControllerTest, computeVelocityCommandRegularBackwards) {
   auto node = std::make_shared<nav2::LifecycleNode>("testGraceful");
   auto tf = nav2::create_transform_buffer(node);
@@ -863,9 +911,9 @@ TEST(GracefulControllerTest, slowDownForObstacle) {
 
   // Create the robot pose
   geometry_msgs::msg::PoseStamped robot_pose;
-  robot_pose.header.frame_id = "test_robot_frame";
-  robot_pose.pose.position.x = 0.0;
-  robot_pose.pose.position.y = 0.0;
+  robot_pose.header.frame_id = "test_global_frame";
+  robot_pose.pose.position.x = 5.0;
+  robot_pose.pose.position.y = 5.0;
   robot_pose.pose.position.z = 0.0;
   robot_pose.pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
 
@@ -967,9 +1015,9 @@ TEST(GracefulControllerTest, computeVelocityCommandObstacleMargin) {
 
   // Create the robot pose
   geometry_msgs::msg::PoseStamped robot_pose;
-  robot_pose.header.frame_id = "test_robot_frame";
-  robot_pose.pose.position.x = 0.0;
-  robot_pose.pose.position.y = 0.0;
+  robot_pose.header.frame_id = "test_global_frame";
+  robot_pose.pose.position.x = 5.0;
+  robot_pose.pose.position.y = 5.0;
   robot_pose.pose.position.z = 0.0;
   robot_pose.pose.orientation = tf2::toMsg(tf2::Quaternion({0, 0, 1}, 0.0));
 

--- a/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp
+++ b/nav2_rotation_shim_controller/include/nav2_rotation_shim_controller/nav2_rotation_shim_controller.hpp
@@ -122,7 +122,7 @@ protected:
    * @return pt location of the output point
    */
   geometry_msgs::msg::PoseStamped getSampledPathPt(
-    const geometry_msgs::msg::PoseStamped & global_goal);
+    const geometry_msgs::msg::PoseStamped & global_goal, const rclcpp::Time & control_time);
 
   /**
    * @brief Uses TF to find the location of the sampled path point in base frame

--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -158,7 +158,7 @@ geometry_msgs::msg::TwistStamped RotationShimController::computeVelocityCommands
 
     std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());
     try {
-      auto sampled_pt = getSampledPathPt(global_goal);
+      auto sampled_pt = getSampledPathPt(global_goal, pose.header.stamp);
       double angular_distance_to_heading;
       if (params_->use_path_orientations) {
         angular_distance_to_heading = angles::shortest_angular_distance(
@@ -206,7 +206,7 @@ geometry_msgs::msg::TwistStamped RotationShimController::computeVelocityCommands
 }
 
 geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathPt(
-  const geometry_msgs::msg::PoseStamped & global_goal)
+  const geometry_msgs::msg::PoseStamped & global_goal, const rclcpp::Time & control_time)
 {
   if (current_path_.poses.size() < 2) {
     throw nav2_core::ControllerException(
@@ -222,15 +222,15 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathPt(
     dy = current_path_.poses[i].pose.position.y - start.position.y;
     if (hypot(dx, dy) >= params_->forward_sampling_distance) {
       current_path_.poses[i].header.frame_id = current_path_.header.frame_id;
-      // Get current time transformation
-      current_path_.poses[i].header.stamp = clock_->now();
+      // Using the propagated control timestamp
+      current_path_.poses[i].header.stamp = control_time;
       return current_path_.poses[i];
     }
   }
 
   auto goal = current_path_.poses.back();
   goal.header.frame_id = current_path_.header.frame_id;
-  goal.header.stamp = clock_->now();
+  goal.header.stamp = control_time;
   double gx = global_goal.pose.position.x - goal.pose.position.x;
   double gy = global_goal.pose.position.y - goal.pose.position.y;
   double distance = hypot(gx, gy);

--- a/nav2_rotation_shim_controller/test/test_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/test/test_shim_controller.cpp
@@ -49,7 +49,7 @@ public:
   geometry_msgs::msg::PoseStamped getSampledPathPtWrapper(
     const geometry_msgs::msg::PoseStamped & global_goal)
   {
-    return getSampledPathPt(global_goal);
+    return getSampledPathPt(global_goal, rclcpp::Time(0));
   }
 
   geometry_msgs::msg::Pose transformPoseToBaseFrameWrapper(geometry_msgs::msg::PoseStamped pt)
@@ -150,6 +150,8 @@ TEST(RotationShimControllerTest, setPlanAndSampledPointsTests)
   auto pose = controller->getSampledPathPtWrapper(global_goal);
   EXPECT_EQ(pose.pose.position.x, 1.0);  // default forward sampling is 0.5
   EXPECT_EQ(pose.pose.position.y, 1.0);
+  EXPECT_EQ(pose.header.stamp.sec, 0);
+  EXPECT_EQ(pose.header.stamp.nanosec, 0u);
 }
 
 TEST(RotationShimControllerTest, rotationAndTransformTests)
@@ -297,6 +299,13 @@ TEST(RotationShimControllerTest, openLoopRotationTests) {
   transform.transform.rotation.z = 0.0;
   transform.transform.rotation.w = 1.0;
   tf_broadcaster->sendTransform(transform);
+
+  geometry_msgs::msg::TransformStamped map_to_base_link;
+  map_to_base_link.header.frame_id = "map";
+  map_to_base_link.child_frame_id = "base_link";
+  map_to_base_link.header.stamp = node->now();
+  map_to_base_link.transform.rotation.w = 1.0;
+  ASSERT_TRUE(tf->setTransform(map_to_base_link, "test", false));
 
   // set a valid primary controller so we can do lifecycle
   node->declare_parameter(
@@ -467,6 +476,13 @@ TEST(RotationShimControllerTest, accelerationTests) {
   transform.transform.rotation.z = 0.0;
   transform.transform.rotation.w = 1.0;
   tf_broadcaster->sendTransform(transform);
+
+  geometry_msgs::msg::TransformStamped map_to_base_link;
+  map_to_base_link.header.frame_id = "map";
+  map_to_base_link.child_frame_id = "base_link";
+  map_to_base_link.header.stamp = node->now();
+  map_to_base_link.transform.rotation.w = 1.0;
+  ASSERT_TRUE(tf->setTransform(map_to_base_link, "test", false));
 
   // set a valid primary controller so we can do lifecycle
   node->declare_parameter(

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -32,6 +32,58 @@
 
 namespace nav2_util
 {
+
+/**
+ * @brief Look up the latest transform and optionally reject it when stale
+ * @param tf_buffer TF buffer to use for the lookup
+ * @param target_frame Frame to transform into
+ * @param source_frame Frame to transform from
+ * @param current_time Time against which the transform age is measured
+ * @param staleness_threshold Maximum transform age in seconds; non-positive disables the check
+ * @return The latest transform
+ * @throw tf2::TransformException if lookup fails or the transform is stale
+ */
+geometry_msgs::msg::PoseStamped getPoseWithStalenessCheck(
+  nav2::TransformBuffer & tf_buffer,
+  const std::string & target_frame,
+  const std::string & source_frame,
+  const rclcpp::Time & current_time,
+  double staleness_threshold);
+
+/**
+ * @brief Look up the latest transform and optionally reject it when stale
+ * @param tf_buffer TF buffer to use for the lookup
+ * @param target_frame Frame to transform into
+ * @param source_frame Frame to transform from
+ * @param current_time Time against which the transform age is measured
+ * @param staleness_threshold Maximum transform age in seconds; non-positive disables the check
+ * @return The latest transform
+ * @throw tf2::TransformException if lookup fails or the transform is stale
+ */
+geometry_msgs::msg::TransformStamped lookupTransformWithStalenessCheck(
+  nav2::TransformBuffer & tf_buffer,
+  const std::string & target_frame,
+  const std::string & source_frame,
+  const rclcpp::Time & current_time,
+  double staleness_threshold);
+
+/**
+ * @brief Convert a stamped transform to the equivalent stamped pose
+ * @param transform Transform to convert
+ * @return Pose containing the transform header, translation, and rotation
+ */
+geometry_msgs::msg::PoseStamped transformToPoseStamped(
+  const geometry_msgs::msg::TransformStamped & transform);
+
+/**
+ * @brief Convert a stamped pose to a transform stamped with the specified child frame
+ * @param pose Pose to convert
+ * @param child_frame Child frame for the transform
+ * @return Transform from the specified child
+ */
+geometry_msgs::msg::TransformStamped poseToTransformStamped(
+  const geometry_msgs::msg::PoseStamped & pose, const std::string & child_frame);
+
 /**
 * @brief get the current pose of the robot
 * @param global_pose Pose to transform

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -43,23 +43,6 @@ namespace nav2_util
  * @return The latest transform
  * @throw tf2::TransformException if lookup fails or the transform is stale
  */
-geometry_msgs::msg::PoseStamped getPoseWithStalenessCheck(
-  nav2::TransformBuffer & tf_buffer,
-  const std::string & target_frame,
-  const std::string & source_frame,
-  const rclcpp::Time & current_time,
-  double staleness_threshold);
-
-/**
- * @brief Look up the latest transform and optionally reject it when stale
- * @param tf_buffer TF buffer to use for the lookup
- * @param target_frame Frame to transform into
- * @param source_frame Frame to transform from
- * @param current_time Time against which the transform age is measured
- * @param staleness_threshold Maximum transform age in seconds; non-positive disables the check
- * @return The latest transform
- * @throw tf2::TransformException if lookup fails or the transform is stale
- */
 geometry_msgs::msg::TransformStamped lookupTransformWithStalenessCheck(
   nav2::TransformBuffer & tf_buffer,
   const std::string & target_frame,

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -36,19 +36,20 @@ namespace nav2_util
 /**
  * @brief Look up the latest transform and optionally reject it when stale
  * @param tf_buffer TF buffer to use for the lookup
- * @param target_frame Frame to transform into
- * @param source_frame Frame to transform from
+ * @param source_frame Reference frame in which to express the target frame pose
+ * @param target_frame Frame whose pose is requested
  * @param current_time Time against which the transform age is measured
  * @param staleness_threshold Maximum transform age in seconds; non-positive disables the check
- * @return The latest transform
- * @throw tf2::TransformException if lookup fails or the transform is stale
+ * @param transform Output latest transform; unchanged on failure
+ * @return True if lookup succeeds and the transform is not stale, false otherwise
  */
-geometry_msgs::msg::TransformStamped lookupTransformWithStalenessCheck(
+bool lookupTransformWithStalenessCheck(
   nav2::TransformBuffer & tf_buffer,
-  const std::string & target_frame,
   const std::string & source_frame,
+  const std::string & target_frame,
   const rclcpp::Time & current_time,
-  double staleness_threshold);
+  double staleness_threshold,
+  geometry_msgs::msg::TransformStamped & transform);
 
 /**
  * @brief Convert a stamped transform to the equivalent stamped pose

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -29,6 +29,78 @@
 namespace nav2_util
 {
 
+geometry_msgs::msg::TransformStamped lookupTransformWithStalenessCheck(
+  nav2::TransformBuffer & tf_buffer,
+  const std::string & target_frame,
+  const std::string & source_frame,
+  const rclcpp::Time & current_time,
+  double staleness_threshold)
+{
+  if (target_frame == source_frame) {
+    geometry_msgs::msg::TransformStamped identity;
+    identity.header.frame_id = target_frame;
+    identity.header.stamp = current_time;
+    identity.child_frame_id = source_frame;
+    identity.transform.rotation.w = 1.0;
+    return identity;
+  }
+
+  auto transform = tf_buffer.lookupTransform(
+    target_frame, source_frame, tf2::TimePointZero);
+
+  const bool has_timestamp =
+    transform.header.stamp.sec != 0 || transform.header.stamp.nanosec != 0;
+  if (staleness_threshold > 0.0 && has_timestamp) {
+    const auto transform_time = rclcpp::Time(
+      transform.header.stamp, current_time.get_clock_type());
+    const double transform_age = (current_time - transform_time).seconds();
+    if (transform_age > staleness_threshold) {
+      throw tf2::ExtrapolationException(
+              "Transform from frame '" + source_frame + "' to frame '" + target_frame +
+              "' is stale: age " + std::to_string(transform_age) +
+              "s exceeds threshold " + std::to_string(staleness_threshold) + "s");
+    }
+  }
+  return transform;
+}
+
+geometry_msgs::msg::PoseStamped transformToPoseStamped(
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header = transform.header;
+  pose.pose.position.x = transform.transform.translation.x;
+  pose.pose.position.y = transform.transform.translation.y;
+  pose.pose.position.z = transform.transform.translation.z;
+  pose.pose.orientation = transform.transform.rotation;
+  return pose;
+}
+
+geometry_msgs::msg::TransformStamped poseToTransformStamped(
+  const geometry_msgs::msg::PoseStamped & pose, const std::string & child_frame)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header = pose.header;
+  transform.child_frame_id = child_frame;
+  transform.transform.translation.x = pose.pose.position.x;
+  transform.transform.translation.y = pose.pose.position.y;
+  transform.transform.translation.z = pose.pose.position.z;
+  transform.transform.rotation = pose.pose.orientation;
+  return transform;
+}
+
+geometry_msgs::msg::PoseStamped getPoseWithStalenessCheck(
+  nav2::TransformBuffer & tf_buffer,
+  const std::string & target_frame,
+  const std::string & source_frame,
+  const rclcpp::Time & current_time,
+  double staleness_threshold)
+{
+  auto transform = lookupTransformWithStalenessCheck(tf_buffer, target_frame, source_frame,
+      current_time, staleness_threshold);
+  return transformToPoseStamped(transform);
+}
+
 bool getCurrentPose(
   geometry_msgs::msg::PoseStamped & global_pose,
   nav2::TransformBuffer & tf_buffer, const std::string global_frame,

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -29,39 +29,51 @@
 namespace nav2_util
 {
 
-geometry_msgs::msg::TransformStamped lookupTransformWithStalenessCheck(
+bool lookupTransformWithStalenessCheck(
   nav2::TransformBuffer & tf_buffer,
-  const std::string & target_frame,
   const std::string & source_frame,
+  const std::string & target_frame,
   const rclcpp::Time & current_time,
-  double staleness_threshold)
+  double staleness_threshold,
+  geometry_msgs::msg::TransformStamped & transform)
 {
-  if (target_frame == source_frame) {
+  if (source_frame == target_frame) {
     geometry_msgs::msg::TransformStamped identity;
-    identity.header.frame_id = target_frame;
+    identity.header.frame_id = source_frame;
     identity.header.stamp = current_time;
-    identity.child_frame_id = source_frame;
+    identity.child_frame_id = target_frame;
     identity.transform.rotation.w = 1.0;
-    return identity;
+    transform = identity;
+    return true;
   }
 
-  auto transform = tf_buffer.lookupTransform(
-    target_frame, source_frame, tf2::TimePointZero);
+  geometry_msgs::msg::TransformStamped latest_transform;
+  try {
+    latest_transform = tf_buffer.lookupTransform(
+      source_frame, target_frame, tf2::TimePointZero);
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("lookupTransformWithStalenessCheck"),
+      "Failed to get transform: %s", ex.what());
+    return false;
+  }
 
   const bool has_timestamp =
-    transform.header.stamp.sec != 0 || transform.header.stamp.nanosec != 0;
+    latest_transform.header.stamp.sec != 0 || latest_transform.header.stamp.nanosec != 0;
   if (staleness_threshold > 0.0 && has_timestamp) {
     const auto transform_time = rclcpp::Time(
-      transform.header.stamp, current_time.get_clock_type());
+      latest_transform.header.stamp, current_time.get_clock_type());
     const double transform_age = (current_time - transform_time).seconds();
     if (transform_age > staleness_threshold) {
-      throw tf2::ExtrapolationException(
-              "Transform from frame '" + source_frame + "' to frame '" + target_frame +
-              "' is stale: age " + std::to_string(transform_age) +
-              "s exceeds threshold " + std::to_string(staleness_threshold) + "s");
+      RCLCPP_ERROR(
+        rclcpp::get_logger("lookupTransformWithStalenessCheck"),
+        "Transform from frame '%s' to frame '%s' is stale: age %fs exceeds threshold %fs",
+        target_frame.c_str(), source_frame.c_str(), transform_age, staleness_threshold);
+      return false;
     }
   }
-  return transform;
+  transform = latest_transform;
+  return true;
 }
 
 geometry_msgs::msg::PoseStamped transformToPoseStamped(

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -89,18 +89,6 @@ geometry_msgs::msg::TransformStamped poseToTransformStamped(
   return transform;
 }
 
-geometry_msgs::msg::PoseStamped getPoseWithStalenessCheck(
-  nav2::TransformBuffer & tf_buffer,
-  const std::string & target_frame,
-  const std::string & source_frame,
-  const rclcpp::Time & current_time,
-  double staleness_threshold)
-{
-  auto transform = lookupTransformWithStalenessCheck(tf_buffer, target_frame, source_frame,
-      current_time, staleness_threshold);
-  return transformToPoseStamped(transform);
-}
-
 bool getCurrentPose(
   geometry_msgs::msg::PoseStamped & global_pose,
   nav2::TransformBuffer & tf_buffer, const std::string global_frame,

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -56,3 +56,137 @@ TEST(RobotUtils, validateTwist)
   msg.angular.z = NAN;
   EXPECT_FALSE(nav2_util::validateTwist(msg));
 }
+
+TEST(RobotUtils, lookupTransformWithStalenessCheck)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  nav2::TransformBuffer tf(clock);
+  const rclcpp::Time current_time(10, 0, RCL_ROS_TIME);
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "map";
+  transform.header.stamp = rclcpp::Time(8, 0, RCL_ROS_TIME);
+  transform.child_frame_id = "base_link";
+  transform.transform.rotation.w = 1.0;
+  tf.setTransform(transform, "test", false);
+
+  EXPECT_THROW(
+    nav2_util::lookupTransformWithStalenessCheck(
+      tf, "map", "base_link", current_time, 1.0),
+    tf2::ExtrapolationException);
+  EXPECT_NO_THROW(
+    nav2_util::lookupTransformWithStalenessCheck(
+      tf, "map", "base_link", current_time, 2.0));
+  EXPECT_NO_THROW(
+    nav2_util::lookupTransformWithStalenessCheck(
+      tf, "map", "base_link", current_time, 0.0));
+
+  transform.header.frame_id = "map";
+  transform.child_frame_id = "static_frame";
+  tf.setTransform(transform, "test", true);
+  EXPECT_NO_THROW(
+    nav2_util::lookupTransformWithStalenessCheck(
+      tf, "map", "static_frame", current_time, 1.0));
+}
+
+TEST(RobotUtils, lookupTransformWithStalenessCheckSameFrameReturnsIdentity)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  nav2::TransformBuffer tf(clock);
+  const rclcpp::Time current_time(10, 123, RCL_ROS_TIME);
+
+  const auto transform = nav2_util::lookupTransformWithStalenessCheck(
+    tf, "base_link", "base_link", current_time, 1.0);
+
+  EXPECT_EQ(transform.header.frame_id, "base_link");
+  EXPECT_EQ(transform.header.stamp.sec, 10);
+  EXPECT_EQ(transform.header.stamp.nanosec, 123u);
+  EXPECT_EQ(transform.child_frame_id, "base_link");
+
+  EXPECT_DOUBLE_EQ(transform.transform.translation.x, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.y, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.z, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.rotation.x, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.rotation.y, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.rotation.z, 0.0);
+  EXPECT_DOUBLE_EQ(transform.transform.rotation.w, 1.0);
+}
+
+TEST(RobotUtils, getPoseWithStalenessCheck)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  nav2::TransformBuffer tf(clock);
+  const rclcpp::Time current_time(10, 0, RCL_ROS_TIME);
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "map";
+  transform.header.stamp = rclcpp::Time(8, 0, RCL_ROS_TIME);
+  transform.child_frame_id = "base_link";
+  transform.transform.translation.x = 1.0;
+  transform.transform.translation.y = 2.0;
+  transform.transform.translation.z = 3.0;
+  transform.transform.rotation.z = 0.6;
+  transform.transform.rotation.w = 0.8;
+  tf.setTransform(transform, "test", false);
+
+  EXPECT_THROW(
+    nav2_util::getPoseWithStalenessCheck(
+      tf, "map", "base_link", current_time, 1.0),
+    tf2::ExtrapolationException);
+
+  const auto pose = nav2_util::getPoseWithStalenessCheck(
+    tf, "map", "base_link", current_time, 2.0);
+  EXPECT_EQ(pose.header.frame_id, transform.header.frame_id);
+  EXPECT_EQ(pose.header.stamp, transform.header.stamp);
+  EXPECT_EQ(pose.pose.position.x, transform.transform.translation.x);
+  EXPECT_EQ(pose.pose.position.y, transform.transform.translation.y);
+  EXPECT_EQ(pose.pose.position.z, transform.transform.translation.z);
+  EXPECT_EQ(pose.pose.orientation, transform.transform.rotation);
+}
+
+TEST(RobotUtils, transformToPoseStamped)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "map";
+  transform.header.stamp.sec = 12;
+  transform.header.stamp.nanosec = 34;
+  transform.child_frame_id = "base_link";
+  transform.transform.translation.x = 1.0;
+  transform.transform.translation.y = 2.0;
+  transform.transform.translation.z = 3.0;
+  transform.transform.rotation.x = 0.1;
+  transform.transform.rotation.y = 0.2;
+  transform.transform.rotation.z = 0.3;
+  transform.transform.rotation.w = 0.4;
+
+  const auto pose = nav2_util::transformToPoseStamped(transform);
+
+  EXPECT_EQ(pose.header.frame_id, transform.header.frame_id);
+  EXPECT_EQ(pose.header.stamp, transform.header.stamp);
+  EXPECT_EQ(pose.pose.position.x, transform.transform.translation.x);
+  EXPECT_EQ(pose.pose.position.y, transform.transform.translation.y);
+  EXPECT_EQ(pose.pose.position.z, transform.transform.translation.z);
+  EXPECT_EQ(pose.pose.orientation, transform.transform.rotation);
+}
+
+TEST(RobotUtils, poseToTransform)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = "map";
+  pose.header.stamp.sec = 12;
+  pose.header.stamp.nanosec = 34;
+  pose.pose.position.x = 1.0;
+  pose.pose.position.y = 2.0;
+  pose.pose.position.z = 3.0;
+  pose.pose.orientation.x = 0.1;
+  pose.pose.orientation.y = 0.2;
+  pose.pose.orientation.z = 0.3;
+  pose.pose.orientation.w = 0.4;
+
+  const auto transform = nav2_util::poseToTransformStamped(pose, "base_link");
+
+  EXPECT_EQ(transform.header, pose.header);
+  EXPECT_EQ(transform.child_frame_id, "base_link");
+  EXPECT_EQ(transform.transform.translation.x, pose.pose.position.x);
+  EXPECT_EQ(transform.transform.translation.y, pose.pose.position.y);
+  EXPECT_EQ(transform.transform.translation.z, pose.pose.position.z);
+  EXPECT_EQ(transform.transform.rotation, pose.pose.orientation);
+}

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -69,23 +69,33 @@ TEST(RobotUtils, lookupTransformWithStalenessCheck)
   transform.transform.rotation.w = 1.0;
   tf.setTransform(transform, "test", false);
 
-  EXPECT_THROW(
+  geometry_msgs::msg::TransformStamped result;
+  result.header.frame_id = "unchanged";
+  EXPECT_FALSE(
     nav2_util::lookupTransformWithStalenessCheck(
-      tf, "map", "base_link", current_time, 1.0),
-    tf2::ExtrapolationException);
-  EXPECT_NO_THROW(
+      tf, "map", "base_link", current_time, 1.0, result));
+  EXPECT_EQ(result.header.frame_id, "unchanged");
+  EXPECT_TRUE(
     nav2_util::lookupTransformWithStalenessCheck(
-      tf, "map", "base_link", current_time, 2.0));
-  EXPECT_NO_THROW(
+      tf, "map", "base_link", current_time, 2.0, result));
+  EXPECT_EQ(result, transform);
+  EXPECT_TRUE(
     nav2_util::lookupTransformWithStalenessCheck(
-      tf, "map", "base_link", current_time, 0.0));
+      tf, "map", "base_link", current_time, 0.0, result));
 
   transform.header.frame_id = "map";
   transform.child_frame_id = "static_frame";
   tf.setTransform(transform, "test", true);
-  EXPECT_NO_THROW(
+  EXPECT_TRUE(
     nav2_util::lookupTransformWithStalenessCheck(
-      tf, "map", "static_frame", current_time, 1.0));
+      tf, "map", "static_frame", current_time, 1.0, result));
+  EXPECT_EQ(result.header.frame_id, "map");
+  EXPECT_EQ(result.child_frame_id, "static_frame");
+
+  const auto previous_result = result;
+  EXPECT_FALSE(nav2_util::lookupTransformWithStalenessCheck(
+      tf, "map", "missing_frame", current_time, 1.0, result));
+  EXPECT_EQ(result, previous_result);
 }
 
 TEST(RobotUtils, lookupTransformWithStalenessCheckSameFrameReturnsIdentity)
@@ -94,8 +104,9 @@ TEST(RobotUtils, lookupTransformWithStalenessCheckSameFrameReturnsIdentity)
   nav2::TransformBuffer tf(clock);
   const rclcpp::Time current_time(10, 123, RCL_ROS_TIME);
 
-  const auto transform = nav2_util::lookupTransformWithStalenessCheck(
-    tf, "base_link", "base_link", current_time, 1.0);
+  geometry_msgs::msg::TransformStamped transform;
+  ASSERT_TRUE(nav2_util::lookupTransformWithStalenessCheck(
+      tf, "base_link", "base_link", current_time, 1.0, transform));
 
   EXPECT_EQ(transform.header.frame_id, "base_link");
   EXPECT_EQ(transform.header.stamp.sec, 10);

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -111,37 +111,6 @@ TEST(RobotUtils, lookupTransformWithStalenessCheckSameFrameReturnsIdentity)
   EXPECT_DOUBLE_EQ(transform.transform.rotation.w, 1.0);
 }
 
-TEST(RobotUtils, getPoseWithStalenessCheck)
-{
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  nav2::TransformBuffer tf(clock);
-  const rclcpp::Time current_time(10, 0, RCL_ROS_TIME);
-  geometry_msgs::msg::TransformStamped transform;
-  transform.header.frame_id = "map";
-  transform.header.stamp = rclcpp::Time(8, 0, RCL_ROS_TIME);
-  transform.child_frame_id = "base_link";
-  transform.transform.translation.x = 1.0;
-  transform.transform.translation.y = 2.0;
-  transform.transform.translation.z = 3.0;
-  transform.transform.rotation.z = 0.6;
-  transform.transform.rotation.w = 0.8;
-  tf.setTransform(transform, "test", false);
-
-  EXPECT_THROW(
-    nav2_util::getPoseWithStalenessCheck(
-      tf, "map", "base_link", current_time, 1.0),
-    tf2::ExtrapolationException);
-
-  const auto pose = nav2_util::getPoseWithStalenessCheck(
-    tf, "map", "base_link", current_time, 2.0);
-  EXPECT_EQ(pose.header.frame_id, transform.header.frame_id);
-  EXPECT_EQ(pose.header.stamp, transform.header.stamp);
-  EXPECT_EQ(pose.pose.position.x, transform.transform.translation.x);
-  EXPECT_EQ(pose.pose.position.y, transform.transform.translation.y);
-  EXPECT_EQ(pose.pose.position.z, transform.transform.translation.z);
-  EXPECT_EQ(pose.pose.orientation, transform.transform.rotation);
-}
-
 TEST(RobotUtils, transformToPoseStamped)
 {
   geometry_msgs::msg::TransformStamped transform;


### PR DESCRIPTION


## Basic Info

**Depends on** https://github.com/ros-navigation/navigation2/pull/6436

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6320 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | only local tests |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Added lookup staleness check for BT navigators and BT actions.

## Description of documentation updates required from your changes

The new parameter needs to be documented

## Description of how this change was tested

Only local test

---

## Future work that may be required in bullet points

See parent ticket

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
